### PR TITLE
fix: eliminar dependencia Koin no utilizada

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,8 +76,7 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
     implementation("androidx.compose.material:material-icons-extended")
-    implementation("com.google.android.gms:play-services-location:21.2.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.10.2")
+
     // 1. Red (Retrofit + Gson + Interceptor para Logs)
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
@@ -86,14 +85,12 @@ dependencies {
     // 2. Navegación en Jetpack Compose
     implementation("androidx.navigation:navigation-compose:2.7.7")
 
-    // 3. Inyección de Dependencias (Koin)
-    implementation("io.insert-koin:koin-androidx-compose:3.5.3")
-
-    // 4. Seguridad (EncryptedSharedPreferences para el JWT)
+    // 3. Seguridad (EncryptedSharedPreferences para el JWT)
     implementation("androidx.security:security-crypto-ktx:1.1.0-alpha06")
 
-    // 5. Geolocalización (FusedLocationProviderClient)
+    // 4. Geolocalización (FusedLocationProviderClient)
     implementation("com.google.android.gms:play-services-location:21.2.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.10.2")
 
     // Nota: Room (Persistencia) lo inyectaremos más adelante
 }


### PR DESCRIPTION
## Problema

`koin-androidx-compose:3.5.3` estaba declarado en `build.gradle.kts` pero nunca se inicializó: no existe `KoinApplication`, ni módulos de Koin, ni ningún `import io.insert-koin` en el código fuente. El proyecto usa el patrón de factories manuales (`DashboardViewModelFactory`, inline factory en `MainActivity`) que se mantienen exactamente igual.

## Cambios

- **Eliminada** la dependencia `io.insert-koin:koin-androidx-compose:3.5.3`
- **Consolidada** la dependencia `play-services-location` que estaba declarada dos veces (líneas 79 y 93)
- **Renumerados** los comentarios del bloque de dependencias para que sean coherentes (1→4)

## Verificación

- No existe ningún `import io.insert-koin` en el código → sin rotura de compilación
- Las factories manuales no se han tocado

## Alcance

Solo modifica `app/build.gradle.kts`. No toca ningún fichero `.kt`.

