### PR TITLE
feat: botón fallback de cerrar sesión en error de Perfil

### DIFF
--- a/app/src/main/java/com/gestorrh/android/ui/perfil/PantallaPerfil.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/perfil/PantallaPerfil.kt
@@ -180,6 +180,9 @@ fun PantallaPerfil(
                         Button(onClick = { viewModel.cargarPerfil() }) {
                             Text(stringResource(R.string.perfil_reintentar))
                         }
+                        OutlinedButton(onClick = { viewModel.cerrarSesion(alCerrarSesion) }) {
+                            Text(stringResource(R.string.perfil_btn_cerrar_sesion))
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Resumen

Añade un botón secundario **Cerrar sesión** en el estado de error de `PantallaPerfil` para evitar que el usuario quede bloqueado si la redirección automática al Login tras un 401 no llega a ejecutarse.

## Cambios

- `PantallaPerfil.kt`: en la rama de error de la UI, junto al botón `Reintentar` se añade un `OutlinedButton` que invoca `viewModel.cerrarSesion(alCerrarSesion)`, reutilizando la lógica existente que limpia la sesión vía `SessionManager.clearSession()` y navega al Login a través del callback.

## Notas para la revisión

- Reutiliza el string ya existente `perfil_btn_cerrar_sesion` (ES/EN) — no se añaden strings nuevos.
- La navegación global ante 401 vía `AuthEventBus` + `LaunchedEffect` en `MainActivity` ya estaba implementada; este cambio es puramente un fallback defensivo en la UI.