### PR TITLE
feat: pantalla perfil, logout y interceptor 401 global

### DIFF
--- a/app/src/main/java/com/gestorrh/android/MainActivity.kt
+++ b/app/src/main/java/com/gestorrh/android/MainActivity.kt
@@ -3,6 +3,14 @@ package com.gestorrh.android
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -10,76 +18,101 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.gestorrh.android.core.network.ApiClient
-import com.gestorrh.android.core.security.TokenManager
+import com.gestorrh.android.core.security.AuthEventBus
+import com.gestorrh.android.core.security.SessionManager
 import com.gestorrh.android.data.network.autenticacion.AuthApi
 import com.gestorrh.android.data.repository.AuthRepository
 import com.gestorrh.android.ui.login.LoginViewModel
 import com.gestorrh.android.ui.login.PantallaLogin
 import com.gestorrh.android.ui.principal.PantallaPrincipal
 import com.gestorrh.android.ui.theme.GestorRHTheme
+import kotlinx.coroutines.launch
 
 /**
  * Actividad principal y punto de entrada (Entry Point) de la aplicación Android.
  * Actúa como el orquestador maestro (Router), encargado de inicializar las dependencias
- * críticas de nivel global (Motor de Red, Caja Fuerte y Repositorios) y de gestionar
+ * críticas de nivel global (Motor de Red, Sesión y Repositorios) y de gestionar
  * la navegación base.
  *
  * Implementa la directriz de "Auto-Login", evaluando la persistencia del Token JWT
  * de manera síncrona en el arranque para decidir la ruta inicial óptima.
+ * Observa [AuthEventBus] para redirigir al Login ante cualquier 401 global.
  */
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val gestorToken = TokenManager(this)
-        val retrofit = ApiClient.crearRetrofit(gestorToken)
+        val sessionManager = SessionManager(this)
+        val retrofit = ApiClient.crearRetrofit(sessionManager)
         val authRepository = AuthRepository(retrofit.create(AuthApi::class.java))
 
         setContent {
             GestorRHTheme {
 
                 val controladorNavegacion = rememberNavController()
+                val snackbarHostState = remember { SnackbarHostState() }
+                val scope = rememberCoroutineScope()
+                val mensajeSesionExpirada = stringResource(R.string.sesion_expirada)
 
-                val destinoInicial = if (gestorToken.obtenerToken() != null) {
+                LaunchedEffect(Unit) {
+                    AuthEventBus.sesionExpirada.collect {
+                        controladorNavegacion.navigate("login") {
+                            popUpTo(0) { inclusive = true }
+                        }
+                        scope.launch {
+                            snackbarHostState.showSnackbar(mensajeSesionExpirada)
+                        }
+                    }
+                }
+
+                val destinoInicial = if (sessionManager.getToken() != null) {
                     "principal"
                 } else {
                     "login"
                 }
 
-                NavHost(
-                    navController = controladorNavegacion,
-                    startDestination = destinoInicial
-                ) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    NavHost(
+                        navController = controladorNavegacion,
+                        startDestination = destinoInicial
+                    ) {
 
-                    composable("login") {
-                        val fabricaViewModel = object : ViewModelProvider.Factory {
-                            @Suppress("UNCHECKED_CAST")
-                            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                                return LoginViewModel(authRepository, gestorToken) as T
-                            }
-                        }
-
-                        val loginViewModel: LoginViewModel = viewModel(factory = fabricaViewModel)
-
-                        PantallaLogin(
-                            viewModel = loginViewModel,
-                            onLoginExitoso = {
-                                controladorNavegacion.navigate("principal") {
-                                    popUpTo("login") { inclusive = true }
+                        composable("login") {
+                            val fabricaViewModel = object : ViewModelProvider.Factory {
+                                @Suppress("UNCHECKED_CAST")
+                                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                                    return LoginViewModel(authRepository, sessionManager) as T
                                 }
                             }
-                        )
+
+                            val loginViewModel: LoginViewModel = viewModel(factory = fabricaViewModel)
+
+                            PantallaLogin(
+                                viewModel = loginViewModel,
+                                onLoginExitoso = {
+                                    controladorNavegacion.navigate("principal") {
+                                        popUpTo("login") { inclusive = true }
+                                    }
+                                }
+                            )
+                        }
+
+                        composable("principal") {
+                            PantallaPrincipal(
+                                alCerrarSesion = {
+                                    sessionManager.clearSession()
+                                    controladorNavegacion.navigate("login") {
+                                        popUpTo(0) { inclusive = true }
+                                    }
+                                }
+                            )
+                        }
                     }
 
-                    composable("principal") {
-                        PantallaPrincipal(
-                            alCerrarSesion = {
-                                // Lógica para cerrar sesión y volver al login (la haremos en la P1-05)
-                                // gestorToken.borrarToken()
-                                // controladorNavegacion.navigate("login") { popUpTo("principal") { inclusive = true } }
-                            }
-                        )
-                    }
+                    SnackbarHost(
+                        hostState = snackbarHostState,
+                        modifier = Modifier.align(Alignment.BottomCenter)
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/gestorrh/android/core/network/ApiClient.kt
+++ b/app/src/main/java/com/gestorrh/android/core/network/ApiClient.kt
@@ -1,9 +1,8 @@
 package com.gestorrh.android.core.network
 
 import com.gestorrh.android.BuildConfig
-import com.gestorrh.android.core.security.TokenManager
+import com.gestorrh.android.core.security.SessionManager
 import com.google.gson.GsonBuilder
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -12,20 +11,18 @@ import java.time.LocalDateTime
 
 /**
  * Motor central de comunicaciones HTTP de la aplicación.
- * Configura y ensambla el cliente de red inyectando automáticamente las políticas
- * de seguridad y el registro de eventos (logs).
+ * Configura y ensambla el cliente de red aplicando el [AuthInterceptor] para
+ * inyección de JWT e intercepción global de 401.
  */
 object ApiClient {
 
     /**
      * Construye una instancia configurada de Retrofit.
-     * Aplica dinámicamente el token JWT de sesión a todas las peticiones salientes
-     * y oculta el tráfico de red en entornos de producción por seguridad.
      *
-     * @param gestorToken Dependencia para acceder a la caja fuerte de credenciales.
+     * @param sessionManager Fuente de verdad de la sesión activa, inyectada en [AuthInterceptor].
      * @return Cliente Retrofit listo para consumir los servicios del backend.
      */
-    fun crearRetrofit(gestorToken: TokenManager): Retrofit {
+    fun crearRetrofit(sessionManager: SessionManager): Retrofit {
 
         val interceptorLogs = HttpLoggingInterceptor().apply {
             level = if (BuildConfig.DEBUG) {
@@ -35,28 +32,8 @@ object ApiClient {
             }
         }
 
-        val interceptorAutenticacion = Interceptor { cadenaCarga ->
-            val peticionOriginal = cadenaCarga.request()
-            val ruta = peticionOriginal.url.encodedPath
-
-            if (ruta.contains("/auth/login-empresa") ||
-                ruta.contains("/auth/login-empleado") ||
-                ruta.contains("/api/empresas/registro")) {
-                return@Interceptor cadenaCarga.proceed(peticionOriginal)
-            }
-
-            val token = gestorToken.obtenerToken()
-            val constructorPeticion = peticionOriginal.newBuilder()
-
-            if (!token.isNullOrEmpty()) {
-                constructorPeticion.addHeader("Authorization", "Bearer $token")
-            }
-
-            cadenaCarga.proceed(constructorPeticion.build())
-        }
-
         val clienteHttp = OkHttpClient.Builder()
-            .addInterceptor(interceptorAutenticacion)
+            .addInterceptor(AuthInterceptor(sessionManager))
             .addInterceptor(interceptorLogs)
             .build()
 

--- a/app/src/main/java/com/gestorrh/android/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/gestorrh/android/core/network/AuthInterceptor.kt
@@ -1,0 +1,47 @@
+package com.gestorrh.android.core.network
+
+import com.gestorrh.android.core.security.AuthEventBus
+import com.gestorrh.android.core.security.SessionManager
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Interceptor de OkHttp con doble responsabilidad:
+ * 1. Inyecta el token JWT de sesión como cabecera Authorization en todas las
+ *    peticiones autenticadas, liberando a cada servicio Retrofit de hacerlo manualmente.
+ * 2. Inspecciona cada respuesta del servidor: si el código es 401 (sesión expirada),
+ *    limpia la sesión y emite un evento global mediante [AuthEventBus] para que
+ *    la UI redirija al Login de forma automática.
+ *
+ * Las rutas `/auth/` quedan excluidas de ambos mecanismos para evitar bucles
+ * infinitos durante el proceso de autenticación inicial.
+ *
+ * @param sessionManager Fuente de verdad del token de sesión activo.
+ */
+class AuthInterceptor(private val sessionManager: SessionManager) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val peticionOriginal = chain.request()
+        val ruta = peticionOriginal.url.encodedPath
+
+        if (ruta.contains("/auth/")) {
+            return chain.proceed(peticionOriginal)
+        }
+
+        val token = sessionManager.getToken()
+        val constructorPeticion = peticionOriginal.newBuilder()
+
+        if (!token.isNullOrEmpty()) {
+            constructorPeticion.addHeader("Authorization", "Bearer $token")
+        }
+
+        val respuesta = chain.proceed(constructorPeticion.build())
+
+        if (respuesta.code == 401) {
+            sessionManager.clearSession()
+            AuthEventBus.emitirSesionExpirada()
+        }
+
+        return respuesta
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/core/security/AuthEventBus.kt
+++ b/app/src/main/java/com/gestorrh/android/core/security/AuthEventBus.kt
@@ -1,0 +1,31 @@
+package com.gestorrh.android.core.security
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Canal de comunicación global para eventos críticos de autenticación.
+ * Permite que el [com.gestorrh.android.core.network.AuthInterceptor] notifique
+ * a la capa de UI sobre una sesión expirada (HTTP 401) sin acoplarse a ningún
+ * componente de presentación.
+ *
+ * Al ser un singleton (object), cualquier colector activo en la app recibirá
+ * el evento independientemente de la pantalla en la que se encuentre el usuario.
+ */
+object AuthEventBus {
+
+    private val _sesionExpirada = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+    /** Flujo al que se suscribe MainActivity para redirigir al login cuando la sesión expira. */
+    val sesionExpirada: SharedFlow<Unit> = _sesionExpirada.asSharedFlow()
+
+    /**
+     * Emite un evento de sesión expirada. Llamado desde el hilo de red de OkHttp,
+     * por lo que se usa [MutableSharedFlow.tryEmit] (no suspendida) con buffer de 1
+     * para garantizar que el evento no se pierda si aún no hay colector activo.
+     */
+    fun emitirSesionExpirada() {
+        _sesionExpirada.tryEmit(Unit)
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/core/security/SessionManager.kt
+++ b/app/src/main/java/com/gestorrh/android/core/security/SessionManager.kt
@@ -1,0 +1,74 @@
+package com.gestorrh.android.core.security
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+/**
+ * Fuente de verdad única para la sesión del empleado autenticado.
+ * Persiste el token JWT y el nombre completo en el Keystore nativo de Android
+ * mediante cifrado AES256-GCM, garantizando que no puedan extraerse en texto plano.
+ *
+ * Sustituye a [TokenManager] como punto central de acceso a credenciales de sesión.
+ * El campo rol se gestionará en la issue P2-01.
+ *
+ * @param contexto Contexto de la aplicación necesario para inicializar el almacenamiento cifrado.
+ */
+class SessionManager(contexto: Context) {
+
+    private val claveMaestra = MasterKey.Builder(contexto)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    private val preferenciasCifradas = EncryptedSharedPreferences.create(
+        contexto,
+        "gestorrh_preferencias_seguras",
+        claveMaestra,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    companion object {
+        private const val CLAVE_TOKEN_JWT = "token_jwt"
+        private const val CLAVE_NOMBRE_EMPLEADO = "nombre_empleado"
+        // TODO(P2-01): añadir persistencia de rol
+    }
+
+    /**
+     * Persiste el token JWT y el nombre del empleado al iniciar sesión.
+     *
+     * @param token Cadena JWT devuelta por el servidor tras autenticación exitosa.
+     * @param nombre Nombre completo del empleado tal como lo devuelve la API.
+     */
+    fun saveSession(token: String, nombre: String) {
+        preferenciasCifradas.edit()
+            .putString(CLAVE_TOKEN_JWT, token)
+            .putString(CLAVE_NOMBRE_EMPLEADO, nombre)
+            .apply()
+    }
+
+    /**
+     * Recupera y descifra el token de sesión activo.
+     *
+     * @return El token en texto plano si hay sesión activa, null en caso contrario.
+     */
+    fun getToken(): String? = preferenciasCifradas.getString(CLAVE_TOKEN_JWT, null)
+
+    /**
+     * Recupera el nombre del empleado de la sesión activa.
+     *
+     * @return El nombre completo si existe sesión, null en caso contrario.
+     */
+    fun getNombre(): String? = preferenciasCifradas.getString(CLAVE_NOMBRE_EMPLEADO, null)
+
+    /**
+     * Purga todos los datos de sesión del almacenamiento seguro.
+     * Invocado durante el logout manual o cuando el servidor devuelve 401.
+     */
+    fun clearSession() {
+        preferenciasCifradas.edit()
+            .remove(CLAVE_TOKEN_JWT)
+            .remove(CLAVE_NOMBRE_EMPLEADO)
+            .apply()
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/data/network/empleado/EmpleadoApi.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/empleado/EmpleadoApi.kt
@@ -1,0 +1,15 @@
+package com.gestorrh.android.data.network.empleado
+
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PUT
+
+interface EmpleadoApi {
+
+    @GET("api/empleados/me")
+    suspend fun getMiPerfil(): Response<RespuestaEmpleadoDTO>
+
+    @PUT("api/empleados/me/contrasena")
+    suspend fun cambiarContrasena(@Body body: PeticionCambiarPasswordDTO): Response<Unit>
+}

--- a/app/src/main/java/com/gestorrh/android/data/network/empleado/EmpleadoModels.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/empleado/EmpleadoModels.kt
@@ -1,0 +1,21 @@
+package com.gestorrh.android.data.network.empleado
+
+import java.time.LocalDateTime
+
+data class RespuestaEmpleadoDTO(
+    val idEmpleado: Long,
+    val nombre: String,
+    val apellidos: String,
+    val email: String,
+    val telefono: String?,
+    val puesto: String?,
+    val departamento: String?,
+    val rol: String,
+    val activo: Boolean,
+    val fechaBajaContrato: LocalDateTime?
+)
+
+data class PeticionCambiarPasswordDTO(
+    val passwordActual: String,
+    val nuevaPassword: String
+)

--- a/app/src/main/java/com/gestorrh/android/data/repository/PerfilRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/PerfilRepository.kt
@@ -1,0 +1,60 @@
+package com.gestorrh.android.data.repository
+
+import com.gestorrh.android.data.network.empleado.EmpleadoApi
+import com.gestorrh.android.data.network.empleado.PeticionCambiarPasswordDTO
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+import com.gestorrh.android.domain.repository.IPerfilRepository
+import okhttp3.ResponseBody
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Implementación de [IPerfilRepository] que delega en [EmpleadoApi].
+ * Convierte las respuestas HTTP en [Result] y extrae el campo "message"
+ * de los cuerpos de error 4xx/5xx, siguiendo el contrato de la API Spring Boot.
+ *
+ * @param empleadoApi Servicio Retrofit para los endpoints de empleado autenticado.
+ */
+class PerfilRepository(private val empleadoApi: EmpleadoApi) : IPerfilRepository {
+
+    override suspend fun obtenerMiPerfil(): Result<RespuestaEmpleadoDTO> {
+        return try {
+            val respuesta = empleadoApi.getMiPerfil()
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                Result.failure(Exception(extraerMensajeError(respuesta.errorBody())))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun cambiarContrasena(passwordActual: String, nuevaPassword: String): Result<Unit> {
+        return try {
+            val respuesta = empleadoApi.cambiarContrasena(
+                PeticionCambiarPasswordDTO(passwordActual, nuevaPassword)
+            )
+            if (respuesta.isSuccessful) {
+                Result.success(Unit)
+            } else {
+                Result.failure(Exception(extraerMensajeError(respuesta.errorBody())))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    private fun extraerMensajeError(errorBody: ResponseBody?): String {
+        return try {
+            val json = errorBody?.string() ?: return MENSAJE_ERROR_DESCONOCIDO
+            JSONObject(json).getString("message")
+        } catch (e: JSONException) {
+            MENSAJE_ERROR_DESCONOCIDO
+        }
+    }
+
+    companion object {
+        private const val MENSAJE_ERROR_DESCONOCIDO = "Error desconocido del servidor"
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/domain/repository/IPerfilRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/IPerfilRepository.kt
@@ -1,0 +1,11 @@
+package com.gestorrh.android.domain.repository
+
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+
+/**
+ * Contrato de dominio para las operaciones de perfil del empleado autenticado.
+ */
+interface IPerfilRepository {
+    suspend fun obtenerMiPerfil(): Result<RespuestaEmpleadoDTO>
+    suspend fun cambiarContrasena(passwordActual: String, nuevaPassword: String): Result<Unit>
+}

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.gestorrh.android.R
 import com.gestorrh.android.core.network.ApiClient
-import com.gestorrh.android.core.security.TokenManager
+import com.gestorrh.android.core.security.SessionManager
 import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.network.fichaje.FichajeApiService
 import com.gestorrh.android.data.network.fichaje.ModalidadTurno
@@ -33,7 +33,7 @@ data class EstadoUiDashboard(
     val idFichajeAbierto: Long? = null,
     val modalidadHoy: ModalidadTurno? = null,
     val tieneTurnoHoy: Boolean = false,
-    /** Nombre completo del empleado autenticado, leído desde [TokenManager] sin llamadas de red. */
+    /** Nombre completo del empleado autenticado, leído desde [SessionManager] sin llamadas de red. */
     val nombreEmpleado: String = ""
 )
 
@@ -43,7 +43,7 @@ enum class EstadoFichaje {
 
 class DashboardViewModel(
     private val fichajeRepository: IFichajeRepository,
-    private val tokenManager: TokenManager
+    private val sessionManager: SessionManager
 ) : ViewModel() {
 
     private val _estadoUi = MutableStateFlow(EstadoUiDashboard())
@@ -54,7 +54,7 @@ class DashboardViewModel(
 
     init {
         // Carga el nombre desde el almacenamiento seguro sin llamada de red
-        val nombre = tokenManager.obtenerNombre() ?: ""
+        val nombre = sessionManager.getNombre() ?: ""
         _estadoUi.update { it.copy(nombreEmpleado = nombre) }
 
         sincronizarEstado()
@@ -211,13 +211,13 @@ class DashboardViewModel(
 class DashboardViewModelFactory(private val contexto: Context) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(DashboardViewModel::class.java)) {
-            val tokenManager = TokenManager(contexto)
-            val retrofit = ApiClient.crearRetrofit(tokenManager)
+            val sessionManager = SessionManager(contexto)
+            val retrofit = ApiClient.crearRetrofit(sessionManager)
             val apiService = retrofit.create(FichajeApiService::class.java)
             val fichajeRepository = FichajeRepository(apiService)
 
             @Suppress("UNCHECKED_CAST")
-            return DashboardViewModel(fichajeRepository, tokenManager) as T
+            return DashboardViewModel(fichajeRepository, sessionManager) as T
         }
         throw IllegalArgumentException("Clase ViewModel desconocida")
     }

--- a/app/src/main/java/com/gestorrh/android/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/login/LoginViewModel.kt
@@ -3,7 +3,7 @@ package com.gestorrh.android.ui.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gestorrh.android.R
-import com.gestorrh.android.core.security.TokenManager
+import com.gestorrh.android.core.security.SessionManager
 import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.domain.repository.IAuthRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,11 +20,11 @@ import kotlinx.coroutines.launch
  * segura y unidireccional.
  *
  * @property authRepository Dependencia del contrato de dominio para autenticación.
- * @property tokenManager Dependencia para interactuar con la caja fuerte del dispositivo (Keystore).
+ * @property sessionManager Fuente de verdad de la sesión activa.
  */
 class LoginViewModel(
     private val authRepository: IAuthRepository,
-    private val tokenManager: TokenManager
+    private val sessionManager: SessionManager
 ) : ViewModel() {
 
     private val _estadoUi = MutableStateFlow(EstadoUiLogin())
@@ -73,8 +73,7 @@ class LoginViewModel(
         viewModelScope.launch {
             authRepository.login(estadoActual.email, estadoActual.password)
                 .onSuccess { respuesta ->
-                    tokenManager.guardarToken(respuesta.token)
-                    tokenManager.guardarNombre(respuesta.nombre)
+                    sessionManager.saveSession(respuesta.token, respuesta.nombre)
                     _estadoUi.update { it.copy(estaCargando = false, loginExitoso = true) }
                 }
                 .onFailure {

--- a/app/src/main/java/com/gestorrh/android/ui/perfil/EstadoUiPerfil.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/perfil/EstadoUiPerfil.kt
@@ -1,0 +1,17 @@
+package com.gestorrh.android.ui.perfil
+
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+
+data class EstadoUiPerfil(
+    val estaCargando: Boolean = true,
+    val perfil: RespuestaEmpleadoDTO? = null,
+    val mensajeError: MensajeUi? = null,
+    val mostrarDialogLogout: Boolean = false,
+    val mostrarDialogCambioPassword: Boolean = false,
+    val passwordActual: String = "",
+    val nuevaPassword: String = "",
+    val errorDialogPassword: String? = null,
+    val estaCambiandoPassword: Boolean = false,
+    val mensajeExito: MensajeUi? = null
+)

--- a/app/src/main/java/com/gestorrh/android/ui/perfil/PantallaPerfil.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/perfil/PantallaPerfil.kt
@@ -1,0 +1,300 @@
+package com.gestorrh.android.ui.perfil
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.gestorrh.android.R
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PantallaPerfil(
+    alCerrarSesion: () -> Unit,
+    viewModel: PerfilViewModel = viewModel(factory = PerfilViewModel.crearFactory(LocalContext.current))
+) {
+    val estado by viewModel.estadoUi.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
+    val mensajeExito = estado.mensajeExito
+    LaunchedEffect(mensajeExito) {
+        if (mensajeExito != null) {
+            val texto = when (mensajeExito) {
+                is MensajeUi.Recurso -> context.getString(mensajeExito.idRecurso)
+                is MensajeUi.Dinamico -> mensajeExito.texto
+            }
+            scope.launch { snackbarHostState.showSnackbar(texto) }
+            viewModel.exitoMostrado()
+        }
+    }
+
+    if (estado.mostrarDialogLogout) {
+        AlertDialog(
+            onDismissRequest = { viewModel.ocultarDialogLogout() },
+            title = { Text(stringResource(R.string.perfil_dialog_logout_titulo)) },
+            text = { Text(stringResource(R.string.perfil_dialog_logout_texto)) },
+            confirmButton = {
+                TextButton(onClick = { viewModel.cerrarSesion(alCerrarSesion) }) {
+                    Text(stringResource(R.string.perfil_dialog_confirmar))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.ocultarDialogLogout() }) {
+                    Text(stringResource(R.string.perfil_dialog_cancelar))
+                }
+            }
+        )
+    }
+
+    if (estado.mostrarDialogCambioPassword) {
+        val mensajeErrorMinimo = stringResource(R.string.perfil_error_password_minimo)
+        var mostrarPasswordActual by remember { mutableStateOf(false) }
+        var mostrarNuevaPassword by remember { mutableStateOf(false) }
+
+        AlertDialog(
+            onDismissRequest = { viewModel.ocultarDialogCambioPassword() },
+            title = { Text(stringResource(R.string.perfil_dialog_cambiar_password_titulo)) },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = estado.passwordActual,
+                        onValueChange = { viewModel.actualizarPasswordActual(it) },
+                        label = { Text(stringResource(R.string.perfil_password_actual_hint)) },
+                        visualTransformation = if (mostrarPasswordActual) VisualTransformation.None else PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                        trailingIcon = {
+                            IconButton(onClick = { mostrarPasswordActual = !mostrarPasswordActual }) {
+                                Icon(
+                                    imageVector = if (mostrarPasswordActual) Icons.Filled.Visibility else Icons.Filled.VisibilityOff,
+                                    contentDescription = null
+                                )
+                            }
+                        },
+                        singleLine = true
+                    )
+                    OutlinedTextField(
+                        value = estado.nuevaPassword,
+                        onValueChange = { viewModel.actualizarNuevaPassword(it) },
+                        label = { Text(stringResource(R.string.perfil_nueva_password_hint)) },
+                        visualTransformation = if (mostrarNuevaPassword) VisualTransformation.None else PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                        trailingIcon = {
+                            IconButton(onClick = { mostrarNuevaPassword = !mostrarNuevaPassword }) {
+                                Icon(
+                                    imageVector = if (mostrarNuevaPassword) Icons.Filled.Visibility else Icons.Filled.VisibilityOff,
+                                    contentDescription = null
+                                )
+                            }
+                        },
+                        isError = estado.errorDialogPassword != null,
+                        singleLine = true
+                    )
+                    val errorPassword = estado.errorDialogPassword
+                    if (errorPassword != null) {
+                        Text(
+                            text = errorPassword,
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = { viewModel.cambiarPassword(mensajeErrorMinimo) },
+                    enabled = !estado.estaCambiandoPassword
+                ) {
+                    if (estado.estaCambiandoPassword) {
+                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                    } else {
+                        Text(stringResource(R.string.perfil_dialog_confirmar))
+                    }
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { viewModel.ocultarDialogCambioPassword() }) {
+                    Text(stringResource(R.string.perfil_dialog_cancelar))
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(stringResource(R.string.perfil_titulo)) })
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingInterior ->
+
+        when {
+            estado.estaCargando -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingInterior),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            estado.mensajeError != null -> {
+                val textoError = when (val error = estado.mensajeError) {
+                    is MensajeUi.Recurso -> stringResource(error.idRecurso)
+                    is MensajeUi.Dinamico -> error.texto
+                    else -> ""
+                }
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingInterior),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text(text = textoError, style = MaterialTheme.typography.bodyLarge)
+                        Button(onClick = { viewModel.cargarPerfil() }) {
+                            Text(stringResource(R.string.perfil_reintentar))
+                        }
+                    }
+                }
+            }
+
+            estado.perfil != null -> {
+                val perfilActual = estado.perfil!!
+                ContenidoPerfil(
+                    perfil = perfilActual,
+                    modifier = Modifier.padding(paddingInterior),
+                    alCambiarPassword = { viewModel.mostrarDialogCambioPassword() },
+                    alCerrarSesion = { viewModel.mostrarDialogLogout() }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContenidoPerfil(
+    perfil: RespuestaEmpleadoDTO,
+    modifier: Modifier = Modifier,
+    alCambiarPassword: () -> Unit,
+    alCerrarSesion: () -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp, vertical = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        val inicial = perfil.nombre.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
+
+        Box(
+            modifier = Modifier
+                .size(88.dp)
+                .background(
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    shape = CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = inicial,
+                fontSize = 36.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "${perfil.nombre} ${perfil.apellidos}",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold
+        )
+
+        Text(
+            text = perfil.rol,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        HorizontalDivider()
+
+        FilaInfoPerfil(
+            etiqueta = stringResource(R.string.perfil_email),
+            valor = perfil.email
+        )
+        FilaInfoPerfil(
+            etiqueta = stringResource(R.string.perfil_telefono),
+            valor = perfil.telefono ?: stringResource(R.string.perfil_sin_dato)
+        )
+        FilaInfoPerfil(
+            etiqueta = stringResource(R.string.perfil_puesto),
+            valor = perfil.puesto ?: stringResource(R.string.perfil_sin_dato)
+        )
+        FilaInfoPerfil(
+            etiqueta = stringResource(R.string.perfil_departamento),
+            valor = perfil.departamento ?: stringResource(R.string.perfil_sin_dato)
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedButton(
+            onClick = alCambiarPassword,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(stringResource(R.string.perfil_btn_cambiar_password))
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Button(
+            onClick = alCerrarSesion,
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.error,
+                contentColor = MaterialTheme.colorScheme.onError
+            )
+        ) {
+            Text(stringResource(R.string.perfil_btn_cerrar_sesion))
+        }
+    }
+}
+
+@Composable
+private fun FilaInfoPerfil(etiqueta: String, valor: String) {
+    ListItem(
+        headlineContent = { Text(valor) },
+        overlineContent = { Text(etiqueta) }
+    )
+    HorizontalDivider()
+}

--- a/app/src/main/java/com/gestorrh/android/ui/perfil/PerfilViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/perfil/PerfilViewModel.kt
@@ -1,0 +1,140 @@
+package com.gestorrh.android.ui.perfil
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.gestorrh.android.R
+import com.gestorrh.android.core.network.ApiClient
+import com.gestorrh.android.core.security.SessionManager
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.empleado.EmpleadoApi
+import com.gestorrh.android.data.repository.PerfilRepository
+import com.gestorrh.android.domain.repository.IPerfilRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Manejador de estado y lógica de presentación para la pantalla de Perfil.
+ * Orquesta la carga del perfil del empleado autenticado, el flujo de logout
+ * y el cambio de contraseña, delegando en [IPerfilRepository] para todas las
+ * operaciones de red.
+ *
+ * @property perfilRepository Contrato de dominio para operaciones de perfil.
+ * @property sessionManager Fuente de verdad de la sesión activa.
+ */
+class PerfilViewModel(
+    private val perfilRepository: IPerfilRepository,
+    private val sessionManager: SessionManager
+) : ViewModel() {
+
+    private val _estadoUi = MutableStateFlow(EstadoUiPerfil())
+    val estadoUi: StateFlow<EstadoUiPerfil> = _estadoUi.asStateFlow()
+
+    init {
+        cargarPerfil()
+    }
+
+    fun cargarPerfil() {
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(estaCargando = true, mensajeError = null) }
+            perfilRepository.obtenerMiPerfil()
+                .onSuccess { perfil ->
+                    _estadoUi.update { it.copy(estaCargando = false, perfil = perfil) }
+                }
+                .onFailure { e ->
+                    val mensaje = if (e.message != null) MensajeUi.Dinamico(e.message!!)
+                    else MensajeUi.Recurso(R.string.error_conexion)
+                    _estadoUi.update { it.copy(estaCargando = false, mensajeError = mensaje) }
+                }
+        }
+    }
+
+    fun mostrarDialogLogout() {
+        _estadoUi.update { it.copy(mostrarDialogLogout = true) }
+    }
+
+    fun ocultarDialogLogout() {
+        _estadoUi.update { it.copy(mostrarDialogLogout = false) }
+    }
+
+    fun cerrarSesion(alCerrarSesion: () -> Unit) {
+        sessionManager.clearSession()
+        alCerrarSesion()
+    }
+
+    fun mostrarDialogCambioPassword() {
+        _estadoUi.update {
+            it.copy(
+                mostrarDialogCambioPassword = true,
+                passwordActual = "",
+                nuevaPassword = "",
+                errorDialogPassword = null
+            )
+        }
+    }
+
+    fun ocultarDialogCambioPassword() {
+        _estadoUi.update { it.copy(mostrarDialogCambioPassword = false) }
+    }
+
+    fun actualizarPasswordActual(valor: String) {
+        _estadoUi.update { it.copy(passwordActual = valor, errorDialogPassword = null) }
+    }
+
+    fun actualizarNuevaPassword(valor: String) {
+        _estadoUi.update { it.copy(nuevaPassword = valor, errorDialogPassword = null) }
+    }
+
+    fun cambiarPassword(mensajeErrorMinimo: String) {
+        val estado = _estadoUi.value
+        if (estado.nuevaPassword.length < 8) {
+            _estadoUi.update { it.copy(errorDialogPassword = mensajeErrorMinimo) }
+            return
+        }
+
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(estaCambiandoPassword = true, errorDialogPassword = null) }
+            perfilRepository.cambiarContrasena(estado.passwordActual, estado.nuevaPassword)
+                .onSuccess {
+                    _estadoUi.update {
+                        it.copy(
+                            estaCambiandoPassword = false,
+                            mostrarDialogCambioPassword = false,
+                            mensajeExito = MensajeUi.Recurso(R.string.perfil_password_cambiada_exito)
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    _estadoUi.update {
+                        it.copy(
+                            estaCambiandoPassword = false,
+                            errorDialogPassword = e.message
+                        )
+                    }
+                }
+        }
+    }
+
+    fun exitoMostrado() {
+        _estadoUi.update { it.copy(mensajeExito = null) }
+    }
+
+    companion object {
+        fun crearFactory(contexto: Context): ViewModelProvider.Factory {
+            return object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val sessionManager = SessionManager(contexto)
+                    val retrofit = ApiClient.crearRetrofit(sessionManager)
+                    val empleadoApi = retrofit.create(EmpleadoApi::class.java)
+                    val perfilRepository = PerfilRepository(empleadoApi)
+                    return PerfilViewModel(perfilRepository, sessionManager) as T
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.rememberNavController
 import com.gestorrh.android.core.navigation.BarraNavegacionInferior
 import com.gestorrh.android.core.navigation.RutasDestino
 import com.gestorrh.android.ui.dashboard.PantallaDashboard
+import com.gestorrh.android.ui.perfil.PantallaPerfil
 
 /**
  * Contenedor maestro de la experiencia "Post-Login".
@@ -60,9 +61,8 @@ fun PantallaPrincipal(
             }
 
             composable(RutasDestino.Perfil.ruta) {
-                // TODO: P1-05 -> Perfil de Usuario
+                PantallaPerfil(alCerrarSesion = alCerrarSesion)
             }
         }
     }
 }
-

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -45,4 +45,24 @@
     <string name="error_desconocido">Unknown server error</string>
     <string name="cd_perfil">Profile</string>
     <string name="cd_teletrabajo">Remote Work Icon</string>
+
+    <string name="perfil_titulo">My Profile</string>
+    <string name="perfil_email">Email address</string>
+    <string name="perfil_telefono">Phone</string>
+    <string name="perfil_puesto">Job title</string>
+    <string name="perfil_departamento">Department</string>
+    <string name="perfil_btn_cerrar_sesion">Sign out</string>
+    <string name="perfil_btn_cambiar_password">Change password</string>
+    <string name="perfil_dialog_logout_titulo">Sign out</string>
+    <string name="perfil_dialog_logout_texto">Are you sure you want to sign out?</string>
+    <string name="perfil_dialog_confirmar">Confirm</string>
+    <string name="perfil_dialog_cancelar">Cancel</string>
+    <string name="perfil_dialog_cambiar_password_titulo">Change password</string>
+    <string name="perfil_password_actual_hint">Current password</string>
+    <string name="perfil_nueva_password_hint">New password</string>
+    <string name="perfil_error_password_minimo">New password must be at least 8 characters</string>
+    <string name="perfil_password_cambiada_exito">Password updated successfully</string>
+    <string name="perfil_sin_dato">—</string>
+    <string name="perfil_reintentar">Retry</string>
+    <string name="sesion_expirada">Your session has expired. Please sign in again</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,4 +45,24 @@
     <string name="error_desconocido">Error desconocido del servidor</string>
     <string name="cd_perfil">Perfil</string>
     <string name="cd_teletrabajo">Icono Teletrabajo</string>
+
+    <string name="perfil_titulo">Mi Perfil</string>
+    <string name="perfil_email">Correo electrónico</string>
+    <string name="perfil_telefono">Teléfono</string>
+    <string name="perfil_puesto">Puesto</string>
+    <string name="perfil_departamento">Departamento</string>
+    <string name="perfil_btn_cerrar_sesion">Cerrar sesión</string>
+    <string name="perfil_btn_cambiar_password">Cambiar contraseña</string>
+    <string name="perfil_dialog_logout_titulo">Cerrar sesión</string>
+    <string name="perfil_dialog_logout_texto">¿Estás seguro de que deseas cerrar sesión?</string>
+    <string name="perfil_dialog_confirmar">Confirmar</string>
+    <string name="perfil_dialog_cancelar">Cancelar</string>
+    <string name="perfil_dialog_cambiar_password_titulo">Cambiar contraseña</string>
+    <string name="perfil_password_actual_hint">Contraseña actual</string>
+    <string name="perfil_nueva_password_hint">Nueva contraseña</string>
+    <string name="perfil_error_password_minimo">La nueva contraseña debe tener mínimo 8 caracteres</string>
+    <string name="perfil_password_cambiada_exito">Contraseña actualizada correctamente</string>
+    <string name="perfil_sin_dato">—</string>
+    <string name="perfil_reintentar">Reintentar</string>
+    <string name="sesion_expirada">Tu sesión ha expirado. Por favor, inicia sesión de nuevo</string>
 </resources>


### PR DESCRIPTION
## Resumen

- **SessionManager** reemplaza a `TokenManager` como fuente de verdad de la sesión (token + nombre en `EncryptedSharedPreferences`)
- **AuthInterceptor** inyecta el JWT en cada petición y captura respuestas 401, limpiando la sesión y emitiendo un evento global; excluye las rutas `/auth/`
- **AuthEventBus** (singleton con `SharedFlow`) desacopla el interceptor de red de la UI; `MainActivity` lo observa y redirige al Login destruyendo el back-stack
- Pantalla **Perfil** completa con avatar, datos personales, dialog de logout con confirmación, dialog de cambio de contraseña con validación local (≥8 chars) y feedback inline de errores del servidor
- Migración de `DashboardViewModel` y `LoginViewModel` a `SessionManager`
- 22 strings nuevos en ES y EN

## Plan de pruebas

- [ ] Login → Perfil muestra nombre completo, email, puesto, departamento y rol
- [ ] "Cerrar sesión" → AlertDialog → Confirmar → navega al Login (back-stack limpio)
- [ ] "Cambiar contraseña" con nueva password < 8 chars → error en el dialog, no se cierra
- [ ] "Cambiar contraseña" con datos correctos → 204 → dialog cerrado + Snackbar de éxito
- [ ] "Cambiar contraseña" con contraseña actual incorrecta → 400 → error del servidor en el dialog
- [ ] Simular 401 desde cualquier pantalla → app navega al Login + Snackbar "Tu sesión ha expirado..."
- [ ] El endpoint de login no activa el 401 global (excluido en `AuthInterceptor`)

Closes #15