### PR TITLE
feat: caché offline de asignaciones con Room (#12)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ import java.util.Properties
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.ksp)
 }
 
 val secretsFile = rootProject.file("secrets.properties")
@@ -92,5 +93,11 @@ dependencies {
     implementation("com.google.android.gms:play-services-location:21.2.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.10.2")
 
-    // Nota: Room (Persistencia) lo inyectaremos más adelante
+    // 5. Persistencia local (Room)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
+
+    // 6. Lifecycle Compose (collectAsStateWithLifecycle)
+    implementation(libs.androidx.lifecycle.runtime.compose)
 }

--- a/app/src/main/java/com/gestorrh/android/MainActivity.kt
+++ b/app/src/main/java/com/gestorrh/android/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.navigation.compose.rememberNavController
 import com.gestorrh.android.core.network.ApiClient
 import com.gestorrh.android.core.security.AuthEventBus
 import com.gestorrh.android.core.security.SessionManager
+import com.gestorrh.android.data.local.GestorRhDatabase
 import com.gestorrh.android.data.network.autenticacion.AuthApi
 import com.gestorrh.android.data.repository.AuthRepository
 import com.gestorrh.android.ui.login.LoginViewModel
@@ -45,6 +46,7 @@ class MainActivity : ComponentActivity() {
         val sessionManager = SessionManager(this)
         val retrofit = ApiClient.crearRetrofit(sessionManager)
         val authRepository = AuthRepository(retrofit.create(AuthApi::class.java))
+        val baseDatos = GestorRhDatabase.getInstance(this)
 
         setContent {
             GestorRHTheme {
@@ -56,6 +58,9 @@ class MainActivity : ComponentActivity() {
 
                 LaunchedEffect(Unit) {
                     AuthEventBus.sesionExpirada.collect {
+                        scope.launch {
+                            baseDatos.asignacionDao().deleteAll()
+                        }
                         controladorNavegacion.navigate("login") {
                             popUpTo(0) { inclusive = true }
                         }
@@ -101,6 +106,9 @@ class MainActivity : ComponentActivity() {
                             PantallaPrincipal(
                                 alCerrarSesion = {
                                     sessionManager.clearSession()
+                                    scope.launch {
+                                        baseDatos.asignacionDao().deleteAll()
+                                    }
                                     controladorNavegacion.navigate("login") {
                                         popUpTo(0) { inclusive = true }
                                     }

--- a/app/src/main/java/com/gestorrh/android/data/local/GestorRhDatabase.kt
+++ b/app/src/main/java/com/gestorrh/android/data/local/GestorRhDatabase.kt
@@ -1,0 +1,38 @@
+package com.gestorrh.android.data.local
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import com.gestorrh.android.data.local.dao.AsignacionDao
+import com.gestorrh.android.data.local.entity.AsignacionEntity
+
+@Database(
+    entities = [AsignacionEntity::class],
+    version = 1,
+    exportSchema = false
+)
+abstract class GestorRhDatabase : RoomDatabase() {
+
+    abstract fun asignacionDao(): AsignacionDao
+
+    companion object {
+        private const val NOMBRE_BASE_DATOS = "gestorrh.db"
+
+        @Volatile
+        private var instancia: GestorRhDatabase? = null
+
+        fun getInstance(contexto: Context): GestorRhDatabase {
+            return instancia ?: synchronized(this) {
+                instancia ?: Room.databaseBuilder(
+                    contexto.applicationContext,
+                    GestorRhDatabase::class.java,
+                    NOMBRE_BASE_DATOS
+                )
+                    .fallbackToDestructiveMigration(dropAllTables = true)
+                    .build()
+                    .also { instancia = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/data/local/dao/AsignacionDao.kt
+++ b/app/src/main/java/com/gestorrh/android/data/local/dao/AsignacionDao.kt
@@ -1,0 +1,40 @@
+package com.gestorrh.android.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Upsert
+import com.gestorrh.android.data.local.entity.AsignacionEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * DAO para acceder a la tabla `asignaciones`.
+ *
+ * Expone las operaciones mínimas necesarias para la estrategia offline-first
+ * de la pestaña Mis Turnos: observación reactiva de la caché, inserción/actualización
+ * masiva tras cada sincronización con el servidor y limpieza total al cerrar sesión.
+ */
+@Dao
+interface AsignacionDao {
+
+    /**
+     * Inserta o actualiza todas las asignaciones recibidas del servidor.
+     * Se usa al finalizar con éxito la llamada a `GET /api/asignaciones/me`.
+     */
+    @Upsert
+    suspend fun upsertAll(asignaciones: List<AsignacionEntity>)
+
+    /**
+     * Devuelve un `Flow` con todas las asignaciones cacheadas ordenadas por fecha
+     * ascendente. El `Flow` emite una nueva lista cada vez que cambian los datos
+     * subyacentes, permitiendo a la UI actualizarse sin acción explícita.
+     */
+    @Query("SELECT * FROM asignaciones ORDER BY fecha ASC")
+    fun getAll(): Flow<List<AsignacionEntity>>
+
+    /**
+     * Elimina todas las filas. Debe invocarse al cerrar sesión para no exponer
+     * los turnos del usuario anterior al siguiente login.
+     */
+    @Query("DELETE FROM asignaciones")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/gestorrh/android/data/local/entity/AsignacionEntity.kt
+++ b/app/src/main/java/com/gestorrh/android/data/local/entity/AsignacionEntity.kt
@@ -1,0 +1,34 @@
+package com.gestorrh.android.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Representación persistida de una asignación de turno en la base de datos local.
+ *
+ * Esta entidad espeja los campos relevantes de `RespuestaAsignacionTurnoDTO` pero
+ * transforma los tipos complejos (`LocalDate`, enums) a tipos primitivos soportados
+ * por Room sin necesidad de TypeConverters:
+ *
+ * - `fecha` se almacena como String con formato ISO `yyyy-MM-dd`.
+ * - `modalidad` se almacena como String con los valores `PRESENCIAL` o `TELETRABAJO`.
+ *
+ * Los campos `horaInicio` y `horaFin` se persisten para que la pantalla de Mis Turnos
+ * pueda renderizar la tarjeta y el detalle de la asignación sin red.
+ *
+ * `fechaSincronizacion` es el timestamp en milisegundos del último refresco exitoso
+ * desde el servidor; sirve para conocer la antigüedad de los datos cacheados.
+ */
+@Entity(tableName = "asignaciones")
+data class AsignacionEntity(
+    @PrimaryKey val idAsignacion: Long,
+    val idTurno: Long,
+    val descripcionTurno: String,
+    val fecha: String,
+    val modalidad: String,
+    val horaInicio: String?,
+    val horaFin: String?,
+    val motivoCambio: String?,
+    val responsableCambio: String?,
+    val fechaSincronizacion: Long
+)

--- a/app/src/main/java/com/gestorrh/android/data/local/mapper/AsignacionMapper.kt
+++ b/app/src/main/java/com/gestorrh/android/data/local/mapper/AsignacionMapper.kt
@@ -1,0 +1,18 @@
+package com.gestorrh.android.data.local.mapper
+
+import com.gestorrh.android.data.local.entity.AsignacionEntity
+import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
+
+fun RespuestaAsignacionTurnoDTO.toEntity(fechaSincronizacion: Long): AsignacionEntity =
+    AsignacionEntity(
+        idAsignacion = idAsignacion,
+        idTurno = idTurno,
+        descripcionTurno = descripcionTurno,
+        fecha = fecha.toString(),
+        modalidad = modalidad.name,
+        horaInicio = horaInicio,
+        horaFin = horaFin,
+        motivoCambio = motivoCambio,
+        responsableCambio = responsableCambio,
+        fechaSincronizacion = fechaSincronizacion
+    )

--- a/app/src/main/java/com/gestorrh/android/data/repository/asignacion/AsignacionRepositoryImpl.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/asignacion/AsignacionRepositoryImpl.kt
@@ -1,35 +1,67 @@
 package com.gestorrh.android.data.repository.asignacion
 
+import com.gestorrh.android.data.local.dao.AsignacionDao
+import com.gestorrh.android.data.local.entity.AsignacionEntity
+import com.gestorrh.android.data.local.mapper.toEntity
 import com.gestorrh.android.data.network.asignacion.AsignacionApiService
-import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
 import com.gestorrh.android.domain.repository.IAsignacionRepository
+import com.gestorrh.android.domain.repository.ResultadoSincronizacion
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
 import okhttp3.ResponseBody
 import org.json.JSONException
 import org.json.JSONObject
+import java.io.IOException
 
 /**
- * Implementación de [IAsignacionRepository] que delega en el servicio Retrofit [AsignacionApiService].
- * Centraliza la extracción de mensajes de error del cuerpo JSON de la respuesta,
- * evitando que esta lógica de protocolo de red se filtre a la capa de presentación.
+ * Implementación offline-first de [IAsignacionRepository].
+ *
+ * La caché de Room actúa como fuente única de verdad para la UI: el `Flow` expuesto
+ * en [observarAsignaciones] emite siempre los datos locales. El método [sincronizar]
+ * refresca la caché en segundo plano llamando al backend y escribiendo la respuesta
+ * con `upsertAll`; la UI se actualiza automáticamente gracias a la reactividad de
+ * Room. Si la red falla pero hay datos en caché, la UI seguirá mostrando la versión
+ * guardada y el ViewModel decidirá el aviso al usuario.
  *
  * @param apiService Servicio Retrofit para los endpoints de asignaciones.
+ * @param dao DAO Room para la tabla `asignaciones`.
  */
 class AsignacionRepositoryImpl(
-    private val apiService: AsignacionApiService
+    private val apiService: AsignacionApiService,
+    private val dao: AsignacionDao
 ) : IAsignacionRepository {
 
-    override suspend fun getMisAsignaciones(): Result<List<RespuestaAsignacionTurnoDTO>> {
-        return try {
+    override fun observarAsignaciones(): Flow<List<AsignacionEntity>> = dao.getAll()
+
+    /**
+     * Ejecuta el refresco contra `GET /api/asignaciones/me`.
+     *
+     * - Si el servidor responde 200, persiste la lista completa en Room con la
+     *   marca de `fechaSincronizacion` actual. El `Flow` emitirá automáticamente.
+     * - Si se produce un [IOException] (sin red, timeout) devuelve
+     *   [ResultadoSincronizacion.SinConexion] para que la UI pueda avisar pero
+     *   sin invalidar la caché existente.
+     * - Cualquier otro fallo (4xx/5xx o parseo) se traduce a [ResultadoSincronizacion.Error]
+     *   con el mensaje `"message"` extraído del cuerpo JSON cuando esté disponible.
+     */
+    override suspend fun sincronizar(): ResultadoSincronizacion = withContext(Dispatchers.IO) {
+        try {
             val respuesta = apiService.getMisAsignaciones()
             if (respuesta.isSuccessful && respuesta.body() != null) {
-                Result.success(respuesta.body()!!)
+                val ahora = System.currentTimeMillis()
+                val entidades = respuesta.body()!!.map { it.toEntity(ahora) }
+                dao.upsertAll(entidades)
+                ResultadoSincronizacion.Exito
             } else {
                 val mensaje = extraerMensajeError(respuesta.errorBody())
                     ?: "Error ${respuesta.code()} al obtener las asignaciones"
-                Result.failure(Exception(mensaje))
+                ResultadoSincronizacion.Error(mensaje)
             }
+        } catch (e: IOException) {
+            ResultadoSincronizacion.SinConexion
         } catch (e: Exception) {
-            Result.failure(e)
+            ResultadoSincronizacion.Error(e.message ?: "Error desconocido")
         }
     }
 

--- a/app/src/main/java/com/gestorrh/android/domain/repository/IAsignacionRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/IAsignacionRepository.kt
@@ -1,19 +1,41 @@
 package com.gestorrh.android.domain.repository
 
-import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
+import com.gestorrh.android.data.local.entity.AsignacionEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Resultado de una sincronización con el servidor.
+ *
+ * Permite al ViewModel distinguir entre un refresco correcto, una caída de red
+ * (donde puede seguir mostrando la caché) y un error explícito de servidor.
+ */
+sealed class ResultadoSincronizacion {
+    data object Exito : ResultadoSincronizacion()
+    data object SinConexion : ResultadoSincronizacion()
+    data class Error(val mensaje: String) : ResultadoSincronizacion()
+}
 
 /**
  * Contrato de la capa de dominio para las operaciones de asignación de turnos.
- * Los ViewModels dependen de esta interfaz, nunca del servicio Retrofit directamente.
- * La implementación concreta vive en la capa de datos ([com.gestorrh.android.data.repository.asignacion]).
+ * Sigue una estrategia offline-first: la UI observa siempre la caché local como
+ * fuente única de verdad, y el refresco con el servidor se lanza por separado.
  */
 interface IAsignacionRepository {
 
     /**
-     * Obtiene la lista de asignaciones de turno del empleado autenticado.
-     *
-     * @return [Result.success] con la lista de [RespuestaAsignacionTurnoDTO], o [Result.failure]
-     *         con el mensaje de error del servidor o de red.
+     * Flujo reactivo con las asignaciones persistidas en Room, ordenadas por fecha.
+     * Emite una nueva lista cada vez que la caché local cambia (por ejemplo, tras
+     * una sincronización exitosa o un `deleteAll()` al cerrar sesión).
      */
-    suspend fun getMisAsignaciones(): Result<List<RespuestaAsignacionTurnoDTO>>
+    fun observarAsignaciones(): Flow<List<AsignacionEntity>>
+
+    /**
+     * Lanza la petición `GET /api/asignaciones/me` y, si es correcta, escribe los
+     * datos recibidos en Room con la marca de `fechaSincronizacion` actual.
+     *
+     * No emite datos directamente: los consumidores reaccionan al `Flow` de
+     * [observarAsignaciones]. Devuelve el resultado de la operación de red para
+     * que la capa superior pueda informar al usuario (Snackbar, estado de error).
+     */
+    suspend fun sincronizar(): ResultadoSincronizacion
 }

--- a/app/src/main/java/com/gestorrh/android/ui/turnos/EstadoUiMisTurnos.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/turnos/EstadoUiMisTurnos.kt
@@ -1,22 +1,25 @@
 package com.gestorrh.android.ui.turnos
 
 import com.gestorrh.android.core.ui.MensajeUi
-import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
+import com.gestorrh.android.data.local.entity.AsignacionEntity
 
 /**
  * Representa el estado inmutable de la UI para la pantalla de Mis Turnos.
  * En Jetpack Compose, cualquier cambio visual se produce al emitir una nueva copia de esta clase,
  * garantizando un flujo de datos unidireccional (UDF) libre de condiciones de carrera.
  *
- * @property cargando Indica si hay una petición de red en curso.
- * @property asignaciones Lista de asignaciones de turno del empleado autenticado.
+ * @property cargando Indica si hay una sincronización en curso y todavía no hay caché.
+ * @property asignaciones Lista de asignaciones cacheadas en Room, ordenadas por fecha ascendente.
  * @property mensajeError Mensaje de error a mostrar en el Snackbar. Null si no hay error.
+ * @property sinConexion true cuando la última sincronización falló por falta de red pero se
+ *                       están mostrando datos cacheados válidos.
  * @property vistaActual Controla qué modo de visualización está activo (lista o calendario).
  */
 data class EstadoUiMisTurnos(
     val cargando: Boolean = true,
-    val asignaciones: List<RespuestaAsignacionTurnoDTO> = emptyList(),
+    val asignaciones: List<AsignacionEntity> = emptyList(),
     val mensajeError: MensajeUi? = null,
+    val sinConexion: Boolean = false,
     val vistaActual: VistaActual = VistaActual.LISTA
 )
 

--- a/app/src/main/java/com/gestorrh/android/ui/turnos/MisTurnosViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/turnos/MisTurnosViewModel.kt
@@ -4,26 +4,31 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.gestorrh.android.R
 import com.gestorrh.android.core.network.ApiClient
 import com.gestorrh.android.core.security.SessionManager
 import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.local.GestorRhDatabase
 import com.gestorrh.android.data.network.asignacion.AsignacionApiService
 import com.gestorrh.android.data.repository.asignacion.AsignacionRepositoryImpl
 import com.gestorrh.android.domain.repository.IAsignacionRepository
-import kotlinx.coroutines.Dispatchers
+import com.gestorrh.android.domain.repository.ResultadoSincronizacion
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 /**
  * ViewModel para la pantalla de Mis Turnos.
- * Expone un único [StateFlow] de [EstadoUiMisTurnos] y orquesta la carga de asignaciones
- * desde el repositorio ejecutándola en [Dispatchers.IO].
  *
- * @param asignacionRepository Repositorio que provee las asignaciones del empleado autenticado.
+ * Expone un único [StateFlow] de [EstadoUiMisTurnos]. La lista de asignaciones procede
+ * siempre del `Flow` reactivo de Room; la red se usa únicamente para refrescar la caché.
+ * Esto garantiza el comportamiento offline-first: al abrir la pantalla el usuario ve
+ * de inmediato los datos guardados, y la UI se actualiza sola cuando termina la sincronización.
+ *
+ * @param asignacionRepository Repositorio que provee el flujo de asignaciones y lanza
+ *        la sincronización con el servidor.
  */
 class MisTurnosViewModel(
     private val asignacionRepository: IAsignacionRepository
@@ -33,27 +38,46 @@ class MisTurnosViewModel(
     val estadoUi: StateFlow<EstadoUiMisTurnos> = _estadoUi.asStateFlow()
 
     init {
+        observarCache()
         cargarAsignaciones()
+    }
+
+    private fun observarCache() {
+        viewModelScope.launch {
+            asignacionRepository.observarAsignaciones().collect { lista ->
+                _estadoUi.update { it.copy(asignaciones = lista) }
+            }
+        }
     }
 
     fun cargarAsignaciones() {
         viewModelScope.launch {
             _estadoUi.update { it.copy(cargando = true, mensajeError = null) }
 
-            val resultado = withContext(Dispatchers.IO) {
-                asignacionRepository.getMisAsignaciones()
+            when (val resultado = asignacionRepository.sincronizar()) {
+                is ResultadoSincronizacion.Exito -> {
+                    _estadoUi.update { it.copy(cargando = false, sinConexion = false) }
+                }
+                is ResultadoSincronizacion.SinConexion -> {
+                    val hayCache = _estadoUi.value.asignaciones.isNotEmpty()
+                    _estadoUi.update {
+                        it.copy(
+                            cargando = false,
+                            sinConexion = hayCache,
+                            mensajeError = if (!hayCache) MensajeUi.Recurso(R.string.error_conexion) else null
+                        )
+                    }
+                }
+                is ResultadoSincronizacion.Error -> {
+                    _estadoUi.update {
+                        it.copy(
+                            cargando = false,
+                            sinConexion = false,
+                            mensajeError = MensajeUi.Dinamico(resultado.mensaje)
+                        )
+                    }
+                }
             }
-
-            resultado
-                .onSuccess { asignaciones ->
-                    val ordenadas = asignaciones.sortedBy { it.fecha }
-                    _estadoUi.update { it.copy(cargando = false, asignaciones = ordenadas) }
-                }
-                .onFailure { error ->
-                    val mensaje = if (error.message != null) MensajeUi.Dinamico(error.message!!)
-                    else MensajeUi.Recurso(com.gestorrh.android.R.string.error_conexion)
-                    _estadoUi.update { it.copy(cargando = false, mensajeError = mensaje) }
-                }
         }
     }
 
@@ -65,6 +89,10 @@ class MisTurnosViewModel(
         _estadoUi.update { it.copy(mensajeError = null) }
     }
 
+    fun avisoSinConexionMostrado() {
+        _estadoUi.update { it.copy(sinConexion = false) }
+    }
+
     companion object {
         fun factory(contexto: Context): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory {
@@ -73,7 +101,8 @@ class MisTurnosViewModel(
                     val sessionManager = SessionManager(contexto)
                     val retrofit = ApiClient.crearRetrofit(sessionManager)
                     val apiService = retrofit.create(AsignacionApiService::class.java)
-                    val repository = AsignacionRepositoryImpl(apiService)
+                    val dao = GestorRhDatabase.getInstance(contexto).asignacionDao()
+                    val repository = AsignacionRepositoryImpl(apiService, dao)
                     return MisTurnosViewModel(repository) as T
                 }
             }

--- a/app/src/main/java/com/gestorrh/android/ui/turnos/PantallaMisTurnos.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/turnos/PantallaMisTurnos.kt
@@ -12,7 +12,6 @@ import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
-import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -24,11 +23,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gestorrh.android.R
 import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.local.entity.AsignacionEntity
 import com.gestorrh.android.data.network.asignacion.ModalidadAsignacion
-import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.YearMonth
@@ -39,6 +39,8 @@ import java.util.Locale
 private val ColorPresencial = Color(0xFF1A365D)
 private val ColorTeletrabajo = Color(0xFF00A8E8)
 
+private fun AsignacionEntity.fechaLocalDate(): LocalDate = LocalDate.parse(fecha)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PantallaMisTurnos(
@@ -47,11 +49,12 @@ fun PantallaMisTurnos(
         factory = MisTurnosViewModel.factory(contexto.applicationContext)
     )
 ) {
-    val estadoUi by viewModel.estadoUi.collectAsState()
+    val estadoUi by viewModel.estadoUi.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val contextoLocal = LocalContext.current
 
     val textoReintentar = stringResource(id = R.string.turnos_reintentar)
+    val textoSinConexion = stringResource(id = R.string.turnos_sin_conexion)
 
     LaunchedEffect(estadoUi.mensajeError) {
         estadoUi.mensajeError?.let { mensajeUi ->
@@ -68,6 +71,16 @@ fun PantallaMisTurnos(
                 viewModel.cargarAsignaciones()
             }
             viewModel.errorMostrado()
+        }
+    }
+
+    LaunchedEffect(estadoUi.sinConexion) {
+        if (estadoUi.sinConexion) {
+            snackbarHostState.showSnackbar(
+                message = textoSinConexion,
+                duration = SnackbarDuration.Short
+            )
+            viewModel.avisoSinConexionMostrado()
         }
     }
 
@@ -109,7 +122,7 @@ fun PantallaMisTurnos(
     ) { paddingValores ->
 
         when {
-            estadoUi.cargando -> {
+            estadoUi.cargando && estadoUi.asignaciones.isEmpty() -> {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -120,7 +133,7 @@ fun PantallaMisTurnos(
                 }
             }
 
-            estadoUi.asignaciones.isEmpty() && !estadoUi.cargando -> {
+            estadoUi.asignaciones.isEmpty() -> {
                 EstadoVacio(modifier = Modifier.padding(paddingValores))
             }
 
@@ -143,7 +156,7 @@ fun PantallaMisTurnos(
 
 @Composable
 private fun VistaListaTurnos(
-    asignaciones: List<RespuestaAsignacionTurnoDTO>,
+    asignaciones: List<AsignacionEntity>,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -158,11 +171,11 @@ private fun VistaListaTurnos(
 }
 
 @Composable
-private fun TarjetaAsignacion(asignacion: RespuestaAsignacionTurnoDTO) {
+private fun TarjetaAsignacion(asignacion: AsignacionEntity) {
     val patronFecha = stringResource(id = R.string.turnos_formato_fecha_tarjeta)
     val fechaFormateada = remember(asignacion.fecha, patronFecha) {
         val locale = Locale.getDefault()
-        asignacion.fecha.format(DateTimeFormatter.ofPattern(patronFecha, locale))
+        asignacion.fechaLocalDate().format(DateTimeFormatter.ofPattern(patronFecha, locale))
             .replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
     }
 
@@ -207,10 +220,11 @@ private fun TarjetaAsignacion(asignacion: RespuestaAsignacionTurnoDTO) {
 }
 
 @Composable
-private fun ChipModalidad(modalidad: ModalidadAsignacion) {
+private fun ChipModalidad(modalidad: String) {
     val (colorFondo, textoRes) = when (modalidad) {
-        ModalidadAsignacion.PRESENCIAL -> ColorPresencial to R.string.turnos_modalidad_presencial
-        ModalidadAsignacion.TELETRABAJO -> ColorTeletrabajo to R.string.turnos_modalidad_teletrabajo
+        ModalidadAsignacion.PRESENCIAL.name -> ColorPresencial to R.string.turnos_modalidad_presencial
+        ModalidadAsignacion.TELETRABAJO.name -> ColorTeletrabajo to R.string.turnos_modalidad_teletrabajo
+        else -> ColorPresencial to R.string.turnos_modalidad_presencial
     }
 
     Surface(
@@ -230,17 +244,18 @@ private fun ChipModalidad(modalidad: ModalidadAsignacion) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun VistaCalendario(
-    asignaciones: List<RespuestaAsignacionTurnoDTO>,
+    asignaciones: List<AsignacionEntity>,
     modifier: Modifier = Modifier
 ) {
     var mesActual by remember { mutableStateOf(YearMonth.now()) }
-    var asignacionSeleccionada by remember { mutableStateOf<RespuestaAsignacionTurnoDTO?>(null) }
+    var asignacionSeleccionada by remember { mutableStateOf<AsignacionEntity?>(null) }
     val sheetState = rememberModalBottomSheetState()
 
     val diasConTurno = remember(asignaciones, mesActual) {
         asignaciones
-            .filter { YearMonth.from(it.fecha) == mesActual }
-            .associateBy { it.fecha }
+            .map { it to it.fechaLocalDate() }
+            .filter { YearMonth.from(it.second) == mesActual }
+            .associate { it.second to it.first }
     }
 
     Column(
@@ -326,14 +341,10 @@ private fun CabeceraMes(
 @Composable
 private fun FilaDiasSemana() {
     val locale = Locale.getDefault()
-    // ISO: lunes=1 … domingo=7. Ajustamos para mostrar L-D
     val diasOrdenados = remember(locale) {
-        DayOfWeek.entries.let { dias ->
-            // Empieza en lunes
-            dias.drop(0).map { dia ->
-                dia.getDisplayName(TextStyle.NARROW, locale)
-                    .replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
-            }
+        DayOfWeek.entries.map { dia ->
+            dia.getDisplayName(TextStyle.NARROW, locale)
+                .replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
         }
     }
 
@@ -358,7 +369,6 @@ private fun CuadriculaDias(
     alClickDia: (LocalDate) -> Unit
 ) {
     val primerDia = mes.atDay(1)
-    // Offset para que la semana empiece en lunes (DayOfWeek.MONDAY.value == 1)
     val offsetInicio = (primerDia.dayOfWeek.value - DayOfWeek.MONDAY.value + 7) % 7
     val diasEnMes = mes.lengthOfMonth()
     val totalCeldas = offsetInicio + diasEnMes
@@ -437,13 +447,13 @@ private fun CeldaDia(
 
 @Composable
 private fun DetalleAsignacion(
-    asignacion: RespuestaAsignacionTurnoDTO,
+    asignacion: AsignacionEntity,
     modifier: Modifier = Modifier
 ) {
     val patronFecha = stringResource(id = R.string.turnos_formato_fecha_detalle)
     val locale = Locale.getDefault()
     val fechaFormateada = remember(asignacion.fecha, patronFecha) {
-        asignacion.fecha.format(DateTimeFormatter.ofPattern(patronFecha, locale))
+        asignacion.fechaLocalDate().format(DateTimeFormatter.ofPattern(patronFecha, locale))
             .replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
     }
 
@@ -475,8 +485,9 @@ private fun DetalleAsignacion(
             etiqueta = stringResource(id = R.string.turnos_detalle_modalidad),
             valor = stringResource(
                 id = when (asignacion.modalidad) {
-                    ModalidadAsignacion.PRESENCIAL -> R.string.turnos_modalidad_presencial
-                    ModalidadAsignacion.TELETRABAJO -> R.string.turnos_modalidad_teletrabajo
+                    ModalidadAsignacion.PRESENCIAL.name -> R.string.turnos_modalidad_presencial
+                    ModalidadAsignacion.TELETRABAJO.name -> R.string.turnos_modalidad_teletrabajo
+                    else -> R.string.turnos_modalidad_presencial
                 }
             )
         )

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -86,4 +86,5 @@
     <string name="turnos_detalle_turno">Shift</string>
     <string name="turnos_detalle_horario">Hours</string>
     <string name="turnos_detalle_modalidad">Mode</string>
+    <string name="turnos_sin_conexion">Offline — showing saved data</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,4 +86,5 @@
     <string name="turnos_detalle_turno">Turno</string>
     <string name="turnos_detalle_horario">Horario</string>
     <string name="turnos_detalle_modalidad">Modalidad</string>
+    <string name="turnos_sin_conexion">Sin conexión — mostrando datos guardados</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.ksp) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,4 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # org.gradle.parallel=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.disallowKotlinSourceSets=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,12 @@ junit = "4.13.2"
 junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.6.1"
+lifecycleRuntimeCompose = "2.7.0"
 activityCompose = "1.8.0"
 kotlin = "2.2.10"
 composeBom = "2026.02.01"
+room = "2.7.1"
+ksp = "2.2.10-2.0.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -15,6 +18,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycleRuntimeCompose" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
@@ -24,8 +28,11 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
Closes #12

## Resumen

Implemento la persistencia local de asignaciones de turno con Room para habilitar el funcionamiento offline de la pestaña Mis Turnos siguiendo una estrategia offline-first: la UI observa siempre la caché local como fuente única de verdad y la red se usa sólo para refrescar.

## Cambios principales

- **Room**: nueva capa `data/local/` con `AsignacionEntity`, `AsignacionDao` (`@Upsert`, `getAll()` como `Flow`, `deleteAll()`) y `GestorRhDatabase` como singleton (double-checked locking).
- **Mapper** DTO→Entity: convierte `LocalDate` a `String` ISO `yyyy-MM-dd` y el enum `ModalidadAsignacion` a `String`.
- **AsignacionRepository** ofrece ahora `observarAsignaciones(): Flow<List<AsignacionEntity>>` y `sincronizar(): ResultadoSincronizacion` (`Exito` / `SinConexion` / `Error`), distinguiendo fallos de red (IOException) de errores HTTP.
- **MisTurnosViewModel** observa la caché y lanza la sincronización en paralelo. Si la sincronización falla por red y hay caché, activa `sinConexion = true`; si la caché está vacía, emite error bloqueante con botón Reintentar.
- **PantallaMisTurnos** consume `AsignacionEntity`, usa `collectAsStateWithLifecycle()` y muestra Snackbar informativo "Sin conexión — mostrando datos guardados" al cargar desde caché.
- **Logout** (manual desde Perfil y automático por 401 en `AuthEventBus`) invoca `asignacionDao.deleteAll()` para no exponer datos del usuario anterior.
- **Dependencias**: añado Room 2.7.1 (runtime + ktx + compiler), plugin KSP y `lifecycle-runtime-compose`.

## Plan de pruebas

- [ ] Login + navegar a Mis Turnos con red → carga y muestra asignaciones
- [ ] Desactivar red, cerrar y reabrir app, ir a Mis Turnos → se muestran los datos cacheados con Snackbar "Sin conexión"
- [ ] Al reconectar y volver a la pestaña, los datos se refrescan automáticamente sin acción del usuario
- [ ] Logout limpia la caché local