### PR TITLE
fix: introducir capa Repository entre ViewModels y Retrofit

### DIFF
--- a/app/src/main/java/com/gestorrh/android/MainActivity.kt
+++ b/app/src/main/java/com/gestorrh/android/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.navigation.compose.rememberNavController
 import com.gestorrh.android.core.network.ApiClient
 import com.gestorrh.android.core.security.TokenManager
 import com.gestorrh.android.data.network.autenticacion.AuthApi
+import com.gestorrh.android.data.repository.AuthRepository
 import com.gestorrh.android.ui.login.LoginViewModel
 import com.gestorrh.android.ui.login.PantallaLogin
 import com.gestorrh.android.ui.principal.PantallaPrincipal
@@ -20,8 +21,10 @@ import com.gestorrh.android.ui.theme.GestorRHTheme
 /**
  * Actividad principal y punto de entrada (Entry Point) de la aplicación Android.
  * Actúa como el orquestador maestro (Router), encargado de inicializar las dependencias
- * críticas de nivel global (Motor de Red y Caja Fuerte) y de gestionar la navegación base.
- * * Implementa la directriz de "Auto-Login", evaluando la persistencia del Token JWT
+ * críticas de nivel global (Motor de Red, Caja Fuerte y Repositorios) y de gestionar
+ * la navegación base.
+ *
+ * Implementa la directriz de "Auto-Login", evaluando la persistencia del Token JWT
  * de manera síncrona en el arranque para decidir la ruta inicial óptima.
  */
 class MainActivity : ComponentActivity() {
@@ -30,7 +33,7 @@ class MainActivity : ComponentActivity() {
 
         val gestorToken = TokenManager(this)
         val retrofit = ApiClient.crearRetrofit(gestorToken)
-        val apiAutenticacion = retrofit.create(AuthApi::class.java)
+        val authRepository = AuthRepository(retrofit.create(AuthApi::class.java))
 
         setContent {
             GestorRHTheme {
@@ -52,7 +55,7 @@ class MainActivity : ComponentActivity() {
                         val fabricaViewModel = object : ViewModelProvider.Factory {
                             @Suppress("UNCHECKED_CAST")
                             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                                return LoginViewModel(apiAutenticacion, gestorToken) as T
+                                return LoginViewModel(authRepository, gestorToken) as T
                             }
                         }
 

--- a/app/src/main/java/com/gestorrh/android/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/AuthRepository.kt
@@ -1,0 +1,46 @@
+package com.gestorrh.android.data.repository
+
+import com.gestorrh.android.data.network.autenticacion.AuthApi
+import com.gestorrh.android.data.network.autenticacion.PeticionLoginDTO
+import com.gestorrh.android.data.network.autenticacion.RespuestaLoginDTO
+import com.gestorrh.android.domain.repository.IAuthRepository
+import okhttp3.ResponseBody
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Implementación de [IAuthRepository] que delega en el servicio Retrofit [AuthApi].
+ * Encapsula toda la lógica de conversión HTTP → Result, liberando a los ViewModels
+ * de conocer los detalles del protocolo de red.
+ *
+ * @param authApi Servicio Retrofit para los endpoints de autenticación.
+ */
+class AuthRepository(private val authApi: AuthApi) : IAuthRepository {
+
+    override suspend fun login(email: String, password: String): Result<RespuestaLoginDTO> {
+        return try {
+            val respuesta = authApi.login(PeticionLoginDTO(email, password))
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                val mensaje = extraerMensajeError(respuesta.errorBody())
+                Result.failure(Exception(mensaje))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    private fun extraerMensajeError(errorBody: ResponseBody?): String {
+        return try {
+            val json = errorBody?.string() ?: return MENSAJE_ERROR_DESCONOCIDO
+            JSONObject(json).getString("message")
+        } catch (e: JSONException) {
+            MENSAJE_ERROR_DESCONOCIDO
+        }
+    }
+
+    companion object {
+        private const val MENSAJE_ERROR_DESCONOCIDO = "Error desconocido del servidor"
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/data/repository/FichajeRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/FichajeRepository.kt
@@ -1,0 +1,81 @@
+package com.gestorrh.android.data.repository
+
+import com.gestorrh.android.data.network.fichaje.FichajeApiService
+import com.gestorrh.android.data.network.fichaje.PeticionFichajeEntradaDTO
+import com.gestorrh.android.data.network.fichaje.PeticionFichajeSalidaDTO
+import com.gestorrh.android.data.network.fichaje.RespuestaEstadoFichajeDTO
+import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
+import com.gestorrh.android.domain.repository.IFichajeRepository
+import okhttp3.ResponseBody
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Implementación de [IFichajeRepository] que delega en el servicio Retrofit [FichajeApiService].
+ * Centraliza la extracción de mensajes de error del cuerpo JSON de la respuesta,
+ * evitando que esta lógica de protocolo de red se filtre a la capa de presentación.
+ *
+ * @param apiService Servicio Retrofit para los endpoints de fichaje.
+ */
+class FichajeRepository(private val apiService: FichajeApiService) : IFichajeRepository {
+
+    override suspend fun obtenerEstadoActual(): Result<RespuestaEstadoFichajeDTO> {
+        return try {
+            val respuesta = apiService.obtenerEstadoActual()
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                val mensaje = extraerMensajeError(respuesta.errorBody())
+                    ?: "Error ${respuesta.code()} al obtener el estado"
+                Result.failure(Exception(mensaje))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun ficharEntrada(peticion: PeticionFichajeEntradaDTO): Result<RespuestaFichajeDTO> {
+        return try {
+            val respuesta = apiService.ficharEntrada(peticion)
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                val mensaje = extraerMensajeError(respuesta.errorBody())
+                    ?: "Error ${respuesta.code()} al fichar entrada"
+                Result.failure(Exception(mensaje))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun ficharSalida(peticion: PeticionFichajeSalidaDTO): Result<RespuestaFichajeDTO> {
+        return try {
+            val respuesta = apiService.ficharSalida(peticion)
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                val mensaje = extraerMensajeError(respuesta.errorBody())
+                    ?: "Error ${respuesta.code()} al fichar salida"
+                Result.failure(Exception(mensaje))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Extrae el campo "message" del cuerpo JSON de una respuesta de error de la API Spring Boot.
+     * La API siempre responde errores 4xx/5xx con un JSON que contiene dicho campo.
+     *
+     * @return El mensaje de error legible, o null si el cuerpo no es parseable.
+     */
+    private fun extraerMensajeError(errorBody: ResponseBody?): String? {
+        return try {
+            val json = errorBody?.string() ?: return null
+            JSONObject(json).getString("message")
+        } catch (e: JSONException) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/domain/repository/IAuthRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/IAuthRepository.kt
@@ -1,0 +1,22 @@
+package com.gestorrh.android.domain.repository
+
+import com.gestorrh.android.data.network.autenticacion.RespuestaLoginDTO
+
+/**
+ * Contrato de la capa de dominio para las operaciones de autenticación.
+ * Los ViewModels dependen de esta interfaz, nunca de la implementación concreta
+ * ni del servicio Retrofit directamente. Esto facilita el testeo unitario
+ * mediante sustitución por dobles de prueba (fakes/mocks).
+ */
+interface IAuthRepository {
+
+    /**
+     * Autentica al empleado con sus credenciales.
+     *
+     * @param email Correo electrónico del empleado.
+     * @param password Contraseña del empleado.
+     * @return [Result.success] con [RespuestaLoginDTO] si el servidor acepta las credenciales,
+     *         o [Result.failure] con el mensaje de error extraído del cuerpo de la respuesta.
+     */
+    suspend fun login(email: String, password: String): Result<RespuestaLoginDTO>
+}

--- a/app/src/main/java/com/gestorrh/android/domain/repository/IFichajeRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/IFichajeRepository.kt
@@ -1,0 +1,40 @@
+package com.gestorrh.android.domain.repository
+
+import com.gestorrh.android.data.network.fichaje.PeticionFichajeEntradaDTO
+import com.gestorrh.android.data.network.fichaje.PeticionFichajeSalidaDTO
+import com.gestorrh.android.data.network.fichaje.RespuestaEstadoFichajeDTO
+import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
+
+/**
+ * Contrato de la capa de dominio para las operaciones de fichaje.
+ * Los ViewModels dependen de esta interfaz, nunca del servicio Retrofit directamente.
+ * La implementación concreta vive en la capa de datos ([com.gestorrh.android.data.repository]).
+ */
+interface IFichajeRepository {
+
+    /**
+     * Consulta el estado de fichaje actual del empleado autenticado.
+     *
+     * @return [Result.success] con [RespuestaEstadoFichajeDTO], o [Result.failure] con
+     *         el mensaje de error del servidor o de red.
+     */
+    suspend fun obtenerEstadoActual(): Result<RespuestaEstadoFichajeDTO>
+
+    /**
+     * Registra la entrada del empleado.
+     *
+     * @param peticion DTO con las coordenadas GPS (null si la modalidad es TELETRABAJO).
+     * @return [Result.success] con [RespuestaFichajeDTO], o [Result.failure] con el
+     *         mensaje de error del servidor (ej. empleado fuera del radio de la sede).
+     */
+    suspend fun ficharEntrada(peticion: PeticionFichajeEntradaDTO): Result<RespuestaFichajeDTO>
+
+    /**
+     * Registra la salida del empleado.
+     *
+     * @param peticion DTO con las coordenadas GPS (null si la modalidad es TELETRABAJO).
+     * @return [Result.success] con [RespuestaFichajeDTO], o [Result.failure] con el
+     *         mensaje de error del servidor.
+     */
+    suspend fun ficharSalida(peticion: PeticionFichajeSalidaDTO): Result<RespuestaFichajeDTO>
+}

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -6,10 +6,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.gestorrh.android.core.network.ApiClient
+import com.gestorrh.android.core.security.TokenManager
 import com.gestorrh.android.data.network.fichaje.FichajeApiService
 import com.gestorrh.android.data.network.fichaje.ModalidadTurno
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeEntradaDTO
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeSalidaDTO
+import com.gestorrh.android.data.repository.FichajeRepository
+import com.gestorrh.android.domain.repository.IFichajeRepository
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,15 +20,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import okhttp3.ResponseBody
-import org.json.JSONObject
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
 data class EstadoUiDashboard(
     val estadoActual: EstadoFichaje = EstadoFichaje.FUERA_TURNO,
     val tiempoTranscurrido: String = "00:00:00",
-
     val estaCargando: Boolean = true,
     val mensajeError: String? = null,
     val idFichajeAbierto: Long? = null,
@@ -38,7 +38,7 @@ enum class EstadoFichaje {
 }
 
 class DashboardViewModel(
-    private val apiService: FichajeApiService
+    private val fichajeRepository: IFichajeRepository
 ) : ViewModel() {
 
     private val _estadoUi = MutableStateFlow(EstadoUiDashboard())
@@ -52,48 +52,40 @@ class DashboardViewModel(
     }
 
     /**
-     * P0-11: Sincronización Inicial (BFF)
+     * P0-11: Sincronización Inicial (BFF).
+     * Consulta el estado de fichaje actual a través del repositorio.
      */
     fun sincronizarEstado() {
         viewModelScope.launch {
             _estadoUi.update { it.copy(estaCargando = true, mensajeError = null) }
 
-            try {
-                val respuesta = apiService.obtenerEstadoActual()
-
-                if (respuesta.isSuccessful) {
-                    val datos = respuesta.body()
-                    if (datos != null) {
-
-                        _estadoUi.update {
-                            it.copy(
-                                idFichajeAbierto = datos.idFichajeAbierto,
-                                modalidadHoy = datos.modalidadHoy,
-                                tieneTurnoHoy = datos.tieneTurnoHoy,
-                                estadoActual = if (datos.trabajandoActualmente) EstadoFichaje.TRABAJANDO else EstadoFichaje.FUERA_TURNO
-                            )
-                        }
-
-                        if (datos.trabajandoActualmente && datos.horaEntrada != null) {
-                            val ahora = LocalDateTime.now()
-                            segundosAcumulados = ChronoUnit.SECONDS.between(datos.horaEntrada, ahora)
-                            iniciarTemporizador()
-                        }
+            fichajeRepository.obtenerEstadoActual()
+                .onSuccess { datos ->
+                    _estadoUi.update {
+                        it.copy(
+                            idFichajeAbierto = datos.idFichajeAbierto,
+                            modalidadHoy = datos.modalidadHoy,
+                            tieneTurnoHoy = datos.tieneTurnoHoy,
+                            estadoActual = if (datos.trabajandoActualmente) EstadoFichaje.TRABAJANDO else EstadoFichaje.FUERA_TURNO
+                        )
                     }
-                } else {
-                    mostrarError("No se pudo obtener el estado actual. Código: ${respuesta.code()}")
+
+                    if (datos.trabajandoActualmente && datos.horaEntrada != null) {
+                        segundosAcumulados = ChronoUnit.SECONDS.between(datos.horaEntrada, LocalDateTime.now())
+                        iniciarTemporizador()
+                    }
                 }
-            } catch (e: Exception) {
-                e.printStackTrace()
-                mostrarError("Error de conexión con el servidor.")
-            } finally {
-                _estadoUi.update { it.copy(estaCargando = false) }
-            }
+                .onFailure { e ->
+                    mostrarError(e.message ?: "Error de conexión con el servidor.")
+                }
+
+            _estadoUi.update { it.copy(estaCargando = false) }
         }
     }
 
     /**
-     * P0-10 y P0-12: Orquestador de Fichaje
+     * P0-10 y P0-12: Orquestador de Fichaje.
+     * Decide si fichar entrada o salida según el estado actual.
      */
     fun alternarFichaje(ubicacion: Location?) {
         val estadoActual = _estadoUi.value
@@ -109,33 +101,28 @@ class DashboardViewModel(
         viewModelScope.launch {
             _estadoUi.update { it.copy(estaCargando = true, mensajeError = null) }
 
-            try {
-                val peticion = if (modalidadHoy == ModalidadTurno.TELETRABAJO) {
-                    PeticionFichajeEntradaDTO(latitud = null, longitud = null)
-                } else {
-                    PeticionFichajeEntradaDTO(latitud = ubicacion?.latitude, longitud = ubicacion?.longitude)
-                }
+            val peticion = if (modalidadHoy == ModalidadTurno.TELETRABAJO) {
+                PeticionFichajeEntradaDTO(latitud = null, longitud = null)
+            } else {
+                PeticionFichajeEntradaDTO(latitud = ubicacion?.latitude, longitud = ubicacion?.longitude)
+            }
 
-                val respuesta = apiService.ficharEntrada(peticion)
-
-                if (respuesta.isSuccessful) {
-                    val fichaje = respuesta.body()
+            fichajeRepository.ficharEntrada(peticion)
+                .onSuccess { fichaje ->
                     _estadoUi.update {
                         it.copy(
                             estadoActual = EstadoFichaje.TRABAJANDO,
-                            idFichajeAbierto = fichaje?.idFichaje
+                            idFichajeAbierto = fichaje.idFichaje
                         )
                     }
                     segundosAcumulados = 0
                     iniciarTemporizador()
-                } else {
-                    mostrarError(extraerMensajeError(respuesta.errorBody()))
                 }
-            } catch (e: Exception) {
-                mostrarError("Fallo de red al intentar fichar.")
-            } finally {
-                _estadoUi.update { it.copy(estaCargando = false) }
-            }
+                .onFailure { e ->
+                    mostrarError(e.message ?: "Fallo de red al intentar fichar.")
+                }
+
+            _estadoUi.update { it.copy(estaCargando = false) }
         }
     }
 
@@ -145,11 +132,13 @@ class DashboardViewModel(
         viewModelScope.launch {
             _estadoUi.update { it.copy(estaCargando = true, mensajeError = null) }
 
-            try {
-                val peticion = PeticionFichajeSalidaDTO(latitud = ubicacion?.latitude, longitud = ubicacion?.longitude)
-                val respuesta = apiService.ficharSalida(peticion)
+            val peticion = PeticionFichajeSalidaDTO(
+                latitud = ubicacion?.latitude,
+                longitud = ubicacion?.longitude
+            )
 
-                if (respuesta.isSuccessful) {
+            fichajeRepository.ficharSalida(peticion)
+                .onSuccess {
                     detenerTemporizador()
                     _estadoUi.update {
                         it.copy(
@@ -158,18 +147,16 @@ class DashboardViewModel(
                             tiempoTranscurrido = "00:00:00"
                         )
                     }
-                } else {
-                    mostrarError(extraerMensajeError(respuesta.errorBody()))
                 }
-            } catch (e: Exception) {
-                mostrarError("Fallo de red al intentar finalizar la jornada.")
-            } finally {
-                _estadoUi.update { it.copy(estaCargando = false) }
-            }
+                .onFailure { e ->
+                    mostrarError(e.message ?: "Fallo de red al intentar finalizar la jornada.")
+                }
+
+            _estadoUi.update { it.copy(estaCargando = false) }
         }
     }
 
-    // FUNCIONES AUXILIARES
+    // ── FUNCIONES AUXILIARES ──────────────────────────────────────────────────
 
     fun errorMostrado() {
         _estadoUi.update { it.copy(mensajeError = null) }
@@ -177,16 +164,6 @@ class DashboardViewModel(
 
     private fun mostrarError(mensaje: String) {
         _estadoUi.update { it.copy(mensajeError = mensaje) }
-    }
-
-    private fun extraerMensajeError(errorBody: ResponseBody?): String {
-        return try {
-            val jsonStr = errorBody?.string() ?: return "Error desconocido"
-            val jsonObject = JSONObject(jsonStr)
-            jsonObject.getString("message")
-        } catch (e: Exception) {
-            "Ocurrió un error en el servidor."
-        }
     }
 
     private fun iniciarTemporizador() {
@@ -214,16 +191,18 @@ class DashboardViewModel(
     }
 }
 
-// FACTORY MANUAL
+// ── FACTORY MANUAL ────────────────────────────────────────────────────────────
+
 class DashboardViewModelFactory(private val contexto: Context) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(DashboardViewModel::class.java)) {
-            val tokenManager = com.gestorrh.android.core.security.TokenManager(contexto)
+            val tokenManager = TokenManager(contexto)
             val retrofit = ApiClient.crearRetrofit(tokenManager)
             val apiService = retrofit.create(FichajeApiService::class.java)
+            val fichajeRepository = FichajeRepository(apiService)
 
             @Suppress("UNCHECKED_CAST")
-            return DashboardViewModel(apiService) as T
+            return DashboardViewModel(fichajeRepository) as T
         }
         throw IllegalArgumentException("Clase ViewModel desconocida")
     }

--- a/app/src/main/java/com/gestorrh/android/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/login/LoginViewModel.kt
@@ -2,26 +2,27 @@ package com.gestorrh.android.ui.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.gestorrh.android.R
 import com.gestorrh.android.core.security.TokenManager
-import com.gestorrh.android.data.network.autenticacion.AuthApi
-import com.gestorrh.android.data.network.autenticacion.PeticionLoginDTO
+import com.gestorrh.android.domain.repository.IAuthRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import com.gestorrh.android.R
 
 /**
  * Manejador de la lógica de presentación y el estado para la pantalla de Autenticación.
- * Actúa como puente (Middleware) entre la Interfaz de Usuario (Jetpack Compose) y la capa de Red/Seguridad.
- * Utiliza flujos reactivos (StateFlow) para garantizar una actualización de la UI segura y unidireccional.
+ * Actúa como puente (Middleware) entre la Interfaz de Usuario (Jetpack Compose) y la capa
+ * de dominio a través del [IAuthRepository], sin acoplarse a ningún detalle de red.
+ * Utiliza flujos reactivos (StateFlow) para garantizar una actualización de la UI
+ * segura y unidireccional.
  *
- * @property authApi Dependencia para invocar los servicios de red de autenticación.
+ * @property authRepository Dependencia del contrato de dominio para autenticación.
  * @property tokenManager Dependencia para interactuar con la caja fuerte del dispositivo (Keystore).
  */
 class LoginViewModel(
-    private val authApi: AuthApi,
+    private val authRepository: IAuthRepository,
     private val tokenManager: TokenManager
 ) : ViewModel() {
 
@@ -32,38 +33,32 @@ class LoginViewModel(
 
     /**
      * Actualiza el estado reactivo con el nuevo correo electrónico introducido por el usuario
-     * y lanza la validación matemática del formulario.
+     * y lanza la validación del formulario.
      *
      * @param nuevoEmail Cadena de texto actual en el campo de correo.
      */
     fun actualizarEmail(nuevoEmail: String) {
         _estadoUi.update { estadoActual ->
-            estadoActual.copy(
-                email = nuevoEmail,
-                mensajeError = null
-            )
+            estadoActual.copy(email = nuevoEmail, mensajeError = null)
         }
         validarFormulario()
     }
 
     /**
      * Actualiza el estado reactivo con la nueva contraseña introducida por el usuario
-     * y lanza la validación matemática del formulario.
+     * y lanza la validación del formulario.
      *
      * @param nuevaPassword Cadena de texto actual en el campo de contraseña.
      */
     fun actualizarPassword(nuevaPassword: String) {
         _estadoUi.update { estadoActual ->
-            estadoActual.copy(
-                password = nuevaPassword,
-                mensajeError = null
-            )
+            estadoActual.copy(password = nuevaPassword, mensajeError = null)
         }
         validarFormulario()
     }
 
     /**
-     * Ejecuta la petición de red para autenticar al empleado contra el servidor Spring Boot.
+     * Ejecuta la petición de autenticación a través del repositorio.
      * La llamada se suspende en un hilo secundario (viewModelScope) para operar
      * asíncronamente sin bloquear la interfaz gráfica del móvil.
      */
@@ -75,16 +70,12 @@ class LoginViewModel(
         }
 
         viewModelScope.launch {
-            try {
-                val peticion = PeticionLoginDTO(estadoActual.email, estadoActual.password)
-                val respuesta = authApi.login(peticion)
-
-                if (respuesta.isSuccessful && respuesta.body() != null) {
-                    val token = respuesta.body()!!.token
-                    tokenManager.guardarToken(token)
-
+            authRepository.login(estadoActual.email, estadoActual.password)
+                .onSuccess { respuesta ->
+                    tokenManager.guardarToken(respuesta.token)
                     _estadoUi.update { it.copy(estaCargando = false, loginExitoso = true) }
-                } else {
+                }
+                .onFailure {
                     _estadoUi.update {
                         it.copy(
                             estaCargando = false,
@@ -93,32 +84,22 @@ class LoginViewModel(
                         )
                     }
                 }
-            } catch (e: Exception) {
-                _estadoUi.update {
-                    it.copy(
-                        estaCargando = false,
-                        mensajeError = R.string.login_error_network,
-                        botonLoginHabilitado = true
-                    )
-                }
-            }
         }
     }
 
     /**
      * Motor de validación reactiva en local.
-     * Comprueba si los datos cumplen los requisitos mínimos para
-     * habilitar el botón, evitando enviar peticiones basura a la API.
+     * Comprueba si los datos cumplen los requisitos mínimos para habilitar el botón,
+     * evitando enviar peticiones basura a la API.
      */
     private fun validarFormulario() {
         val email = _estadoUi.value.email
         val password = _estadoUi.value.password
 
-        val emailValido = email.matches(patronEmail)
-        val passwordValida = password.isNotEmpty()
-
         _estadoUi.update { estadoActual ->
-            estadoActual.copy(botonLoginHabilitado = emailValido && passwordValida)
+            estadoActual.copy(
+                botonLoginHabilitado = email.matches(patronEmail) && password.isNotEmpty()
+            )
         }
     }
 }


### PR DESCRIPTION
## Problema

Los ViewModels accedían directamente a los servicios Retrofit, mezclando lógica de protocolo de red (parseo de `errorBody`, inspección de códigos HTTP) con lógica de presentación. Esto viola la arquitectura MVVM y hace imposible el testeo unitario de los ViewModels sin un servidor real.

## Cambios

### Nuevos ficheros — capa `domain/repository/`
| Fichero | Descripción |
|---|---|
| `IAuthRepository.kt` | Contrato de autenticación: `suspend fun login(...)` |
| `IFichajeRepository.kt` | Contrato de fichaje: `obtenerEstadoActual`, `ficharEntrada`, `ficharSalida` |

### Nuevos ficheros — capa `data/repository/`
| Fichero | Descripción |
|---|---|
| `AuthRepository.kt` | Implementación: delega en `AuthApi`, extrae `message` del JSON de error |
| `FichajeRepository.kt` | Implementación: delega en `FichajeApiService`, extrae mensajes de error |

### Ficheros modificados
- **`LoginViewModel`** — ahora recibe `IAuthRepository`, elimina dependencia directa de `AuthApi`
- **`DashboardViewModel`** — ahora recibe `IFichajeRepository`, elimina `extraerMensajeError` y el import de `ResponseBody`/`JSONObject`
- **`DashboardViewModelFactory`** — construye `FichajeRepository` e inyecta la interfaz
- **`MainActivity`** — construye `AuthRepository` e inyecta la interfaz en el factory de `LoginViewModel`

## Arquitectura resultante

```
ViewModel → IRepository (domain) ← Repository (data) → ApiService (Retrofit)
```

Los repositorios devuelven `Result<T>` idiomático de Kotlin. Los ViewModels usan `.onSuccess { }` / `.onFailure { }` sin conocer ningún detalle HTTP.

## Alcance

No se crean tests en este PR (planificado para una issue posterior). Solo se establece la estructura de capas correcta.

> **Base branch:** `fix/eliminar-koin` — mergear en orden: C1 → C2

