### PR TITLE
fix: mostrar horario de entrada y salida en Mis Turnos

### DIFF
--- a/app/src/main/java/com/gestorrh/android/data/network/asignacion/AsignacionResponse.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/asignacion/AsignacionResponse.kt
@@ -11,6 +11,8 @@ data class RespuestaAsignacionTurnoDTO(
     val descripcionTurno: String,
     val fecha: LocalDate,
     val modalidad: ModalidadAsignacion,
+    val horaInicio: String?,
+    val horaFin: String?,
     val motivoCambio: String?,
     val fechaCambio: LocalDateTime?,
     val responsableCambio: String?

--- a/app/src/main/java/com/gestorrh/android/ui/turnos/PantallaMisTurnos.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/turnos/PantallaMisTurnos.kt
@@ -191,6 +191,14 @@ private fun TarjetaAsignacion(asignacion: RespuestaAsignacionTurnoDTO) {
                     fontWeight = FontWeight.SemiBold,
                     color = MaterialTheme.colorScheme.onSurface
                 )
+                if (asignacion.horaInicio != null && asignacion.horaFin != null) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = "${asignacion.horaInicio} - ${asignacion.horaFin}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
             Spacer(modifier = Modifier.width(12.dp))
             ChipModalidad(modalidad = asignacion.modalidad)
@@ -457,6 +465,12 @@ private fun DetalleAsignacion(
             etiqueta = stringResource(id = R.string.turnos_detalle_turno),
             valor = asignacion.descripcionTurno
         )
+        if (asignacion.horaInicio != null && asignacion.horaFin != null) {
+            FilaDetalle(
+                etiqueta = stringResource(id = R.string.turnos_detalle_horario),
+                valor = "${asignacion.horaInicio} - ${asignacion.horaFin}"
+            )
+        }
         FilaDetalle(
             etiqueta = stringResource(id = R.string.turnos_detalle_modalidad),
             valor = stringResource(

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -84,5 +84,6 @@
     <string name="turnos_detalle_titulo">Shift detail</string>
     <string name="turnos_detalle_fecha">Date</string>
     <string name="turnos_detalle_turno">Shift</string>
+    <string name="turnos_detalle_horario">Hours</string>
     <string name="turnos_detalle_modalidad">Mode</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,5 +84,6 @@
     <string name="turnos_detalle_titulo">Detalle del turno</string>
     <string name="turnos_detalle_fecha">Fecha</string>
     <string name="turnos_detalle_turno">Turno</string>
+    <string name="turnos_detalle_horario">Horario</string>
     <string name="turnos_detalle_modalidad">Modalidad</string>
 </resources>


### PR DESCRIPTION
## Resumen

Extiende la funcionalidad de la pantalla Mis Turnos implementada en #11 para mostrar el tramo horario (`horaInicio` - `horaFin`) de cada asignación cuando el backend lo incluye.

- Añade `horaInicio: String?` y `horaFin: String?` a `RespuestaAsignacionTurnoDTO`
- **Vista Lista:** muestra `"08:00 - 16:30"` debajo de `descripcionTurno` con `bodyMedium` / `onSurfaceVariant`
- **Vista Calendario (BottomSheet):** añade la fila *Horario* en el detalle de la asignación seleccionada
- Si cualquiera de los dos campos es `null` no se renderiza ninguna línea de horario (nullable-safe)
- Añade `turnos_detalle_horario` a `strings.xml` y `strings-en/strings.xml`

## Verificación

- `./gradlew test` → **BUILD SUCCESSFUL** (26 tareas, 0 fallos)

Closes #11