### PR TITLE
fix: dashboard con nombre real del empleado y fecha dinámica

### DIFF
--- a/app/src/main/java/com/gestorrh/android/core/security/TokenManager.kt
+++ b/app/src/main/java/com/gestorrh/android/core/security/TokenManager.kt
@@ -28,6 +28,7 @@ class TokenManager(contexto: Context) {
 
     companion object {
         private const val CLAVE_TOKEN_JWT = "token_jwt"
+        private const val CLAVE_NOMBRE_EMPLEADO = "nombre_empleado"
     }
 
     /**
@@ -56,5 +57,33 @@ class TokenManager(contexto: Context) {
      */
     fun borrarToken() {
         preferenciasCifradas.edit().remove(CLAVE_TOKEN_JWT).apply()
+    }
+
+    /**
+     * Almacena el nombre completo del empleado autenticado.
+     * Se persiste junto al token para evitar llamadas de red adicionales al arrancar la app.
+     * El nombre ya viene en [com.gestorrh.android.data.network.autenticacion.RespuestaLoginDTO.nombre].
+     *
+     * @param nombre Nombre completo del empleado tal como lo devuelve el servidor.
+     */
+    fun guardarNombre(nombre: String) {
+        preferenciasCifradas.edit().putString(CLAVE_NOMBRE_EMPLEADO, nombre).apply()
+    }
+
+    /**
+     * Recupera el nombre del empleado de la sesión activa.
+     *
+     * @return El nombre completo si existe, o null si no hay sesión iniciada.
+     */
+    fun obtenerNombre(): String? {
+        return preferenciasCifradas.getString(CLAVE_NOMBRE_EMPLEADO, null)
+    }
+
+    /**
+     * Purga el nombre del almacenamiento seguro.
+     * Debe llamarse junto a [borrarToken] en el flujo de Logout (P1-05).
+     */
+    fun borrarNombre() {
+        preferenciasCifradas.edit().remove(CLAVE_NOMBRE_EMPLEADO).apply()
     }
 }

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -32,7 +32,9 @@ data class EstadoUiDashboard(
     val mensajeError: MensajeUi? = null,
     val idFichajeAbierto: Long? = null,
     val modalidadHoy: ModalidadTurno? = null,
-    val tieneTurnoHoy: Boolean = false
+    val tieneTurnoHoy: Boolean = false,
+    /** Nombre completo del empleado autenticado, leído desde [TokenManager] sin llamadas de red. */
+    val nombreEmpleado: String = ""
 )
 
 enum class EstadoFichaje {
@@ -40,7 +42,8 @@ enum class EstadoFichaje {
 }
 
 class DashboardViewModel(
-    private val fichajeRepository: IFichajeRepository
+    private val fichajeRepository: IFichajeRepository,
+    private val tokenManager: TokenManager
 ) : ViewModel() {
 
     private val _estadoUi = MutableStateFlow(EstadoUiDashboard())
@@ -50,6 +53,10 @@ class DashboardViewModel(
     private var segundosAcumulados: Long = 0
 
     init {
+        // Carga el nombre desde el almacenamiento seguro sin llamada de red
+        val nombre = tokenManager.obtenerNombre() ?: ""
+        _estadoUi.update { it.copy(nombreEmpleado = nombre) }
+
         sincronizarEstado()
     }
 
@@ -210,7 +217,7 @@ class DashboardViewModelFactory(private val contexto: Context) : ViewModelProvid
             val fichajeRepository = FichajeRepository(apiService)
 
             @Suppress("UNCHECKED_CAST")
-            return DashboardViewModel(fichajeRepository) as T
+            return DashboardViewModel(fichajeRepository, tokenManager) as T
         }
         throw IllegalArgumentException("Clase ViewModel desconocida")
     }

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -31,6 +31,9 @@ import com.gestorrh.android.core.location.GestorLocalizacion
 import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.network.fichaje.ModalidadTurno
 import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @Composable
 fun PantallaDashboard(
@@ -105,7 +108,7 @@ fun PantallaDashboard(
                 .padding(24.dp)
                 .verticalScroll(rememberScrollState())
         ) {
-            CabeceraDashboard()
+            CabeceraDashboard(nombreEmpleado = estadoUi.nombreEmpleado)
 
             Spacer(modifier = Modifier.height(40.dp))
 
@@ -141,7 +144,25 @@ fun PantallaDashboard(
 }
 
 @Composable
-private fun CabeceraDashboard() {
+private fun CabeceraDashboard(nombreEmpleado: String) {
+    // Fecha actual formateada y localizada con java.time, sin llamadas de red adicionales.
+    // El patrón de formato se carga desde strings.xml para que cada locale tenga su propia
+    // representación (ES: "EEEE, d 'de' MMMM" / EN: "EEEE, MMMM d").
+    val patronFecha = stringResource(id = R.string.dashboard_formato_fecha)
+    val fechaHoy = remember(patronFecha) {
+        val locale = Locale.getDefault()
+        val formatter = DateTimeFormatter.ofPattern(patronFecha, locale)
+        val fechaFormateada = LocalDate.now().format(formatter)
+        // Capitaliza la primera letra (los locales suelen devolver el día en minúsculas)
+        fechaFormateada.replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
+    }
+
+    val saludo = if (nombreEmpleado.isNotEmpty()) {
+        stringResource(id = R.string.dashboard_saludo_nombre, nombreEmpleado)
+    } else {
+        stringResource(id = R.string.dashboard_saludo_generico)
+    }
+
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -149,12 +170,12 @@ private fun CabeceraDashboard() {
     ) {
         Column {
             Text(
-                text = stringResource(id = R.string.dashboard_fecha_ejemplo),
+                text = fechaHoy,
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.primary
             )
             Text(
-                text = stringResource(id = R.string.dashboard_saludo),
+                text = saludo,
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface

--- a/app/src/main/java/com/gestorrh/android/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/login/LoginViewModel.kt
@@ -74,6 +74,7 @@ class LoginViewModel(
             authRepository.login(estadoActual.email, estadoActual.password)
                 .onSuccess { respuesta ->
                     tokenManager.guardarToken(respuesta.token)
+                    tokenManager.guardarNombre(respuesta.nombre)
                     _estadoUi.update { it.copy(estaCargando = false, loginExitoso = true) }
                 }
                 .onFailure {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -16,8 +16,12 @@
     <string name="nav_ausencias">Time Off</string>
     <string name="nav_perfil">Profile</string>
     <string name="nav_equipo">My team</string>
-    <string name="dashboard_saludo">Hello, Employee!</string>
-    <string name="dashboard_fecha_ejemplo">Monday, October 14</string>
+    <!-- Dynamic greeting: %s is replaced with the authenticated employee's name -->
+    <string name="dashboard_saludo_nombre">Hello, %s!</string>
+    <!-- Generic fallback greeting (session without persisted name) -->
+    <string name="dashboard_saludo_generico">Welcome!</string>
+    <!-- Date format pattern for java.time.DateTimeFormatter -->
+    <string name="dashboard_formato_fecha">EEEE, MMMM d</string>
     <string name="dashboard_turno_titulo">Next Shift</string>
     <string name="dashboard_turno_valor">08:00 – 16:00</string>
     <string name="dashboard_ausencia_titulo">Time Off</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,8 +16,12 @@
     <string name="nav_ausencias">Ausencias</string>
     <string name="nav_perfil">Perfil</string>
     <string name="nav_equipo">Mi equipo</string>
-    <string name="dashboard_saludo">¡Hola, Empleado!</string>
-    <string name="dashboard_fecha_ejemplo">Lunes, 14 de Octubre</string>
+    <!-- Saludo dinámico: %s se sustituye por el nombre del empleado autenticado -->
+    <string name="dashboard_saludo_nombre">¡Hola, %s!</string>
+    <!-- Saludo genérico de respaldo (sesión sin nombre persistido) -->
+    <string name="dashboard_saludo_generico">¡Bienvenido!</string>
+    <!-- Patrón de formato de fecha localizado para java.time.DateTimeFormatter -->
+    <string name="dashboard_formato_fecha">EEEE, d \'de\' MMMM</string>
     <string name="dashboard_turno_titulo">Siguiente Turno</string>
     <string name="dashboard_turno_valor">08:00 – 16:00</string>
     <string name="dashboard_ausencia_titulo">Ausencias</string>


### PR DESCRIPTION
## Problema

El dashboard mostraba dos datos completamente estáticos:
- Saludo: `"¡Hola, Empleado!"` — hardcodeado en `strings.xml`, nunca variaba
- Fecha: `"Lunes, 14 de Octubre"` — hardcodeada, nunca se actualizaba

## Solución

### Nombre del empleado — sin llamadas de red adicionales

El nombre ya viene en `RespuestaLoginDTO.nombre` en el momento del login. La estrategia es persistirlo en `TokenManager` (misma caja fuerte cifrada que el JWT) para que esté disponible en arranques posteriores sin petición extra.

**Flujo:**
```
Login exitoso → tokenManager.guardarNombre(respuesta.nombre)
               ↓
App abre → DashboardViewModel.init → tokenManager.obtenerNombre()
               ↓
EstadoUiDashboard.nombreEmpleado → PantallaDashboard → "¡Hola, Ana!"
```

### Fecha dinámica — localizada con java.time

Se usa `LocalDate.now()` + `DateTimeFormatter` con un patrón que se carga desde `strings.xml`, permitiendo que cada idioma tenga su propio formato sin lógica condicional en Kotlin:

| Locale | `dashboard_formato_fecha` | Resultado |
|---|---|---|
| ES | `EEEE, d 'de' MMMM` | Jueves, 17 de abril |
| EN | `EEEE, MMMM d` | Thursday, April 17 |

## Cambios

| Fichero | Cambio |
|---|---|
| `TokenManager.kt` | `guardarNombre` / `obtenerNombre` / `borrarNombre` |
| `LoginViewModel.kt` | Llama `tokenManager.guardarNombre(respuesta.nombre)` tras login |
| `EstadoUiDashboard.kt` | Campo `nombreEmpleado: String = ""` |
| `DashboardViewModel.kt` | Recibe `TokenManager`; lee nombre en `init` |
| `DashboardViewModelFactory` | Inyecta `tokenManager` en el VM |
| `PantallaDashboard.kt` | `CabeceraDashboard(nombreEmpleado)` + fecha dinámica |
| `strings.xml` ES + EN | `dashboard_saludo_nombre`, `dashboard_saludo_generico`, `dashboard_formato_fecha` |

## Fuera de alcance

Las ausencias permanecen con `0 Pendientes` hardcodeado — se resolverán correctamente en **P1-04** cuando se implemente el listado de ausencias.

> **Base branch:** `fix/manejo-errores-viewmodels` — mergear en orden: C1 → C2 → C3 → C4
