### PR TITLE
[P1-01] UI de Mis Turnos — vista lista y calendario

### DIFF
--- a/app/src/main/java/com/gestorrh/android/core/network/ApiClient.kt
+++ b/app/src/main/java/com/gestorrh/android/core/network/ApiClient.kt
@@ -7,6 +7,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 /**
@@ -39,6 +40,7 @@ object ApiClient {
 
         val gson = GsonBuilder()
             .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeDeserializer())
+            .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
             .create()
 
         return Retrofit.Builder()

--- a/app/src/main/java/com/gestorrh/android/core/network/LocalDateDeserializer.kt
+++ b/app/src/main/java/com/gestorrh/android/core/network/LocalDateDeserializer.kt
@@ -1,0 +1,18 @@
+package com.gestorrh.android.core.network
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import java.lang.reflect.Type
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+/**
+ * Enseña a Retrofit (Gson) cómo transformar el String "yyyy-MM-dd" de Spring Boot
+ * en un objeto LocalDate de Kotlin.
+ */
+class LocalDateDeserializer : JsonDeserializer<LocalDate> {
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): LocalDate {
+        return LocalDate.parse(json.asString, DateTimeFormatter.ISO_LOCAL_DATE)
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/data/network/asignacion/AsignacionApiService.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/asignacion/AsignacionApiService.kt
@@ -1,0 +1,10 @@
+package com.gestorrh.android.data.network.asignacion
+
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface AsignacionApiService {
+
+    @GET("api/asignaciones/me")
+    suspend fun getMisAsignaciones(): Response<List<RespuestaAsignacionTurnoDTO>>
+}

--- a/app/src/main/java/com/gestorrh/android/data/network/asignacion/AsignacionResponse.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/asignacion/AsignacionResponse.kt
@@ -1,0 +1,22 @@
+package com.gestorrh.android.data.network.asignacion
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class RespuestaAsignacionTurnoDTO(
+    val idAsignacion: Long,
+    val idEmpleado: Long,
+    val nombreCompletoEmpleado: String,
+    val idTurno: Long,
+    val descripcionTurno: String,
+    val fecha: LocalDate,
+    val modalidad: ModalidadAsignacion,
+    val motivoCambio: String?,
+    val fechaCambio: LocalDateTime?,
+    val responsableCambio: String?
+)
+
+enum class ModalidadAsignacion {
+    PRESENCIAL,
+    TELETRABAJO
+}

--- a/app/src/main/java/com/gestorrh/android/data/repository/asignacion/AsignacionRepositoryImpl.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/asignacion/AsignacionRepositoryImpl.kt
@@ -1,0 +1,44 @@
+package com.gestorrh.android.data.repository.asignacion
+
+import com.gestorrh.android.data.network.asignacion.AsignacionApiService
+import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
+import com.gestorrh.android.domain.repository.IAsignacionRepository
+import okhttp3.ResponseBody
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Implementación de [IAsignacionRepository] que delega en el servicio Retrofit [AsignacionApiService].
+ * Centraliza la extracción de mensajes de error del cuerpo JSON de la respuesta,
+ * evitando que esta lógica de protocolo de red se filtre a la capa de presentación.
+ *
+ * @param apiService Servicio Retrofit para los endpoints de asignaciones.
+ */
+class AsignacionRepositoryImpl(
+    private val apiService: AsignacionApiService
+) : IAsignacionRepository {
+
+    override suspend fun getMisAsignaciones(): Result<List<RespuestaAsignacionTurnoDTO>> {
+        return try {
+            val respuesta = apiService.getMisAsignaciones()
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                val mensaje = extraerMensajeError(respuesta.errorBody())
+                    ?: "Error ${respuesta.code()} al obtener las asignaciones"
+                Result.failure(Exception(mensaje))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    private fun extraerMensajeError(errorBody: ResponseBody?): String? {
+        return try {
+            val json = errorBody?.string() ?: return null
+            JSONObject(json).getString("message")
+        } catch (e: JSONException) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/domain/repository/IAsignacionRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/IAsignacionRepository.kt
@@ -1,0 +1,19 @@
+package com.gestorrh.android.domain.repository
+
+import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
+
+/**
+ * Contrato de la capa de dominio para las operaciones de asignación de turnos.
+ * Los ViewModels dependen de esta interfaz, nunca del servicio Retrofit directamente.
+ * La implementación concreta vive en la capa de datos ([com.gestorrh.android.data.repository.asignacion]).
+ */
+interface IAsignacionRepository {
+
+    /**
+     * Obtiene la lista de asignaciones de turno del empleado autenticado.
+     *
+     * @return [Result.success] con la lista de [RespuestaAsignacionTurnoDTO], o [Result.failure]
+     *         con el mensaje de error del servidor o de red.
+     */
+    suspend fun getMisAsignaciones(): Result<List<RespuestaAsignacionTurnoDTO>>
+}

--- a/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
@@ -11,6 +11,7 @@ import com.gestorrh.android.core.navigation.BarraNavegacionInferior
 import com.gestorrh.android.core.navigation.RutasDestino
 import com.gestorrh.android.ui.dashboard.PantallaDashboard
 import com.gestorrh.android.ui.perfil.PantallaPerfil
+import com.gestorrh.android.ui.turnos.PantallaMisTurnos
 
 /**
  * Contenedor maestro de la experiencia "Post-Login".
@@ -53,7 +54,7 @@ fun PantallaPrincipal(
             }
 
             composable(RutasDestino.Turnos.ruta) {
-                // TODO: P1-01 -> UI de Mis Turnos
+                PantallaMisTurnos()
             }
 
             composable(RutasDestino.Ausencias.ruta) {

--- a/app/src/main/java/com/gestorrh/android/ui/turnos/EstadoUiMisTurnos.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/turnos/EstadoUiMisTurnos.kt
@@ -1,0 +1,26 @@
+package com.gestorrh.android.ui.turnos
+
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
+
+/**
+ * Representa el estado inmutable de la UI para la pantalla de Mis Turnos.
+ * En Jetpack Compose, cualquier cambio visual se produce al emitir una nueva copia de esta clase,
+ * garantizando un flujo de datos unidireccional (UDF) libre de condiciones de carrera.
+ *
+ * @property cargando Indica si hay una petición de red en curso.
+ * @property asignaciones Lista de asignaciones de turno del empleado autenticado.
+ * @property mensajeError Mensaje de error a mostrar en el Snackbar. Null si no hay error.
+ * @property vistaActual Controla qué modo de visualización está activo (lista o calendario).
+ */
+data class EstadoUiMisTurnos(
+    val cargando: Boolean = true,
+    val asignaciones: List<RespuestaAsignacionTurnoDTO> = emptyList(),
+    val mensajeError: MensajeUi? = null,
+    val vistaActual: VistaActual = VistaActual.LISTA
+)
+
+enum class VistaActual {
+    LISTA,
+    CALENDARIO
+}

--- a/app/src/main/java/com/gestorrh/android/ui/turnos/MisTurnosViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/turnos/MisTurnosViewModel.kt
@@ -1,0 +1,81 @@
+package com.gestorrh.android.ui.turnos
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.gestorrh.android.core.network.ApiClient
+import com.gestorrh.android.core.security.SessionManager
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.asignacion.AsignacionApiService
+import com.gestorrh.android.data.repository.asignacion.AsignacionRepositoryImpl
+import com.gestorrh.android.domain.repository.IAsignacionRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * ViewModel para la pantalla de Mis Turnos.
+ * Expone un único [StateFlow] de [EstadoUiMisTurnos] y orquesta la carga de asignaciones
+ * desde el repositorio ejecutándola en [Dispatchers.IO].
+ *
+ * @param asignacionRepository Repositorio que provee las asignaciones del empleado autenticado.
+ */
+class MisTurnosViewModel(
+    private val asignacionRepository: IAsignacionRepository
+) : ViewModel() {
+
+    private val _estadoUi = MutableStateFlow(EstadoUiMisTurnos())
+    val estadoUi: StateFlow<EstadoUiMisTurnos> = _estadoUi.asStateFlow()
+
+    init {
+        cargarAsignaciones()
+    }
+
+    fun cargarAsignaciones() {
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(cargando = true, mensajeError = null) }
+
+            val resultado = withContext(Dispatchers.IO) {
+                asignacionRepository.getMisAsignaciones()
+            }
+
+            resultado
+                .onSuccess { asignaciones ->
+                    val ordenadas = asignaciones.sortedBy { it.fecha }
+                    _estadoUi.update { it.copy(cargando = false, asignaciones = ordenadas) }
+                }
+                .onFailure { error ->
+                    val mensaje = if (error.message != null) MensajeUi.Dinamico(error.message!!)
+                    else MensajeUi.Recurso(com.gestorrh.android.R.string.error_conexion)
+                    _estadoUi.update { it.copy(cargando = false, mensajeError = mensaje) }
+                }
+        }
+    }
+
+    fun cambiarVista(vista: VistaActual) {
+        _estadoUi.update { it.copy(vistaActual = vista) }
+    }
+
+    fun errorMostrado() {
+        _estadoUi.update { it.copy(mensajeError = null) }
+    }
+
+    companion object {
+        fun factory(contexto: Context): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val sessionManager = SessionManager(contexto)
+                    val retrofit = ApiClient.crearRetrofit(sessionManager)
+                    val apiService = retrofit.create(AsignacionApiService::class.java)
+                    val repository = AsignacionRepositoryImpl(apiService)
+                    return MisTurnosViewModel(repository) as T
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/turnos/PantallaMisTurnos.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/turnos/PantallaMisTurnos.kt
@@ -1,0 +1,526 @@
+package com.gestorrh.android.ui.turnos
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.gestorrh.android.R
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.asignacion.ModalidadAsignacion
+import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.util.Locale
+
+private val ColorPresencial = Color(0xFF1A365D)
+private val ColorTeletrabajo = Color(0xFF00A8E8)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PantallaMisTurnos(
+    contexto: android.content.Context = LocalContext.current,
+    viewModel: MisTurnosViewModel = viewModel(
+        factory = MisTurnosViewModel.factory(contexto.applicationContext)
+    )
+) {
+    val estadoUi by viewModel.estadoUi.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val contextoLocal = LocalContext.current
+
+    val textoReintentar = stringResource(id = R.string.turnos_reintentar)
+
+    LaunchedEffect(estadoUi.mensajeError) {
+        estadoUi.mensajeError?.let { mensajeUi ->
+            val textoMensaje = when (mensajeUi) {
+                is MensajeUi.Recurso -> contextoLocal.getString(mensajeUi.idRecurso)
+                is MensajeUi.Dinamico -> mensajeUi.texto
+            }
+            val resultado = snackbarHostState.showSnackbar(
+                message = textoMensaje,
+                actionLabel = textoReintentar,
+                duration = SnackbarDuration.Long
+            )
+            if (resultado == SnackbarResult.ActionPerformed) {
+                viewModel.cargarAsignaciones()
+            }
+            viewModel.errorMostrado()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(id = R.string.turnos_titulo),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                },
+                actions = {
+                    IconButton(onClick = { viewModel.cambiarVista(VistaActual.LISTA) }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.List,
+                            contentDescription = stringResource(id = R.string.turnos_cd_vista_lista),
+                            tint = if (estadoUi.vistaActual == VistaActual.LISTA)
+                                MaterialTheme.colorScheme.primary
+                            else
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    IconButton(onClick = { viewModel.cambiarVista(VistaActual.CALENDARIO) }) {
+                        Icon(
+                            imageVector = Icons.Filled.CalendarMonth,
+                            contentDescription = stringResource(id = R.string.turnos_cd_vista_calendario),
+                            tint = if (estadoUi.vistaActual == VistaActual.CALENDARIO)
+                                MaterialTheme.colorScheme.primary
+                            else
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+    ) { paddingValores ->
+
+        when {
+            estadoUi.cargando -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValores),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            estadoUi.asignaciones.isEmpty() && !estadoUi.cargando -> {
+                EstadoVacio(modifier = Modifier.padding(paddingValores))
+            }
+
+            estadoUi.vistaActual == VistaActual.LISTA -> {
+                VistaListaTurnos(
+                    asignaciones = estadoUi.asignaciones,
+                    modifier = Modifier.padding(paddingValores)
+                )
+            }
+
+            else -> {
+                VistaCalendario(
+                    asignaciones = estadoUi.asignaciones,
+                    modifier = Modifier.padding(paddingValores)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun VistaListaTurnos(
+    asignaciones: List<RespuestaAsignacionTurnoDTO>,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        items(asignaciones, key = { it.idAsignacion }) { asignacion ->
+            TarjetaAsignacion(asignacion = asignacion)
+        }
+    }
+}
+
+@Composable
+private fun TarjetaAsignacion(asignacion: RespuestaAsignacionTurnoDTO) {
+    val patronFecha = stringResource(id = R.string.turnos_formato_fecha_tarjeta)
+    val fechaFormateada = remember(asignacion.fecha, patronFecha) {
+        val locale = Locale.getDefault()
+        asignacion.fecha.format(DateTimeFormatter.ofPattern(patronFecha, locale))
+            .replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = fechaFormateada,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = asignacion.descripcionTurno,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            ChipModalidad(modalidad = asignacion.modalidad)
+        }
+    }
+}
+
+@Composable
+private fun ChipModalidad(modalidad: ModalidadAsignacion) {
+    val (colorFondo, textoRes) = when (modalidad) {
+        ModalidadAsignacion.PRESENCIAL -> ColorPresencial to R.string.turnos_modalidad_presencial
+        ModalidadAsignacion.TELETRABAJO -> ColorTeletrabajo to R.string.turnos_modalidad_teletrabajo
+    }
+
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = colorFondo
+    ) {
+        Text(
+            text = stringResource(id = textoRes),
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun VistaCalendario(
+    asignaciones: List<RespuestaAsignacionTurnoDTO>,
+    modifier: Modifier = Modifier
+) {
+    var mesActual by remember { mutableStateOf(YearMonth.now()) }
+    var asignacionSeleccionada by remember { mutableStateOf<RespuestaAsignacionTurnoDTO?>(null) }
+    val sheetState = rememberModalBottomSheetState()
+
+    val diasConTurno = remember(asignaciones, mesActual) {
+        asignaciones
+            .filter { YearMonth.from(it.fecha) == mesActual }
+            .associateBy { it.fecha }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        CabeceraMes(
+            mes = mesActual,
+            alRetroceder = { mesActual = mesActual.minusMonths(1) },
+            alAvanzar = { mesActual = mesActual.plusMonths(1) }
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        FilaDiasSemana()
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        CuadriculaDias(
+            mes = mesActual,
+            diasConTurno = diasConTurno.keys,
+            alClickDia = { dia ->
+                diasConTurno[dia]?.let { asignacion ->
+                    asignacionSeleccionada = asignacion
+                }
+            }
+        )
+    }
+
+    asignacionSeleccionada?.let { asignacion ->
+        ModalBottomSheet(
+            onDismissRequest = { asignacionSeleccionada = null },
+            sheetState = sheetState
+        ) {
+            DetalleAsignacion(
+                asignacion = asignacion,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun CabeceraMes(
+    mes: YearMonth,
+    alRetroceder: () -> Unit,
+    alAvanzar: () -> Unit
+) {
+    val locale = Locale.getDefault()
+    val nombreMes = remember(mes, locale) {
+        val texto = mes.month.getDisplayName(TextStyle.FULL, locale)
+        texto.replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = alRetroceder) {
+            Icon(
+                imageVector = Icons.Filled.ChevronLeft,
+                contentDescription = stringResource(id = R.string.turnos_cd_mes_anterior)
+            )
+        }
+
+        Text(
+            text = "$nombreMes ${mes.year}",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+
+        IconButton(onClick = alAvanzar) {
+            Icon(
+                imageVector = Icons.Filled.ChevronRight,
+                contentDescription = stringResource(id = R.string.turnos_cd_mes_siguiente)
+            )
+        }
+    }
+}
+
+@Composable
+private fun FilaDiasSemana() {
+    val locale = Locale.getDefault()
+    // ISO: lunes=1 … domingo=7. Ajustamos para mostrar L-D
+    val diasOrdenados = remember(locale) {
+        DayOfWeek.entries.let { dias ->
+            // Empieza en lunes
+            dias.drop(0).map { dia ->
+                dia.getDisplayName(TextStyle.NARROW, locale)
+                    .replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
+            }
+        }
+    }
+
+    Row(modifier = Modifier.fillMaxWidth()) {
+        diasOrdenados.forEach { dia ->
+            Text(
+                text = dia,
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
+@Composable
+private fun CuadriculaDias(
+    mes: YearMonth,
+    diasConTurno: Set<LocalDate>,
+    alClickDia: (LocalDate) -> Unit
+) {
+    val primerDia = mes.atDay(1)
+    // Offset para que la semana empiece en lunes (DayOfWeek.MONDAY.value == 1)
+    val offsetInicio = (primerDia.dayOfWeek.value - DayOfWeek.MONDAY.value + 7) % 7
+    val diasEnMes = mes.lengthOfMonth()
+    val totalCeldas = offsetInicio + diasEnMes
+    val filas = (totalCeldas + 6) / 7
+
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        for (fila in 0 until filas) {
+            Row(modifier = Modifier.fillMaxWidth()) {
+                for (col in 0..6) {
+                    val indice = fila * 7 + col
+                    val numeroDia = indice - offsetInicio + 1
+
+                    if (numeroDia < 1 || numeroDia > diasEnMes) {
+                        Spacer(modifier = Modifier.weight(1f))
+                    } else {
+                        val fecha = mes.atDay(numeroDia)
+                        val tieneTurno = fecha in diasConTurno
+                        val esHoy = fecha == LocalDate.now()
+
+                        CeldaDia(
+                            numero = numeroDia,
+                            esHoy = esHoy,
+                            tieneTurno = tieneTurno,
+                            alClick = { alClickDia(fecha) },
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CeldaDia(
+    numero: Int,
+    esHoy: Boolean,
+    tieneTurno: Boolean,
+    alClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val colorFondo = when {
+        esHoy -> MaterialTheme.colorScheme.primaryContainer
+        else -> Color.Transparent
+    }
+
+    Column(
+        modifier = modifier
+            .aspectRatio(1f)
+            .clip(MaterialTheme.shapes.small)
+            .background(colorFondo)
+            .clickable(enabled = tieneTurno, onClick = alClick),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = numero.toString(),
+            style = MaterialTheme.typography.bodyMedium,
+            color = when {
+                esHoy -> MaterialTheme.colorScheme.onPrimaryContainer
+                else -> MaterialTheme.colorScheme.onSurface
+            },
+            fontWeight = if (esHoy) FontWeight.Bold else FontWeight.Normal
+        )
+        if (tieneTurno) {
+            Spacer(modifier = Modifier.height(2.dp))
+            Box(
+                modifier = Modifier
+                    .size(5.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.primary)
+            )
+        }
+    }
+}
+
+@Composable
+private fun DetalleAsignacion(
+    asignacion: RespuestaAsignacionTurnoDTO,
+    modifier: Modifier = Modifier
+) {
+    val patronFecha = stringResource(id = R.string.turnos_formato_fecha_detalle)
+    val locale = Locale.getDefault()
+    val fechaFormateada = remember(asignacion.fecha, patronFecha) {
+        asignacion.fecha.format(DateTimeFormatter.ofPattern(patronFecha, locale))
+            .replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
+    }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(id = R.string.turnos_detalle_titulo),
+            style = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        FilaDetalle(
+            etiqueta = stringResource(id = R.string.turnos_detalle_fecha),
+            valor = fechaFormateada
+        )
+        FilaDetalle(
+            etiqueta = stringResource(id = R.string.turnos_detalle_turno),
+            valor = asignacion.descripcionTurno
+        )
+        FilaDetalle(
+            etiqueta = stringResource(id = R.string.turnos_detalle_modalidad),
+            valor = stringResource(
+                id = when (asignacion.modalidad) {
+                    ModalidadAsignacion.PRESENCIAL -> R.string.turnos_modalidad_presencial
+                    ModalidadAsignacion.TELETRABAJO -> R.string.turnos_modalidad_teletrabajo
+                }
+            )
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun FilaDetalle(etiqueta: String, valor: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = etiqueta,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = valor,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+}
+
+@Composable
+private fun EstadoVacio(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.CalendarToday,
+            contentDescription = null,
+            modifier = Modifier.size(72.dp),
+            tint = MaterialTheme.colorScheme.outlineVariant
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(id = R.string.turnos_vacio_titulo),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(id = R.string.turnos_vacio_descripcion),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 32.dp)
+        )
+    }
+}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -65,4 +65,24 @@
     <string name="perfil_sin_dato">—</string>
     <string name="perfil_reintentar">Retry</string>
     <string name="sesion_expirada">Your session has expired. Please sign in again</string>
+
+    <!-- My Shifts Screen -->
+    <string name="turnos_titulo">My Shifts</string>
+    <string name="turnos_modalidad_presencial">ON-SITE</string>
+    <string name="turnos_modalidad_teletrabajo">REMOTE</string>
+    <string name="turnos_reintentar">Retry</string>
+    <string name="turnos_vacio_titulo">No shifts assigned</string>
+    <string name="turnos_vacio_descripcion">You have no shifts assigned for this period. Contact HR if you think this is a mistake.</string>
+    <string name="turnos_cd_vista_lista">List view</string>
+    <string name="turnos_cd_vista_calendario">Calendar view</string>
+    <string name="turnos_cd_mes_anterior">Previous month</string>
+    <string name="turnos_cd_mes_siguiente">Next month</string>
+    <!-- Date pattern for list cards: "Mon, Apr 21" -->
+    <string name="turnos_formato_fecha_tarjeta">EEE, MMM d</string>
+    <!-- Full date pattern for BottomSheet detail -->
+    <string name="turnos_formato_fecha_detalle">EEEE, MMMM d, yyyy</string>
+    <string name="turnos_detalle_titulo">Shift detail</string>
+    <string name="turnos_detalle_fecha">Date</string>
+    <string name="turnos_detalle_turno">Shift</string>
+    <string name="turnos_detalle_modalidad">Mode</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,4 +65,24 @@
     <string name="perfil_sin_dato">—</string>
     <string name="perfil_reintentar">Reintentar</string>
     <string name="sesion_expirada">Tu sesión ha expirado. Por favor, inicia sesión de nuevo</string>
+
+    <!-- Pantalla Mis Turnos -->
+    <string name="turnos_titulo">Mis Turnos</string>
+    <string name="turnos_modalidad_presencial">PRESENCIAL</string>
+    <string name="turnos_modalidad_teletrabajo">TELETRABAJO</string>
+    <string name="turnos_reintentar">Reintentar</string>
+    <string name="turnos_vacio_titulo">Sin turnos asignados</string>
+    <string name="turnos_vacio_descripcion">No tienes turnos asignados en este periodo. Contacta con RRHH si crees que es un error.</string>
+    <string name="turnos_cd_vista_lista">Vista en lista</string>
+    <string name="turnos_cd_vista_calendario">Vista en calendario</string>
+    <string name="turnos_cd_mes_anterior">Mes anterior</string>
+    <string name="turnos_cd_mes_siguiente">Mes siguiente</string>
+    <!-- Patrón de fecha para las tarjetas de la lista: "lun., 21 de abr." -->
+    <string name="turnos_formato_fecha_tarjeta">EEE, d \'de\' MMM</string>
+    <!-- Patrón de fecha completo para el detalle del BottomSheet -->
+    <string name="turnos_formato_fecha_detalle">EEEE, d \'de\' MMMM \'de\' yyyy</string>
+    <string name="turnos_detalle_titulo">Detalle del turno</string>
+    <string name="turnos_detalle_fecha">Fecha</string>
+    <string name="turnos_detalle_turno">Turno</string>
+    <string name="turnos_detalle_modalidad">Modalidad</string>
 </resources>


### PR DESCRIPTION
## Resumen

- Implementa la pantalla **Mis Turnos** (`PantallaMisTurnos`) con vista dual lista/calendario conectada a la segunda pestaña del `BottomNavigationBar`
- Crea la capa de datos completa: DTOs (`RespuestaAsignacionTurnoDTO`), `AsignacionApiService`, `IAsignacionRepository` e `AsignacionRepositoryImpl`
- Añade `LocalDateDeserializer` para deserializar el campo `fecha` (`yyyy-MM-dd`) y lo registra en `ApiClient`
- El `MisTurnosViewModel` expone un único `StateFlow<EstadoUiMisTurnos>` y carga datos en `Dispatchers.IO` con Factory manual (sin frameworks de DI)

## Funcionalidades incluidas

- **Vista Lista:** `LazyColumn` con `Card` por asignación — fecha formateada, descripción del turno y chip de modalidad (`#1A365D` PRESENCIAL / `#00A8E8` TELETRABAJO)
- **Vista Calendario:** componente mensual compacto con punto indicador en días con turno; al pulsar un día marcado se abre un `ModalBottomSheet` con el detalle (fecha, turno, modalidad)
- `TopAppBar` con selector de vista (iconos lista/calendario) en el extremo derecho
- `CircularProgressIndicator` durante la carga
- Estado vacío ilustrado si no hay asignaciones
- `Snackbar` de error con botón **Reintentar** que reintenta la llamada al repositorio
- Todos los textos en `strings.xml` y `strings-en/strings.xml` — cero strings hardcodeados

## Verificación

- `./gradlew test` → **BUILD SUCCESSFUL** (26 tareas, 0 tests fallidos)
- Compilación sin warnings nuevos (deprecation de `Icons.Filled.List` corregida por `Icons.AutoMirrored.Filled.List`)

Closes #11