### PR TITLE
fix: unificar manejo de errores en ViewModels con MensajeUi

### DIFF
--- a/app/src/main/java/com/gestorrh/android/core/ui/MensajeUi.kt
+++ b/app/src/main/java/com/gestorrh/android/core/ui/MensajeUi.kt
@@ -1,0 +1,35 @@
+package com.gestorrh.android.core.ui
+
+import androidx.annotation.StringRes
+
+/**
+ * Abstracción que unifica los dos tipos de mensajes de error posibles en los ViewModels:
+ *
+ * - [Recurso]: errores estáticos conocidos en tiempo de compilación (ej. "Error de red",
+ *   "Permiso denegado"). Se referencian por su ID de recurso de string para garantizar
+ *   la correcta localización (i18n) y evitar strings hardcodeados en Kotlin.
+ *
+ * - [Dinamico]: mensajes procedentes del servidor (campo "message" del JSON de error).
+ *   Son cadenas que el backend genera en tiempo de ejecución y que la aplicación no puede
+ *   conocer de antemano (ej. "El empleado se encuentra fuera del radio de la sede").
+ *
+ * Las pantallas (Composables) resuelven esta abstracción con [android.content.Context.getString]
+ * o [androidx.compose.ui.res.stringResource] según el tipo, evitando que los ViewModels
+ * necesiten acceder a [android.content.Context].
+ */
+sealed class MensajeUi {
+
+    /**
+     * Error estático localizable mediante un ID de recurso string.
+     *
+     * @property idRecurso Identificador del string en `res/values/strings.xml`.
+     */
+    data class Recurso(@StringRes val idRecurso: Int) : MensajeUi()
+
+    /**
+     * Error dinámico cuyo texto proviene del servidor en tiempo de ejecución.
+     *
+     * @property texto Cadena de texto tal como la devuelve la API.
+     */
+    data class Dinamico(val texto: String) : MensajeUi()
+}

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -5,8 +5,10 @@ import android.location.Location
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.gestorrh.android.R
 import com.gestorrh.android.core.network.ApiClient
 import com.gestorrh.android.core.security.TokenManager
+import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.network.fichaje.FichajeApiService
 import com.gestorrh.android.data.network.fichaje.ModalidadTurno
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeEntradaDTO
@@ -27,7 +29,7 @@ data class EstadoUiDashboard(
     val estadoActual: EstadoFichaje = EstadoFichaje.FUERA_TURNO,
     val tiempoTranscurrido: String = "00:00:00",
     val estaCargando: Boolean = true,
-    val mensajeError: String? = null,
+    val mensajeError: MensajeUi? = null,
     val idFichajeAbierto: Long? = null,
     val modalidadHoy: ModalidadTurno? = null,
     val tieneTurnoHoy: Boolean = false
@@ -76,7 +78,9 @@ class DashboardViewModel(
                     }
                 }
                 .onFailure { e ->
-                    mostrarError(e.message ?: "Error de conexión con el servidor.")
+                    val mensaje = if (e.message != null) MensajeUi.Dinamico(e.message!!)
+                    else MensajeUi.Recurso(R.string.error_conexion)
+                    mostrarError(mensaje)
                 }
 
             _estadoUi.update { it.copy(estaCargando = false) }
@@ -119,7 +123,9 @@ class DashboardViewModel(
                     iniciarTemporizador()
                 }
                 .onFailure { e ->
-                    mostrarError(e.message ?: "Fallo de red al intentar fichar.")
+                    val mensaje = if (e.message != null) MensajeUi.Dinamico(e.message!!)
+                    else MensajeUi.Recurso(R.string.error_fallo_red_entrada)
+                    mostrarError(mensaje)
                 }
 
             _estadoUi.update { it.copy(estaCargando = false) }
@@ -149,7 +155,9 @@ class DashboardViewModel(
                     }
                 }
                 .onFailure { e ->
-                    mostrarError(e.message ?: "Fallo de red al intentar finalizar la jornada.")
+                    val mensaje = if (e.message != null) MensajeUi.Dinamico(e.message!!)
+                    else MensajeUi.Recurso(R.string.error_fallo_red_salida)
+                    mostrarError(mensaje)
                 }
 
             _estadoUi.update { it.copy(estaCargando = false) }
@@ -162,7 +170,7 @@ class DashboardViewModel(
         _estadoUi.update { it.copy(mensajeError = null) }
     }
 
-    private fun mostrarError(mensaje: String) {
+    private fun mostrarError(mensaje: MensajeUi) {
         _estadoUi.update { it.copy(mensajeError = mensaje) }
     }
 

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -28,6 +28,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gestorrh.android.R
 import com.gestorrh.android.core.location.GestorLocalizacion
+import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.network.fichaje.ModalidadTurno
 import kotlinx.coroutines.launch
 
@@ -45,10 +46,15 @@ fun PantallaDashboard(
     val gestorLocalizacion = remember { GestorLocalizacion(contexto) }
 
     val errorPermisoTexto = stringResource(id = R.string.error_permiso_ubicacion)
+    val contextoLocal = LocalContext.current
 
     LaunchedEffect(estadoUi.mensajeError) {
-        estadoUi.mensajeError?.let { mensaje ->
-            snackbarHostState.showSnackbar(mensaje)
+        estadoUi.mensajeError?.let { mensajeUi ->
+            val textoMensaje = when (mensajeUi) {
+                is MensajeUi.Recurso -> contextoLocal.getString(mensajeUi.idRecurso)
+                is MensajeUi.Dinamico -> mensajeUi.texto
+            }
+            snackbarHostState.showSnackbar(textoMensaje)
             viewModel.errorMostrado()
         }
     }

--- a/app/src/main/java/com/gestorrh/android/ui/login/EstadoUiLogin.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/login/EstadoUiLogin.kt
@@ -1,6 +1,6 @@
 package com.gestorrh.android.ui.login
 
-import androidx.annotation.StringRes
+import com.gestorrh.android.core.ui.MensajeUi
 
 /**
  * Representa el estado inmutable de la Interfaz de Usuario (UI) para la pantalla de autenticación.
@@ -9,16 +9,18 @@ import androidx.annotation.StringRes
  *
  * @property email Valor actual introducido en el campo de correo electrónico.
  * @property password Valor actual introducido en el campo de contraseña.
- * @property botonLoginHabilitado Indica si el botón de acceso debe ser interactuable (se activa al cumplir la validación local).
- * @property estaCargando Activa los indicadores visuales de espera mientras el servidor procesa la petición de red.
- * @property mensajeError Identificador del recurso de string (StringRes) que contiene el error a mostrar (ej. "Credenciales inválidas"). Null si no hay errores.
- * @property loginExitoso Bandera de un solo uso (One-Time Event) que notifica a la vista que debe ejecutar la navegación hacia el Dashboard.
+ * @property botonLoginHabilitado Indica si el botón de acceso debe ser interactuable.
+ * @property estaCargando Activa los indicadores visuales de espera mientras el servidor procesa la petición.
+ * @property mensajeError Mensaje de error a mostrar en el Snackbar. Usa [MensajeUi] para distinguir
+ *   entre errores estáticos (StringRes) y errores dinámicos procedentes del servidor. Null si no hay error.
+ * @property loginExitoso Bandera de un solo uso (One-Time Event) que notifica a la vista que debe
+ *   ejecutar la navegación hacia el Dashboard.
  */
 data class EstadoUiLogin(
     val email: String = "",
     val password: String = "",
     val botonLoginHabilitado: Boolean = false,
     val estaCargando: Boolean = false,
-    @StringRes val mensajeError: Int? = null,
+    val mensajeError: MensajeUi? = null,
     val loginExitoso: Boolean = false
 )

--- a/app/src/main/java/com/gestorrh/android/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/login/LoginViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gestorrh.android.R
 import com.gestorrh.android.core.security.TokenManager
+import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.domain.repository.IAuthRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -79,7 +80,7 @@ class LoginViewModel(
                     _estadoUi.update {
                         it.copy(
                             estaCargando = false,
-                            mensajeError = R.string.login_error_credentials,
+                            mensajeError = MensajeUi.Recurso(R.string.login_error_credentials),
                             botonLoginHabilitado = true
                         )
                     }

--- a/app/src/main/java/com/gestorrh/android/ui/login/PantallaLogin.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/login/PantallaLogin.kt
@@ -15,7 +15,9 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
 import com.gestorrh.android.R
+import com.gestorrh.android.core.ui.MensajeUi
 
 /**
  * Interfaz gráfica para la autenticación de usuarios.
@@ -94,9 +96,14 @@ fun PantallaLogin(
                 modifier = Modifier.padding(top = 4.dp, bottom = 48.dp)
             )
 
-            estadoUi.mensajeError?.let { errorResId ->
+            estadoUi.mensajeError?.let { mensajeUi ->
+                val contextoLocal = LocalContext.current
+                val textoError = when (mensajeUi) {
+                    is MensajeUi.Recurso -> stringResource(id = mensajeUi.idRecurso)
+                    is MensajeUi.Dinamico -> mensajeUi.texto
+                }
                 Text(
-                    text = stringResource(id = errorResId),
+                    text = textoError,
                     color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodyMedium,
                     modifier = Modifier.padding(bottom = 16.dp)

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -35,6 +35,10 @@
     <string name="dashboard_modalidad_remota">REMOTE WORK</string>
 
     <string name="error_permiso_ubicacion">Location permission denied. Cannot clock in.</string>
+    <string name="error_conexion">Server connection error</string>
+    <string name="error_fallo_red_entrada">Network error while clocking in</string>
+    <string name="error_fallo_red_salida">Network error while clocking out</string>
+    <string name="error_desconocido">Unknown server error</string>
     <string name="cd_perfil">Profile</string>
     <string name="cd_teletrabajo">Remote Work Icon</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,10 @@
     <string name="dashboard_modalidad_remota">MODALIDAD REMOTA</string>
 
     <string name="error_permiso_ubicacion">Permiso de ubicación denegado. No se puede fichar.</string>
+    <string name="error_conexion">Error de conexión con el servidor</string>
+    <string name="error_fallo_red_entrada">Fallo de red al intentar fichar entrada</string>
+    <string name="error_fallo_red_salida">Fallo de red al intentar finalizar la jornada</string>
+    <string name="error_desconocido">Error desconocido del servidor</string>
     <string name="cd_perfil">Perfil</string>
     <string name="cd_teletrabajo">Icono Teletrabajo</string>
 </resources>


### PR DESCRIPTION
## Problema

`DashboardViewModel` usaba strings literales hardcodeados para todos sus errores:
```kotlin
mostrarError("Error de conexión con el servidor.")
mostrarError("Fallo de red al intentar fichar.")
```
Esto viola la regla del proyecto ("ningún string visible al usuario puede estar hardcodeado en Kotlin") y rompe la localización.

Adicionalmente, `LoginViewModel` usaba `Int?` (StringRes) y `DashboardViewModel` usaba `String?`, dos tipos inconsistentes para el mismo concepto.

## Solución: `sealed class MensajeUi`

Se crea `core/ui/MensajeUi.kt` con dos variantes:

```kotlin
sealed class MensajeUi {
    data class Recurso(@StringRes val idRecurso: Int) : MensajeUi()  // errores estáticos
    data class Dinamico(val texto: String) : MensajeUi()             // mensajes del servidor
}
```

**¿Por qué no `Int?` directo como LoginViewModel?**
`DashboardViewModel` recibe mensajes dinámicos del servidor (p.ej. _"Empleado fuera del radio de la sede"_) que no pueden conocerse en tiempo de compilación. `MensajeUi` mantiene la localización para los errores estáticos y preserva los mensajes de la API sin pérdida de información.

## Cambios

| Fichero | Cambio |
|---|---|
| `core/ui/MensajeUi.kt` | **Nuevo** — sealed class |
| `EstadoUiLogin.kt` | `mensajeError: Int?` → `MensajeUi?` |
| `LoginViewModel.kt` | Usa `MensajeUi.Recurso(R.string.xxx)` |
| `DashboardViewModel.kt` | `mensajeError: String?` → `MensajeUi?`; strings literales → `MensajeUi.Recurso` |
| `PantallaDashboard.kt` | Resuelve `MensajeUi` con `when {}` en `LaunchedEffect` |
| `PantallaLogin.kt` | Resuelve `MensajeUi` con `when {}` inline |
| `strings.xml` ES + EN | 4 nuevas entradas: `error_conexion`, `error_fallo_red_entrada`, `error_fallo_red_salida`, `error_desconocido` |

> **Base branch:** `fix/añadir-capa-repository` — mergear en orden: C1 → C2 → C3

