### PR TITLE
feat: formulario solicitud de ausencia con multipart

### DIFF
--- a/app/src/main/java/com/gestorrh/android/data/network/ausencia/AusenciaApiService.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/ausencia/AusenciaApiService.kt
@@ -1,0 +1,21 @@
+package com.gestorrh.android.data.network.ausencia
+
+import okhttp3.MultipartBody
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+interface AusenciaApiService {
+
+    @Multipart
+    @POST("api/ausencias")
+    suspend fun crearAusencia(
+        @Part datos: MultipartBody.Part,
+        @Part archivo: MultipartBody.Part?
+    ): Response<RespuestaAusenciaDTO>
+
+    @GET("api/ausencias/tipos")
+    suspend fun getTiposAusencia(): Response<List<String>>
+}

--- a/app/src/main/java/com/gestorrh/android/data/network/ausencia/PeticionAusenciaDTO.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/ausencia/PeticionAusenciaDTO.kt
@@ -1,0 +1,10 @@
+package com.gestorrh.android.data.network.ausencia
+
+import java.time.LocalDate
+
+data class PeticionAusenciaDTO(
+    val tipo: String,
+    val descripcion: String?,
+    val fechaInicio: LocalDate,
+    val fechaFin: LocalDate
+)

--- a/app/src/main/java/com/gestorrh/android/data/network/ausencia/RespuestaAusenciaDTO.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/ausencia/RespuestaAusenciaDTO.kt
@@ -1,0 +1,20 @@
+package com.gestorrh.android.data.network.ausencia
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class RespuestaAusenciaDTO(
+    val idAusencia: Long,
+    val idEmpleado: Long?,
+    val nombreCompletoEmpleado: String?,
+    val tipo: String,
+    val descripcion: String?,
+    val fechaInicio: LocalDate,
+    val fechaFin: LocalDate,
+    val estado: String,
+    val justificante: String?,
+    val fechaSolicitud: LocalDateTime?,
+    val fechaResolucion: LocalDateTime?,
+    val responsableResolucion: String?,
+    val motivoRechazo: String?
+)

--- a/app/src/main/java/com/gestorrh/android/data/network/ausencia/TipoAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/ausencia/TipoAusencia.kt
@@ -1,0 +1,14 @@
+package com.gestorrh.android.data.network.ausencia
+
+enum class TipoAusencia {
+    MEDICA,
+    VACACIONES,
+    MOTIVO_PERSONAL,
+    OTROS
+}
+
+enum class EstadoAusencia {
+    PENDIENTE,
+    APROBADA,
+    RECHAZADA
+}

--- a/app/src/main/java/com/gestorrh/android/data/repository/ausencia/AusenciaRepositoryImpl.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/ausencia/AusenciaRepositoryImpl.kt
@@ -1,0 +1,89 @@
+package com.gestorrh.android.data.repository.ausencia
+
+import com.gestorrh.android.data.network.ausencia.AusenciaApiService
+import com.gestorrh.android.data.network.ausencia.PeticionAusenciaDTO
+import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
+import com.gestorrh.android.domain.repository.IAusenciaRepository
+import com.google.gson.Gson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.ResponseBody
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.IOException
+
+class AusenciaRepositoryImpl(
+    private val apiService: AusenciaApiService,
+    private val gson: Gson
+) : IAusenciaRepository {
+
+    override suspend fun obtenerTipos(): Result<List<String>> = withContext(Dispatchers.IO) {
+        try {
+            val respuesta = apiService.getTiposAusencia()
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                Result.failure(
+                    Exception(
+                        extraerMensajeError(respuesta.errorBody())
+                            ?: "Error ${respuesta.code()} al obtener los tipos de ausencia"
+                    )
+                )
+            }
+        } catch (e: IOException) {
+            Result.failure(e)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun crearAusencia(
+        peticion: PeticionAusenciaDTO,
+        archivoBytes: ByteArray?,
+        nombreArchivo: String?
+    ): Result<RespuestaAusenciaDTO> = withContext(Dispatchers.IO) {
+        try {
+            val datosPart = MultipartBody.Part.createFormData(
+                "datos",
+                null,
+                gson.toJson(peticion).toRequestBody("application/json".toMediaTypeOrNull())
+            )
+
+            val archivoPart = archivoBytes?.let { bytes ->
+                MultipartBody.Part.createFormData(
+                    "archivo",
+                    nombreArchivo ?: "justificante",
+                    bytes.toRequestBody("application/octet-stream".toMediaTypeOrNull())
+                )
+            }
+
+            val respuesta = apiService.crearAusencia(datosPart, archivoPart)
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                Result.failure(
+                    Exception(
+                        extraerMensajeError(respuesta.errorBody())
+                            ?: "Error ${respuesta.code()} al crear la ausencia"
+                    )
+                )
+            }
+        } catch (e: IOException) {
+            Result.failure(e)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    private fun extraerMensajeError(errorBody: ResponseBody?): String? {
+        return try {
+            val json = errorBody?.string() ?: return null
+            JSONObject(json).getString("message")
+        } catch (e: JSONException) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/domain/repository/IAusenciaRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/IAusenciaRepository.kt
@@ -1,0 +1,39 @@
+package com.gestorrh.android.domain.repository
+
+import com.gestorrh.android.data.network.ausencia.PeticionAusenciaDTO
+import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
+
+/**
+ * Contrato de dominio para las operaciones sobre ausencias del empleado autenticado.
+ *
+ * Concentra las dos operaciones que la pantalla de solicitud necesita: leer el
+ * diccionario de tipos disponibles desde el servidor (para alimentar el desplegable
+ * sin acoplarlo al enum local) y enviar una nueva solicitud usando `multipart/form-data`
+ * con la parte JSON `datos` y la parte binaria opcional `archivo`.
+ *
+ * Las implementaciones devuelven [Result] envolviendo el cuerpo de respuesta en caso
+ * de éxito o una [Throwable] cuyo mensaje sea apto para mostrar al usuario directamente
+ * (extraído del campo `message` del JSON de error de la API cuando esté disponible).
+ */
+interface IAusenciaRepository {
+
+    /**
+     * Recupera la lista de tipos de ausencia válidos desde `GET /api/ausencias/tipos`.
+     */
+    suspend fun obtenerTipos(): Result<List<String>>
+
+    /**
+     * Envía una nueva solicitud de ausencia a `POST /api/ausencias` empaquetando
+     * [peticion] como parte JSON `datos` y [archivoBytes] (opcional) como parte
+     * binaria `archivo`.
+     *
+     * @param peticion Datos validados de la solicitud.
+     * @param archivoBytes Contenido binario del justificante o `null` si no se adjunta.
+     * @param nombreArchivo Nombre original del archivo, usado en el `filename` del multipart.
+     */
+    suspend fun crearAusencia(
+        peticion: PeticionAusenciaDTO,
+        archivoBytes: ByteArray?,
+        nombreArchivo: String?
+    ): Result<RespuestaAusenciaDTO>
+}

--- a/app/src/main/java/com/gestorrh/android/domain/usecase/ausencia/SolicitarAusenciaUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/ausencia/SolicitarAusenciaUseCase.kt
@@ -1,0 +1,61 @@
+package com.gestorrh.android.domain.usecase.ausencia
+
+import com.gestorrh.android.data.network.ausencia.PeticionAusenciaDTO
+import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
+import com.gestorrh.android.domain.repository.IAusenciaRepository
+import java.time.LocalDate
+
+/**
+ * Caso de uso que valida una solicitud de ausencia antes de delegarla al repositorio.
+ *
+ * Las validaciones replican las reglas que el servidor también aplica, pero se ejecutan
+ * en el cliente para evitar viajes de red innecesarios y poder anclar el mensaje de error
+ * al campo concreto del formulario. Si alguna regla falla devuelve [Result.failure] con
+ * un identificador estable en el mensaje (`fechaInicio_pasada`, `fechaFin_anterior`) para
+ * que la capa de presentación pueda traducirlo al recurso de string adecuado.
+ *
+ * Reglas aplicadas:
+ * - `fechaInicio` debe ser hoy o futura.
+ * - `fechaFin` debe ser igual o posterior a `fechaInicio`.
+ *
+ * Si la entrada es válida invoca a [IAusenciaRepository.crearAusencia] reenviando el
+ * justificante opcional sin modificarlo.
+ */
+class SolicitarAusenciaUseCase(
+    private val repository: IAusenciaRepository
+) {
+
+    sealed class ErrorValidacion(mensaje: String) : Exception(mensaje) {
+        data object FechaInicioPasada : ErrorValidacion("fechaInicio_pasada")
+        data object FechaFinAnterior : ErrorValidacion("fechaFin_anterior")
+        data object TipoVacio : ErrorValidacion("tipo_vacio")
+    }
+
+    suspend operator fun invoke(
+        tipo: String?,
+        descripcion: String?,
+        fechaInicio: LocalDate?,
+        fechaFin: LocalDate?,
+        archivoBytes: ByteArray?,
+        nombreArchivo: String?,
+        hoy: LocalDate = LocalDate.now()
+    ): Result<RespuestaAusenciaDTO> {
+        if (tipo.isNullOrBlank()) {
+            return Result.failure(ErrorValidacion.TipoVacio)
+        }
+        if (fechaInicio == null || fechaInicio.isBefore(hoy)) {
+            return Result.failure(ErrorValidacion.FechaInicioPasada)
+        }
+        if (fechaFin == null || fechaFin.isBefore(fechaInicio)) {
+            return Result.failure(ErrorValidacion.FechaFinAnterior)
+        }
+
+        val peticion = PeticionAusenciaDTO(
+            tipo = tipo,
+            descripcion = descripcion?.takeIf { it.isNotBlank() },
+            fechaInicio = fechaInicio,
+            fechaFin = fechaFin
+        )
+        return repository.crearAusencia(peticion, archivoBytes, nombreArchivo)
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiSolicitudAusencia.kt
@@ -1,0 +1,31 @@
+package com.gestorrh.android.ui.ausencia
+
+import android.net.Uri
+import androidx.annotation.StringRes
+import com.gestorrh.android.core.ui.MensajeUi
+import java.time.LocalDate
+
+data class EstadoUiSolicitudAusencia(
+    val tiposDisponibles: List<String> = emptyList(),
+    val cargandoTipos: Boolean = false,
+    val tipoSeleccionado: String? = null,
+    val fechaInicio: LocalDate? = null,
+    val fechaFin: LocalDate? = null,
+    val descripcion: String = "",
+    val archivoUri: Uri? = null,
+    val nombreArchivo: String? = null,
+    val errorTipo: Int? = null,
+    @StringRes val errorFechaInicio: Int? = null,
+    @StringRes val errorFechaFin: Int? = null,
+    @StringRes val avisoJustificante: Int? = null,
+    val enviando: Boolean = false,
+    val mensajeError: MensajeUi? = null,
+    val envioExitoso: Boolean = false
+) {
+    val formularioValido: Boolean
+        get() = !tipoSeleccionado.isNullOrBlank()
+            && fechaInicio != null
+            && fechaFin != null
+            && !fechaFin.isBefore(fechaInicio)
+            && !fechaInicio.isBefore(LocalDate.now())
+}

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
@@ -1,0 +1,342 @@
+package com.gestorrh.android.ui.ausencia
+
+import android.content.Context
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.gestorrh.android.R
+import com.gestorrh.android.core.ui.MensajeUi
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+private val ColorAvisoAmbar = Color(0xFFB26A00)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PantallaSolicitudAusencia(
+    contexto: Context = LocalContext.current,
+    viewModel: SolicitudAusenciaViewModel = viewModel(
+        factory = SolicitudAusenciaViewModel.factory(contexto.applicationContext)
+    ),
+    alVolver: () -> Unit = {},
+    alEnvioExitoso: () -> Unit = {}
+) {
+    val estadoUi by viewModel.estadoUi.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val contextoLocal = LocalContext.current
+    val mensajeExito = stringResource(R.string.ausencia_envio_exitoso)
+
+    val selectorArchivo = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        viewModel.seleccionarArchivo(uri)
+    }
+
+    LaunchedEffect(estadoUi.mensajeError) {
+        estadoUi.mensajeError?.let { mensaje ->
+            val texto = when (mensaje) {
+                is MensajeUi.Recurso -> contextoLocal.getString(mensaje.idRecurso)
+                is MensajeUi.Dinamico -> mensaje.texto
+            }
+            snackbarHostState.showSnackbar(texto, duration = SnackbarDuration.Long)
+            viewModel.errorMostrado()
+        }
+    }
+
+    LaunchedEffect(estadoUi.envioExitoso) {
+        if (estadoUi.envioExitoso) {
+            snackbarHostState.showSnackbar(mensajeExito, duration = SnackbarDuration.Short)
+            viewModel.envioConsumido()
+            alEnvioExitoso()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(stringResource(R.string.ausencia_titulo_pantalla)) })
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            DesplegableTipo(estadoUi, viewModel)
+
+            CampoFecha(
+                etiqueta = stringResource(R.string.ausencia_label_fecha_inicio),
+                fecha = estadoUi.fechaInicio,
+                errorRes = estadoUi.errorFechaInicio,
+                onFechaSeleccionada = viewModel::cambiarFechaInicio,
+                fechaMinima = LocalDate.now()
+            )
+
+            CampoFecha(
+                etiqueta = stringResource(R.string.ausencia_label_fecha_fin),
+                fecha = estadoUi.fechaFin,
+                errorRes = estadoUi.errorFechaFin,
+                onFechaSeleccionada = viewModel::cambiarFechaFin,
+                fechaMinima = estadoUi.fechaInicio ?: LocalDate.now()
+            )
+
+            OutlinedTextField(
+                value = estadoUi.descripcion,
+                onValueChange = viewModel::cambiarDescripcion,
+                label = { Text(stringResource(R.string.ausencia_label_descripcion)) },
+                modifier = Modifier.fillMaxWidth(),
+                minLines = 3,
+                maxLines = 6
+            )
+
+            BotonAdjuntar(
+                nombreArchivo = estadoUi.nombreArchivo,
+                onAdjuntar = { selectorArchivo.launch("*/*") },
+                onQuitar = viewModel::quitarArchivo
+            )
+
+            estadoUi.avisoJustificante?.let { idAviso ->
+                Text(
+                    text = stringResource(idAviso),
+                    color = ColorAvisoAmbar,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            Button(
+                onClick = viewModel::enviar,
+                enabled = estadoUi.formularioValido && !estadoUi.enviando,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (estadoUi.enviando) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                } else {
+                    Text(stringResource(R.string.ausencia_btn_enviar))
+                }
+            }
+
+            OutlinedButton(
+                onClick = alVolver,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = !estadoUi.enviando
+            ) {
+                Text(stringResource(R.string.ausencia_btn_cancelar))
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DesplegableTipo(
+    estadoUi: EstadoUiSolicitudAusencia,
+    viewModel: SolicitudAusenciaViewModel
+) {
+    var expandido by remember { mutableStateOf(false) }
+    Box(modifier = Modifier.fillMaxWidth()) {
+        OutlinedTextField(
+            value = estadoUi.tipoSeleccionado?.let { etiquetaTipo(it) }
+                ?: if (estadoUi.cargandoTipos) stringResource(R.string.ausencia_cargando_tipos) else "",
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(stringResource(R.string.ausencia_label_tipo)) },
+            trailingIcon = {
+                IconButton(onClick = {
+                    if (estadoUi.tiposDisponibles.isNotEmpty()) expandido = true
+                }) {
+                    Icon(Icons.Filled.ArrowDropDown, contentDescription = null)
+                }
+            },
+            isError = estadoUi.errorTipo != null,
+            supportingText = {
+                estadoUi.errorTipo?.let { Text(stringResource(it)) }
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+        DropdownMenu(
+            expanded = expandido,
+            onDismissRequest = { expandido = false }
+        ) {
+            estadoUi.tiposDisponibles.forEach { tipo ->
+                DropdownMenuItem(
+                    text = { Text(etiquetaTipo(tipo)) },
+                    onClick = {
+                        viewModel.seleccionarTipo(tipo)
+                        expandido = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CampoFecha(
+    etiqueta: String,
+    fecha: LocalDate?,
+    errorRes: Int?,
+    onFechaSeleccionada: (LocalDate) -> Unit,
+    fechaMinima: LocalDate
+) {
+    var mostrandoSelector by remember { mutableStateOf(false) }
+    val texto = fecha?.format(SolicitudAusenciaViewModel.FORMATO_FECHA) ?: ""
+
+    OutlinedTextField(
+        value = texto,
+        onValueChange = {},
+        readOnly = true,
+        label = { Text(etiqueta) },
+        trailingIcon = {
+            IconButton(onClick = { mostrandoSelector = true }) {
+                Icon(Icons.Filled.DateRange, contentDescription = etiqueta)
+            }
+        },
+        isError = errorRes != null,
+        supportingText = {
+            errorRes?.let { Text(stringResource(it)) }
+        },
+        modifier = Modifier.fillMaxWidth()
+    )
+
+    if (mostrandoSelector) {
+        val estadoPicker = rememberDatePickerState(
+            initialSelectedDateMillis = (fecha ?: fechaMinima)
+                .atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        )
+        DatePickerDialog(
+            onDismissRequest = { mostrandoSelector = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    estadoPicker.selectedDateMillis?.let { millis ->
+                        val fechaSeleccionada = Instant.ofEpochMilli(millis)
+                            .atZone(ZoneId.of("UTC"))
+                            .toLocalDate()
+                        onFechaSeleccionada(fechaSeleccionada)
+                    }
+                    mostrandoSelector = false
+                }) {
+                    Text(stringResource(R.string.ausencia_dialog_aceptar))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { mostrandoSelector = false }) {
+                    Text(stringResource(R.string.ausencia_dialog_cancelar))
+                }
+            }
+        ) {
+            DatePicker(state = estadoPicker)
+        }
+    }
+}
+
+@Composable
+private fun BotonAdjuntar(
+    nombreArchivo: String?,
+    onAdjuntar: () -> Unit,
+    onQuitar: () -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        OutlinedButton(
+            onClick = onAdjuntar,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(Icons.Filled.AttachFile, contentDescription = null)
+            Spacer(Modifier.size(8.dp))
+            Text(stringResource(R.string.ausencia_btn_adjuntar))
+        }
+        if (nombreArchivo != null) {
+            Box(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = nombreArchivo,
+                    modifier = Modifier
+                        .align(Alignment.CenterStart)
+                        .padding(end = 40.dp),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.Medium
+                )
+                IconButton(
+                    onClick = onQuitar,
+                    modifier = Modifier.align(Alignment.CenterEnd)
+                ) {
+                    Icon(
+                        Icons.Filled.Close,
+                        contentDescription = stringResource(R.string.ausencia_cd_quitar_archivo)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun etiquetaTipo(tipo: String): String {
+    val resId = when (tipo) {
+        "MEDICA" -> R.string.ausencia_tipo_medica
+        "VACACIONES" -> R.string.ausencia_tipo_vacaciones
+        "MOTIVO_PERSONAL" -> R.string.ausencia_tipo_motivo_personal
+        "OTROS" -> R.string.ausencia_tipo_otros
+        else -> null
+    }
+    return resId?.let { stringResource(it) } ?: tipo
+}

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
@@ -1,0 +1,275 @@
+package com.gestorrh.android.ui.ausencia
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.gestorrh.android.R
+import com.gestorrh.android.core.network.ApiClient
+import com.gestorrh.android.core.security.SessionManager
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.ausencia.AusenciaApiService
+import com.gestorrh.android.data.repository.ausencia.AusenciaRepositoryImpl
+import com.gestorrh.android.domain.repository.IAusenciaRepository
+import com.gestorrh.android.domain.usecase.ausencia.SolicitarAusenciaUseCase
+import com.google.gson.GsonBuilder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.IOException
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+/**
+ * ViewModel del formulario de solicitud de ausencia.
+ *
+ * Mantiene en un único [StateFlow] de [EstadoUiSolicitudAusencia] todo el estado
+ * del formulario, incluida la lista de tipos cargada desde `GET /api/ausencias/tipos`,
+ * los valores actuales de los campos, los errores inline por campo y el resultado del
+ * envío. La pantalla solo emite eventos: la lógica de validación, la conversión del
+ * `Uri` adjunto a bytes y la construcción del `multipart` viven aquí o en el UseCase.
+ *
+ * Bloquea reentradas en [enviar] mediante el flag `enviando` para evitar el doble envío
+ * por doble clic, y traduce los errores de validación del UseCase a recursos de string
+ * para que la pantalla los muestre directamente con `stringResource`.
+ *
+ * @param ausenciaRepository Acceso a los endpoints de ausencias.
+ * @param solicitarAusenciaUseCase Encapsula validaciones locales y la llamada al repositorio.
+ * @param contextoAplicacion Contexto de aplicación para resolver el `ContentResolver` al
+ *        leer el `Uri` del justificante. Solo se usa para esta operación de I/O.
+ */
+class SolicitudAusenciaViewModel(
+    private val ausenciaRepository: IAusenciaRepository,
+    private val solicitarAusenciaUseCase: SolicitarAusenciaUseCase,
+    private val contextoAplicacion: Context
+) : ViewModel() {
+
+    private val _estadoUi = MutableStateFlow(EstadoUiSolicitudAusencia())
+    val estadoUi: StateFlow<EstadoUiSolicitudAusencia> = _estadoUi.asStateFlow()
+
+    init {
+        cargarTipos()
+    }
+
+    fun cargarTipos() {
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(cargandoTipos = true) }
+            ausenciaRepository.obtenerTipos()
+                .onSuccess { lista ->
+                    _estadoUi.update { it.copy(cargandoTipos = false, tiposDisponibles = lista) }
+                }
+                .onFailure { error ->
+                    _estadoUi.update {
+                        it.copy(
+                            cargandoTipos = false,
+                            mensajeError = if (error is IOException) {
+                                MensajeUi.Recurso(R.string.error_conexion)
+                            } else {
+                                MensajeUi.Dinamico(error.message ?: "")
+                            }
+                        )
+                    }
+                }
+        }
+    }
+
+    fun seleccionarTipo(tipo: String) {
+        _estadoUi.update {
+            it.copy(
+                tipoSeleccionado = tipo,
+                errorTipo = null,
+                avisoJustificante = calcularAviso(tipo, it.archivoUri != null)
+            )
+        }
+    }
+
+    fun cambiarFechaInicio(fecha: LocalDate) {
+        _estadoUi.update {
+            val errorInicio = if (fecha.isBefore(LocalDate.now())) {
+                R.string.ausencia_error_fecha_inicio_pasada
+            } else {
+                null
+            }
+            val errorFin = if (it.fechaFin != null && it.fechaFin.isBefore(fecha)) {
+                R.string.ausencia_error_fecha_fin_anterior
+            } else {
+                null
+            }
+            it.copy(fechaInicio = fecha, errorFechaInicio = errorInicio, errorFechaFin = errorFin)
+        }
+    }
+
+    fun cambiarFechaFin(fecha: LocalDate) {
+        _estadoUi.update {
+            val errorFin = if (it.fechaInicio != null && fecha.isBefore(it.fechaInicio)) {
+                R.string.ausencia_error_fecha_fin_anterior
+            } else {
+                null
+            }
+            it.copy(fechaFin = fecha, errorFechaFin = errorFin)
+        }
+    }
+
+    fun cambiarDescripcion(texto: String) {
+        _estadoUi.update { it.copy(descripcion = texto) }
+    }
+
+    fun seleccionarArchivo(uri: Uri?) {
+        viewModelScope.launch {
+            val nombre = uri?.let { obtenerNombreArchivo(it) }
+            _estadoUi.update {
+                it.copy(
+                    archivoUri = uri,
+                    nombreArchivo = nombre,
+                    avisoJustificante = calcularAviso(it.tipoSeleccionado, uri != null)
+                )
+            }
+        }
+    }
+
+    fun quitarArchivo() {
+        _estadoUi.update {
+            it.copy(
+                archivoUri = null,
+                nombreArchivo = null,
+                avisoJustificante = calcularAviso(it.tipoSeleccionado, false)
+            )
+        }
+    }
+
+    fun errorMostrado() {
+        _estadoUi.update { it.copy(mensajeError = null) }
+    }
+
+    fun envioConsumido() {
+        _estadoUi.update { it.copy(envioExitoso = false) }
+    }
+
+    fun enviar() {
+        val estadoActual = _estadoUi.value
+        if (estadoActual.enviando) return
+
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(enviando = true, mensajeError = null) }
+
+            val archivoBytes = estadoActual.archivoUri?.let { leerBytes(it) }
+
+            val resultado = solicitarAusenciaUseCase(
+                tipo = estadoActual.tipoSeleccionado,
+                descripcion = estadoActual.descripcion,
+                fechaInicio = estadoActual.fechaInicio,
+                fechaFin = estadoActual.fechaFin,
+                archivoBytes = archivoBytes,
+                nombreArchivo = estadoActual.nombreArchivo
+            )
+
+            resultado
+                .onSuccess {
+                    _estadoUi.update {
+                        it.copy(enviando = false, envioExitoso = true)
+                    }
+                }
+                .onFailure { error ->
+                    when (error) {
+                        SolicitarAusenciaUseCase.ErrorValidacion.FechaInicioPasada ->
+                            _estadoUi.update {
+                                it.copy(
+                                    enviando = false,
+                                    errorFechaInicio = R.string.ausencia_error_fecha_inicio_pasada
+                                )
+                            }
+                        SolicitarAusenciaUseCase.ErrorValidacion.FechaFinAnterior ->
+                            _estadoUi.update {
+                                it.copy(
+                                    enviando = false,
+                                    errorFechaFin = R.string.ausencia_error_fecha_fin_anterior
+                                )
+                            }
+                        SolicitarAusenciaUseCase.ErrorValidacion.TipoVacio ->
+                            _estadoUi.update {
+                                it.copy(
+                                    enviando = false,
+                                    errorTipo = R.string.ausencia_error_tipo_vacio
+                                )
+                            }
+                        is IOException ->
+                            _estadoUi.update {
+                                it.copy(
+                                    enviando = false,
+                                    mensajeError = MensajeUi.Recurso(R.string.error_conexion)
+                                )
+                            }
+                        else ->
+                            _estadoUi.update {
+                                it.copy(
+                                    enviando = false,
+                                    mensajeError = MensajeUi.Dinamico(
+                                        error.message ?: ""
+                                    )
+                                )
+                            }
+                    }
+                }
+        }
+    }
+
+    private fun calcularAviso(tipo: String?, hayArchivo: Boolean): Int? {
+        return if (tipo == "MEDICA" && !hayArchivo) {
+            R.string.ausencia_aviso_justificante_medica
+        } else {
+            null
+        }
+    }
+
+    private suspend fun leerBytes(uri: Uri): ByteArray? = withContext(Dispatchers.IO) {
+        try {
+            contextoAplicacion.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private suspend fun obtenerNombreArchivo(uri: Uri): String? = withContext(Dispatchers.IO) {
+        try {
+            contextoAplicacion.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                val indice = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (indice >= 0 && cursor.moveToFirst()) cursor.getString(indice) else null
+            } ?: uri.lastPathSegment
+        } catch (e: Exception) {
+            uri.lastPathSegment
+        }
+    }
+
+    companion object {
+        val FORMATO_FECHA: DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+
+        fun factory(contexto: Context): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val sessionManager = SessionManager(contexto)
+                    val retrofit = ApiClient.crearRetrofit(sessionManager)
+                    val apiService = retrofit.create(AusenciaApiService::class.java)
+                    val gson = GsonBuilder()
+                        .registerTypeAdapter(
+                            LocalDate::class.java,
+                            com.google.gson.JsonSerializer<LocalDate> { src, _, _ ->
+                                com.google.gson.JsonPrimitive(
+                                    src.format(DateTimeFormatter.ISO_LOCAL_DATE)
+                                )
+                            }
+                        )
+                        .create()
+                    val repository = AusenciaRepositoryImpl(apiService, gson)
+                    val useCase = SolicitarAusenciaUseCase(repository)
+                    return SolicitudAusenciaViewModel(repository, useCase, contexto) as T
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.gestorrh.android.core.navigation.BarraNavegacionInferior
 import com.gestorrh.android.core.navigation.RutasDestino
+import com.gestorrh.android.ui.ausencia.PantallaSolicitudAusencia
 import com.gestorrh.android.ui.dashboard.PantallaDashboard
 import com.gestorrh.android.ui.perfil.PantallaPerfil
 import com.gestorrh.android.ui.turnos.PantallaMisTurnos
@@ -58,7 +59,20 @@ fun PantallaPrincipal(
             }
 
             composable(RutasDestino.Ausencias.ruta) {
-                // TODO: P1-03 -> Solicitud de Ausencias
+                PantallaSolicitudAusencia(
+                    alVolver = {
+                        controladorNavegacionInterno.navigate(RutasDestino.Inicio.ruta) {
+                            popUpTo(RutasDestino.Inicio.ruta) { inclusive = false }
+                            launchSingleTop = true
+                        }
+                    },
+                    alEnvioExitoso = {
+                        controladorNavegacionInterno.navigate(RutasDestino.Inicio.ruta) {
+                            popUpTo(RutasDestino.Inicio.ruta) { inclusive = false }
+                            launchSingleTop = true
+                        }
+                    }
+                )
             }
 
             composable(RutasDestino.Perfil.ruta) {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -87,4 +87,27 @@
     <string name="turnos_detalle_horario">Hours</string>
     <string name="turnos_detalle_modalidad">Mode</string>
     <string name="turnos_sin_conexion">Offline — showing saved data</string>
+
+    <!-- Time Off Request Screen -->
+    <string name="ausencia_titulo_pantalla">Request time off</string>
+    <string name="ausencia_label_tipo">Time off type</string>
+    <string name="ausencia_cargando_tipos">Loading types…</string>
+    <string name="ausencia_label_fecha_inicio">Start date</string>
+    <string name="ausencia_label_fecha_fin">End date</string>
+    <string name="ausencia_label_descripcion">Description (optional)</string>
+    <string name="ausencia_btn_adjuntar">Attach supporting document</string>
+    <string name="ausencia_cd_quitar_archivo">Remove attachment</string>
+    <string name="ausencia_btn_enviar">Submit request</string>
+    <string name="ausencia_btn_cancelar">Cancel</string>
+    <string name="ausencia_dialog_aceptar">OK</string>
+    <string name="ausencia_dialog_cancelar">Cancel</string>
+    <string name="ausencia_envio_exitoso">Request sent successfully</string>
+    <string name="ausencia_error_tipo_vacio">Select a time off type</string>
+    <string name="ausencia_error_fecha_inicio_pasada">Start date cannot be in the past</string>
+    <string name="ausencia_error_fecha_fin_anterior">End date cannot be earlier than the start date</string>
+    <string name="ausencia_aviso_justificante_medica">We recommend attaching a supporting document for medical leaves</string>
+    <string name="ausencia_tipo_medica">Medical</string>
+    <string name="ausencia_tipo_vacaciones">Vacation</string>
+    <string name="ausencia_tipo_motivo_personal">Personal reason</string>
+    <string name="ausencia_tipo_otros">Other</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,4 +87,27 @@
     <string name="turnos_detalle_horario">Horario</string>
     <string name="turnos_detalle_modalidad">Modalidad</string>
     <string name="turnos_sin_conexion">Sin conexión — mostrando datos guardados</string>
+
+    <!-- Pantalla Solicitud de Ausencia -->
+    <string name="ausencia_titulo_pantalla">Solicitar ausencia</string>
+    <string name="ausencia_label_tipo">Tipo de ausencia</string>
+    <string name="ausencia_cargando_tipos">Cargando tipos…</string>
+    <string name="ausencia_label_fecha_inicio">Fecha de inicio</string>
+    <string name="ausencia_label_fecha_fin">Fecha de fin</string>
+    <string name="ausencia_label_descripcion">Descripción (opcional)</string>
+    <string name="ausencia_btn_adjuntar">Adjuntar justificante</string>
+    <string name="ausencia_cd_quitar_archivo">Quitar archivo adjunto</string>
+    <string name="ausencia_btn_enviar">Enviar solicitud</string>
+    <string name="ausencia_btn_cancelar">Cancelar</string>
+    <string name="ausencia_dialog_aceptar">Aceptar</string>
+    <string name="ausencia_dialog_cancelar">Cancelar</string>
+    <string name="ausencia_envio_exitoso">Solicitud enviada correctamente</string>
+    <string name="ausencia_error_tipo_vacio">Selecciona un tipo de ausencia</string>
+    <string name="ausencia_error_fecha_inicio_pasada">La fecha de inicio no puede ser anterior a hoy</string>
+    <string name="ausencia_error_fecha_fin_anterior">La fecha de fin no puede ser anterior a la de inicio</string>
+    <string name="ausencia_aviso_justificante_medica">Recomendamos adjuntar un justificante para ausencias médicas</string>
+    <string name="ausencia_tipo_medica">Médica</string>
+    <string name="ausencia_tipo_vacaciones">Vacaciones</string>
+    <string name="ausencia_tipo_motivo_personal">Motivo personal</string>
+    <string name="ausencia_tipo_otros">Otros</string>
 </resources>


### PR DESCRIPTION
Closes #13

## Resumen
- Nueva pantalla `PantallaSolicitudAusencia` accesible desde la pestaña Ausencias del BottomNavigationBar.
- Capa de red (`AusenciaApiService`) con `POST /api/ausencias` (`multipart/form-data`) y `GET /api/ausencias/tipos`; DTOs `PeticionAusenciaDTO` y `RespuestaAusenciaDTO` siguiendo el contrato del Swagger.
- Repositorio `AusenciaRepositoryImpl` que serializa la parte JSON `datos` con Gson y adjunta opcionalmente la parte binaria `archivo`.
- `SolicitarAusenciaUseCase` con validaciones locales (`fechaInicio` no pasada, `fechaFin >= fechaInicio`) que devuelven errores tipados para mostrar mensajes específicos por campo.
- `SolicitudAusenciaViewModel` con Factory manual, carga dinámica de tipos, gestión del Uri del justificante y bloqueo del envío durante la petición para evitar dobles clics.
- Mensajes de error inline por campo, aviso ámbar no bloqueante cuando el tipo es `MEDICA` sin justificante y feedback de éxito por Snackbar antes de volver a la pantalla anterior.
- Strings nuevos en `values/strings.xml` y `values-en/strings.xml`.

## Test plan
- [ ] Abrir la pestaña "Ausencias" y comprobar que el desplegable carga los tipos desde `GET /api/ausencias/tipos`.
- [ ] Intentar seleccionar una `fechaInicio` anterior a hoy → mensaje inline de error.
- [ ] Seleccionar `fechaFin` anterior a `fechaInicio` → mensaje inline en el campo de fin.
- [ ] Adjuntar un archivo desde el selector del sistema y comprobar que aparece su nombre con opción de eliminarlo.
- [ ] Seleccionar tipo `MEDICA` sin adjuntar nada → ver aviso ámbar (no bloquea el envío).
- [ ] Enviar una solicitud válida → Snackbar de éxito y vuelta a la pantalla previa.
- [ ] Enviar pulsando dos veces seguidas → confirmar que solo se dispara una petición.
- [ ] Forzar respuesta 400 del backend → Snackbar con el `message` recibido.