### PR TITLE
feat: pantalla listado mis ausencias con refresco automático (#14)

### DIFF
--- a/app/src/main/java/com/gestorrh/android/core/navigation/RutasDestino.kt
+++ b/app/src/main/java/com/gestorrh/android/core/navigation/RutasDestino.kt
@@ -26,4 +26,12 @@ sealed class RutasDestino(
     data object Ausencias : RutasDestino("ausencias", R.string.nav_ausencias, Icons.Filled.EventBusy)
     data object Perfil : RutasDestino("perfil", R.string.nav_perfil, Icons.Filled.Person)
     data object GestionEquipo : RutasDestino("equipo", R.string.nav_equipo, Icons.Filled.Group)
+
+    /**
+     * Destino interno para el formulario de solicitud de ausencia. No aparece en la
+     * barra de navegación inferior: se alcanza desde el FAB de [Ausencias] y vuelve
+     * a ese destino tras enviar o cancelar.
+     */
+    data object SolicitarAusencia :
+        RutasDestino("ausencias/solicitar", R.string.nav_ausencias, Icons.Filled.EventBusy)
 }

--- a/app/src/main/java/com/gestorrh/android/data/network/ausencia/AusenciaApiService.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/ausencia/AusenciaApiService.kt
@@ -6,6 +6,7 @@ import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
+import retrofit2.http.Query
 
 interface AusenciaApiService {
 
@@ -18,4 +19,9 @@ interface AusenciaApiService {
 
     @GET("api/ausencias/tipos")
     suspend fun getTiposAusencia(): Response<List<String>>
+
+    @GET("api/ausencias/me")
+    suspend fun getMisAusencias(
+        @Query("estado") estado: String? = null
+    ): Response<List<RespuestaAusenciaDTO>>
 }

--- a/app/src/main/java/com/gestorrh/android/data/repository/ausencia/AusenciaRepositoryImpl.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/ausencia/AusenciaRepositoryImpl.kt
@@ -78,6 +78,27 @@ class AusenciaRepositoryImpl(
         }
     }
 
+    override suspend fun obtenerMisAusencias(estado: String?): Result<List<RespuestaAusenciaDTO>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val respuesta = apiService.getMisAusencias(estado)
+                if (respuesta.isSuccessful && respuesta.body() != null) {
+                    Result.success(respuesta.body()!!)
+                } else {
+                    Result.failure(
+                        Exception(
+                            extraerMensajeError(respuesta.errorBody())
+                                ?: "Error ${respuesta.code()} al obtener las ausencias"
+                        )
+                    )
+                }
+            } catch (e: IOException) {
+                Result.failure(e)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
     private fun extraerMensajeError(errorBody: ResponseBody?): String? {
         return try {
             val json = errorBody?.string() ?: return null

--- a/app/src/main/java/com/gestorrh/android/domain/repository/IAusenciaRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/IAusenciaRepository.kt
@@ -36,4 +36,13 @@ interface IAusenciaRepository {
         archivoBytes: ByteArray?,
         nombreArchivo: String?
     ): Result<RespuestaAusenciaDTO>
+
+    /**
+     * Recupera las solicitudes de ausencia del empleado autenticado desde
+     * `GET /api/ausencias/me`, admitiendo un filtro opcional por [estado].
+     *
+     * @param estado Valor del enum `EstadoAusencia` (`SOLICITADA`, `APROBADA`, `RECHAZADA`) o
+     *        `null` para recuperar todas.
+     */
+    suspend fun obtenerMisAusencias(estado: String? = null): Result<List<RespuestaAusenciaDTO>>
 }

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiMisAusencias.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiMisAusencias.kt
@@ -1,0 +1,19 @@
+package com.gestorrh.android.ui.ausencia
+
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
+
+/**
+ * Estado inmutable que consume la pantalla [PantallaMisAusencias].
+ *
+ * @property cargando `true` mientras hay una petición en vuelo — la UI muestra el
+ *           indicador de progreso centrado cuando la lista aún no se ha cargado.
+ * @property ausencias Listado de solicitudes del empleado autenticado tal como llega de
+ *           `GET /api/ausencias/me` (el servidor ya aplica el orden deseado).
+ * @property mensajeError Error a mostrar en el Snackbar o `null` si no hay error pendiente.
+ */
+data class EstadoUiMisAusencias(
+    val cargando: Boolean = false,
+    val ausencias: List<RespuestaAusenciaDTO> = emptyList(),
+    val mensajeError: MensajeUi? = null
+)

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/MisAusenciasViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/MisAusenciasViewModel.kt
@@ -1,0 +1,83 @@
+package com.gestorrh.android.ui.ausencia
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.gestorrh.android.R
+import com.gestorrh.android.core.network.ApiClient
+import com.gestorrh.android.core.security.SessionManager
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.ausencia.AusenciaApiService
+import com.gestorrh.android.data.repository.ausencia.AusenciaRepositoryImpl
+import com.gestorrh.android.domain.repository.IAusenciaRepository
+import com.google.gson.Gson
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.io.IOException
+
+/**
+ * ViewModel del listado "Mis ausencias".
+ *
+ * Expone un único [StateFlow] de [EstadoUiMisAusencias] con el listado de solicitudes
+ * del empleado autenticado leído desde `GET /api/ausencias/me`. La pantalla invoca
+ * [cargarAusencias] tanto al producirse el evento `Lifecycle.Event.ON_RESUME` (para
+ * refrescar al regresar de la pantalla de solicitud de P1-03) como al gesto de
+ * pull-to-refresh.
+ *
+ * La petición se ejecuta en `Dispatchers.IO` dentro del repositorio, por lo que el
+ * ViewModel solo orquesta el lanzamiento en [viewModelScope] y mantiene el flag
+ * `cargando` para que la UI pueda distinguir entre carga inicial y refresco manual.
+ *
+ * @param ausenciaRepository Acceso al endpoint de listado de ausencias propias.
+ */
+class MisAusenciasViewModel(
+    private val ausenciaRepository: IAusenciaRepository
+) : ViewModel() {
+
+    private val _estadoUi = MutableStateFlow(EstadoUiMisAusencias())
+    val estadoUi: StateFlow<EstadoUiMisAusencias> = _estadoUi.asStateFlow()
+
+    fun cargarAusencias() {
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(cargando = true, mensajeError = null) }
+            ausenciaRepository.obtenerMisAusencias()
+                .onSuccess { lista ->
+                    _estadoUi.update { it.copy(cargando = false, ausencias = lista) }
+                }
+                .onFailure { error ->
+                    _estadoUi.update {
+                        it.copy(
+                            cargando = false,
+                            mensajeError = if (error is IOException) {
+                                MensajeUi.Recurso(R.string.error_conexion)
+                            } else {
+                                MensajeUi.Dinamico(error.message ?: "")
+                            }
+                        )
+                    }
+                }
+        }
+    }
+
+    fun errorMostrado() {
+        _estadoUi.update { it.copy(mensajeError = null) }
+    }
+
+    companion object {
+        fun factory(contexto: Context): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val sessionManager = SessionManager(contexto)
+                    val retrofit = ApiClient.crearRetrofit(sessionManager)
+                    val apiService = retrofit.create(AusenciaApiService::class.java)
+                    val repository = AusenciaRepositoryImpl(apiService, Gson())
+                    return MisAusenciasViewModel(repository) as T
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
@@ -1,0 +1,296 @@
+package com.gestorrh.android.ui.ausencia
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.EventBusy
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.gestorrh.android.R
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
+import java.time.format.DateTimeFormatter
+
+private val ColorEstadoSolicitada = Color(0xFFF57C00)
+private val ColorEstadoAprobada = Color(0xFF2E7D32)
+private val ColorEstadoRechazada = Color(0xFFD32F2F)
+
+private val FormatoFecha: DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PantallaMisAusencias(
+    contexto: Context = LocalContext.current,
+    viewModel: MisAusenciasViewModel = viewModel(
+        factory = MisAusenciasViewModel.factory(contexto.applicationContext)
+    ),
+    alSolicitarNueva: () -> Unit = {}
+) {
+    val estadoUi by viewModel.estadoUi.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val contextoLocal = LocalContext.current
+    val propietarioCicloVida = LocalLifecycleOwner.current
+
+    DisposableEffect(propietarioCicloVida) {
+        val observador = LifecycleEventObserver { _, evento ->
+            if (evento == Lifecycle.Event.ON_RESUME) {
+                viewModel.cargarAusencias()
+            }
+        }
+        propietarioCicloVida.lifecycle.addObserver(observador)
+        onDispose { propietarioCicloVida.lifecycle.removeObserver(observador) }
+    }
+
+    val textoReintentar = stringResource(R.string.mis_ausencias_reintentar)
+
+    LaunchedEffect(estadoUi.mensajeError) {
+        estadoUi.mensajeError?.let { mensaje ->
+            val texto = when (mensaje) {
+                is MensajeUi.Recurso -> contextoLocal.getString(mensaje.idRecurso)
+                is MensajeUi.Dinamico -> mensaje.texto
+            }
+            val resultado = snackbarHostState.showSnackbar(
+                message = texto,
+                actionLabel = textoReintentar,
+                duration = SnackbarDuration.Long
+            )
+            viewModel.errorMostrado()
+            if (resultado == SnackbarResult.ActionPerformed) {
+                viewModel.cargarAusencias()
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(stringResource(R.string.mis_ausencias_titulo)) })
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = alSolicitarNueva) {
+                Icon(
+                    imageVector = Icons.Filled.Add,
+                    contentDescription = stringResource(R.string.mis_ausencias_cd_nueva)
+                )
+            }
+        }
+    ) { padding ->
+        PullToRefreshBox(
+            isRefreshing = estadoUi.cargando && estadoUi.ausencias.isNotEmpty(),
+            onRefresh = { viewModel.cargarAusencias() },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            when {
+                estadoUi.cargando && estadoUi.ausencias.isEmpty() -> IndicadorCargando()
+                estadoUi.ausencias.isEmpty() -> EstadoVacio()
+                else -> ListaAusencias(
+                    ausencias = estadoUi.ausencias,
+                    padding = PaddingValues(16.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun IndicadorCargando() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun EstadoVacio() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.EventBusy,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier
+                .padding(bottom = 16.dp)
+                .height(72.dp)
+                .fillMaxWidth()
+        )
+        Text(
+            text = stringResource(R.string.mis_ausencias_vacio_titulo),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.mis_ausencias_vacio_descripcion),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun ListaAusencias(
+    ausencias: List<RespuestaAusenciaDTO>,
+    padding: PaddingValues
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = padding,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        items(ausencias, key = { it.idAusencia }) { ausencia ->
+            TarjetaAusencia(ausencia)
+        }
+    }
+}
+
+@Composable
+private fun TarjetaAusencia(ausencia: RespuestaAusenciaDTO) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = etiquetaTipoAusencia(ausencia.tipo),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f)
+                )
+                ChipEstado(estado = ausencia.estado)
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(
+                    R.string.mis_ausencias_rango_fechas,
+                    ausencia.fechaInicio.format(FormatoFecha),
+                    ausencia.fechaFin.format(FormatoFecha)
+                ),
+                style = MaterialTheme.typography.bodyMedium
+            )
+
+            if (!ausencia.descripcion.isNullOrBlank()) {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = ausencia.descripcion,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            if (!ausencia.motivoRechazo.isNullOrBlank()) {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringResource(
+                        R.string.mis_ausencias_observaciones,
+                        ausencia.motivoRechazo
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChipEstado(estado: String) {
+    val color = when (estado) {
+        "SOLICITADA" -> ColorEstadoSolicitada
+        "APROBADA" -> ColorEstadoAprobada
+        "RECHAZADA" -> ColorEstadoRechazada
+        else -> MaterialTheme.colorScheme.outline
+    }
+    Box(
+        modifier = Modifier
+            .background(color = color, shape = RoundedCornerShape(50))
+            .padding(horizontal = 12.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = etiquetaEstado(estado),
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+private fun etiquetaEstado(estado: String): String {
+    val resId = when (estado) {
+        "SOLICITADA" -> R.string.mis_ausencias_estado_solicitada
+        "APROBADA" -> R.string.mis_ausencias_estado_aprobada
+        "RECHAZADA" -> R.string.mis_ausencias_estado_rechazada
+        else -> null
+    }
+    return resId?.let { stringResource(it) } ?: estado
+}
+
+@Composable
+private fun etiquetaTipoAusencia(tipo: String): String {
+    val resId = when (tipo) {
+        "MEDICA" -> R.string.ausencia_tipo_medica
+        "VACACIONES" -> R.string.ausencia_tipo_vacaciones
+        "MOTIVO_PERSONAL" -> R.string.ausencia_tipo_motivo_personal
+        "OTROS" -> R.string.ausencia_tipo_otros
+        else -> null
+    }
+    return resId?.let { stringResource(it) } ?: tipo
+}
+

--- a/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.gestorrh.android.core.navigation.BarraNavegacionInferior
 import com.gestorrh.android.core.navigation.RutasDestino
+import com.gestorrh.android.ui.ausencia.PantallaMisAusencias
 import com.gestorrh.android.ui.ausencia.PantallaSolicitudAusencia
 import com.gestorrh.android.ui.dashboard.PantallaDashboard
 import com.gestorrh.android.ui.perfil.PantallaPerfil
@@ -59,18 +60,28 @@ fun PantallaPrincipal(
             }
 
             composable(RutasDestino.Ausencias.ruta) {
+                PantallaMisAusencias(
+                    alSolicitarNueva = {
+                        controladorNavegacionInterno.navigate(RutasDestino.SolicitarAusencia.ruta) {
+                            launchSingleTop = true
+                        }
+                    }
+                )
+            }
+
+            composable(RutasDestino.SolicitarAusencia.ruta) {
                 PantallaSolicitudAusencia(
                     alVolver = {
-                        controladorNavegacionInterno.navigate(RutasDestino.Inicio.ruta) {
-                            popUpTo(RutasDestino.Inicio.ruta) { inclusive = false }
-                            launchSingleTop = true
-                        }
+                        controladorNavegacionInterno.popBackStack(
+                            route = RutasDestino.Ausencias.ruta,
+                            inclusive = false
+                        )
                     },
                     alEnvioExitoso = {
-                        controladorNavegacionInterno.navigate(RutasDestino.Inicio.ruta) {
-                            popUpTo(RutasDestino.Inicio.ruta) { inclusive = false }
-                            launchSingleTop = true
-                        }
+                        controladorNavegacionInterno.popBackStack(
+                            route = RutasDestino.Ausencias.ruta,
+                            inclusive = false
+                        )
                     }
                 )
             }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -110,4 +110,18 @@
     <string name="ausencia_tipo_vacaciones">Vacation</string>
     <string name="ausencia_tipo_motivo_personal">Personal reason</string>
     <string name="ausencia_tipo_otros">Other</string>
+
+    <!-- My Time Off Screen -->
+    <string name="mis_ausencias_titulo">My time off</string>
+    <string name="mis_ausencias_cd_nueva">Request new time off</string>
+    <string name="mis_ausencias_reintentar">Retry</string>
+    <string name="mis_ausencias_vacio_titulo">No time off requests yet</string>
+    <string name="mis_ausencias_vacio_descripcion">When you request time off it will appear here with its current status.</string>
+    <!-- %1$s = start date, %2$s = end date -->
+    <string name="mis_ausencias_rango_fechas">%1$s → %2$s</string>
+    <!-- %1$s = review notes provided by the supervisor -->
+    <string name="mis_ausencias_observaciones">Notes: %1$s</string>
+    <string name="mis_ausencias_estado_solicitada">PENDING</string>
+    <string name="mis_ausencias_estado_aprobada">APPROVED</string>
+    <string name="mis_ausencias_estado_rechazada">REJECTED</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,4 +110,18 @@
     <string name="ausencia_tipo_vacaciones">Vacaciones</string>
     <string name="ausencia_tipo_motivo_personal">Motivo personal</string>
     <string name="ausencia_tipo_otros">Otros</string>
+
+    <!-- Pantalla Mis Ausencias -->
+    <string name="mis_ausencias_titulo">Mis ausencias</string>
+    <string name="mis_ausencias_cd_nueva">Solicitar nueva ausencia</string>
+    <string name="mis_ausencias_reintentar">Reintentar</string>
+    <string name="mis_ausencias_vacio_titulo">No tienes solicitudes de ausencia</string>
+    <string name="mis_ausencias_vacio_descripcion">Cuando solicites una ausencia aparecerá aquí con su estado actual.</string>
+    <!-- %1$s = fecha inicio, %2$s = fecha fin -->
+    <string name="mis_ausencias_rango_fechas">%1$s → %2$s</string>
+    <!-- %1$s = observaciones de la revisión devueltas por el supervisor -->
+    <string name="mis_ausencias_observaciones">Observaciones: %1$s</string>
+    <string name="mis_ausencias_estado_solicitada">SOLICITADA</string>
+    <string name="mis_ausencias_estado_aprobada">APROBADA</string>
+    <string name="mis_ausencias_estado_rechazada">RECHAZADA</string>
 </resources>


### PR DESCRIPTION
Closes #14

## Resumen
- Pantalla "Mis ausencias" con `LazyColumn` de tarjetas que muestra tipo, rango de fechas, descripción (si existe), chip de estado con los colores del Design System (`SOLICITADA` #F57C00, `APROBADA` #2E7D32, `RECHAZADA` #D32F2F) y las observaciones de la revisión cuando las hay.
- Refresco automático al retomar la pantalla mediante `DisposableEffect` que observa `Lifecycle.Event.ON_RESUME` — equivalente al `onResume` de Activities/Fragments, sin recargar en cada recomposición.
- `PullToRefreshBox` de Material 3 para refresco manual, `CircularProgressIndicator` durante la carga inicial, estado vacío ilustrado y Snackbar de error con acción "Reintentar".
- FAB "+" en la esquina inferior derecha que navega al formulario de solicitud (P1-03). Al enviar o cancelar se vuelve al listado y éste se refresca por el propio `ON_RESUME`.

## Cambios técnicos
- `AusenciaApiService`: nuevo `GET /api/ausencias/me` con query opcional `estado`.
- `IAusenciaRepository` + `AusenciaRepositoryImpl`: método `obtenerMisAusencias(estado)` con extracción del `message` del `errorBody` y dispatcher `IO`.
- `MisAusenciasViewModel` con Factory manual (sin Koin/Hilt/Dagger) y `StateFlow<EstadoUiMisAusencias>`.
- `RutasDestino.SolicitarAusencia` como ruta interna del grafo (no aparece en la bottom bar). La pestaña "Ausencias" pasa a renderizar `PantallaMisAusencias`.
- Strings nuevos en `values/strings.xml` y `values-en/strings.xml`.

## Plan de prueba
- [ ] Al entrar a la pestaña "Ausencias" se carga el listado automáticamente.
- [ ] Los chips de estado muestran los colores exactos SOLICITADA=ámbar, APROBADA=verde, RECHAZADA=rojo.
- [ ] El FAB navega al formulario de solicitud de P1-03.
- [ ] Al volver del formulario el listado se refresca automáticamente mostrando la nueva ausencia.
- [ ] El pull-to-refresh actualiza el listado.
- [ ] Con la API apagada se muestra el Snackbar de error con botón "Reintentar".
- [ ] Sin ausencias, se muestra el estado vacío con el mensaje ilustrado.