### PR TITLE
feat: editar y cancelar ausencias en estado solicitada (#14)

### DIFF
--- a/app/src/main/java/com/gestorrh/android/core/navigation/RutasDestino.kt
+++ b/app/src/main/java/com/gestorrh/android/core/navigation/RutasDestino.kt
@@ -29,9 +29,46 @@ sealed class RutasDestino(
 
     /**
      * Destino interno para el formulario de solicitud de ausencia. No aparece en la
-     * barra de navegación inferior: se alcanza desde el FAB de [Ausencias] y vuelve
-     * a ese destino tras enviar o cancelar.
+     * barra de navegación inferior: se alcanza desde el FAB de [Ausencias] (modo
+     * creación) o desde el botón "Editar" de una tarjeta (modo edición, con los
+     * argumentos opcionales `id`, `tipo`, `inicio`, `fin` y `descripcion` ya
+     * rellenos en la URL).
      */
-    data object SolicitarAusencia :
-        RutasDestino("ausencias/solicitar", R.string.nav_ausencias, Icons.Filled.EventBusy)
+    data object SolicitarAusencia : RutasDestino(
+        ruta = "ausencias/solicitar?id={id}&tipo={tipo}&inicio={inicio}&fin={fin}&descripcion={descripcion}",
+        tituloResId = R.string.nav_ausencias,
+        icono = Icons.Filled.EventBusy
+    ) {
+        const val ARG_ID: String = "id"
+        const val ARG_TIPO: String = "tipo"
+        const val ARG_INICIO: String = "inicio"
+        const val ARG_FIN: String = "fin"
+        const val ARG_DESCRIPCION: String = "descripcion"
+
+        /** URL de entrada sin argumentos: abre el formulario en modo creación. */
+        const val RUTA_CREAR: String = "ausencias/solicitar"
+
+        /**
+         * Construye la URL de edición con los datos de la ausencia seleccionada.
+         * La descripción se URL-encodea porque puede contener espacios o signos.
+         */
+        fun rutaEditar(
+            id: Long,
+            tipo: String,
+            fechaInicioIso: String,
+            fechaFinIso: String,
+            descripcion: String?
+        ): String {
+            val descCodificada = descripcion
+                ?.takeIf { it.isNotBlank() }
+                ?.let { java.net.URLEncoder.encode(it, "UTF-8") }
+                .orEmpty()
+            return "ausencias/solicitar" +
+                "?id=$id" +
+                "&tipo=$tipo" +
+                "&inicio=$fechaInicioIso" +
+                "&fin=$fechaFinIso" +
+                "&descripcion=$descCodificada"
+        }
+    }
 }

--- a/app/src/main/java/com/gestorrh/android/core/network/ApiClient.kt
+++ b/app/src/main/java/com/gestorrh/android/core/network/ApiClient.kt
@@ -3,12 +3,15 @@ package com.gestorrh.android.core.network
 import com.gestorrh.android.BuildConfig
 import com.gestorrh.android.core.security.SessionManager
 import com.google.gson.GsonBuilder
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializer
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 /**
  * Motor central de comunicaciones HTTP de la aplicación.
@@ -41,6 +44,12 @@ object ApiClient {
         val gson = GsonBuilder()
             .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeDeserializer())
             .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
+            .registerTypeAdapter(
+                LocalDate::class.java,
+                JsonSerializer<LocalDate> { src, _, _ ->
+                    JsonPrimitive(src.format(DateTimeFormatter.ISO_LOCAL_DATE))
+                }
+            )
             .create()
 
         return Retrofit.Builder()

--- a/app/src/main/java/com/gestorrh/android/data/network/ausencia/AusenciaApiService.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/ausencia/AusenciaApiService.kt
@@ -2,10 +2,14 @@ package com.gestorrh.android.data.network.ausencia
 
 import okhttp3.MultipartBody
 import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Part
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface AusenciaApiService {
@@ -24,4 +28,15 @@ interface AusenciaApiService {
     suspend fun getMisAusencias(
         @Query("estado") estado: String? = null
     ): Response<List<RespuestaAusenciaDTO>>
+
+    @PUT("api/ausencias/{id}")
+    suspend fun actualizarAusencia(
+        @Path("id") id: Long,
+        @Body peticion: PeticionAusenciaDTO
+    ): Response<RespuestaAusenciaDTO>
+
+    @DELETE("api/ausencias/{id}")
+    suspend fun cancelarAusencia(
+        @Path("id") id: Long
+    ): Response<Unit>
 }

--- a/app/src/main/java/com/gestorrh/android/data/repository/ausencia/AusenciaRepositoryImpl.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/ausencia/AusenciaRepositoryImpl.kt
@@ -99,6 +99,50 @@ class AusenciaRepositoryImpl(
             }
         }
 
+    override suspend fun actualizarAusencia(
+        idAusencia: Long,
+        peticion: PeticionAusenciaDTO
+    ): Result<RespuestaAusenciaDTO> = withContext(Dispatchers.IO) {
+        try {
+            val respuesta = apiService.actualizarAusencia(idAusencia, peticion)
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                Result.failure(
+                    Exception(
+                        extraerMensajeError(respuesta.errorBody())
+                            ?: "Error ${respuesta.code()} al actualizar la ausencia"
+                    )
+                )
+            }
+        } catch (e: IOException) {
+            Result.failure(e)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun cancelarAusencia(idAusencia: Long): Result<Unit> =
+        withContext(Dispatchers.IO) {
+            try {
+                val respuesta = apiService.cancelarAusencia(idAusencia)
+                if (respuesta.isSuccessful) {
+                    Result.success(Unit)
+                } else {
+                    Result.failure(
+                        Exception(
+                            extraerMensajeError(respuesta.errorBody())
+                                ?: "Error ${respuesta.code()} al cancelar la ausencia"
+                        )
+                    )
+                }
+            } catch (e: IOException) {
+                Result.failure(e)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
     private fun extraerMensajeError(errorBody: ResponseBody?): String? {
         return try {
             val json = errorBody?.string() ?: return null

--- a/app/src/main/java/com/gestorrh/android/domain/repository/IAusenciaRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/IAusenciaRepository.kt
@@ -45,4 +45,21 @@ interface IAusenciaRepository {
      *        `null` para recuperar todas.
      */
     suspend fun obtenerMisAusencias(estado: String? = null): Result<List<RespuestaAusenciaDTO>>
+
+    /**
+     * Actualiza una ausencia existente mediante `PUT /api/ausencias/{id}` enviando
+     * [peticion] como JSON. El servidor solo permite la operación si la ausencia está
+     * en estado `SOLICITADA`; en caso contrario devuelve 409/400 y el mensaje se
+     * propaga tal cual desde el campo `message` del cuerpo de error.
+     */
+    suspend fun actualizarAusencia(
+        idAusencia: Long,
+        peticion: PeticionAusenciaDTO
+    ): Result<RespuestaAusenciaDTO>
+
+    /**
+     * Cancela (elimina) una ausencia propia mediante `DELETE /api/ausencias/{id}`.
+     * Solo permitido si la ausencia está en estado `SOLICITADA`.
+     */
+    suspend fun cancelarAusencia(idAusencia: Long): Result<Unit>
 }

--- a/app/src/main/java/com/gestorrh/android/domain/usecase/ausencia/SolicitarAusenciaUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/ausencia/SolicitarAusenciaUseCase.kt
@@ -38,6 +38,7 @@ class SolicitarAusenciaUseCase(
         fechaFin: LocalDate?,
         archivoBytes: ByteArray?,
         nombreArchivo: String?,
+        idAusenciaEditar: Long? = null,
         hoy: LocalDate = LocalDate.now()
     ): Result<RespuestaAusenciaDTO> {
         if (tipo.isNullOrBlank()) {
@@ -56,6 +57,10 @@ class SolicitarAusenciaUseCase(
             fechaInicio = fechaInicio,
             fechaFin = fechaFin
         )
-        return repository.crearAusencia(peticion, archivoBytes, nombreArchivo)
+        return if (idAusenciaEditar != null) {
+            repository.actualizarAusencia(idAusenciaEditar, peticion)
+        } else {
+            repository.crearAusencia(peticion, archivoBytes, nombreArchivo)
+        }
     }
 }

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiMisAusencias.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiMisAusencias.kt
@@ -15,5 +15,7 @@ import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
 data class EstadoUiMisAusencias(
     val cargando: Boolean = false,
     val ausencias: List<RespuestaAusenciaDTO> = emptyList(),
-    val mensajeError: MensajeUi? = null
+    val mensajeError: MensajeUi? = null,
+    val cancelando: Boolean = false,
+    val cancelacionExitosa: Boolean = false
 )

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiSolicitudAusencia.kt
@@ -20,8 +20,12 @@ data class EstadoUiSolicitudAusencia(
     @StringRes val avisoJustificante: Int? = null,
     val enviando: Boolean = false,
     val mensajeError: MensajeUi? = null,
-    val envioExitoso: Boolean = false
+    val envioExitoso: Boolean = false,
+    val idAusenciaEditar: Long? = null
 ) {
+    val modoEdicion: Boolean
+        get() = idAusenciaEditar != null
+
     val formularioValido: Boolean
         get() = !tipoSeleccionado.isNullOrBlank()
             && fechaInicio != null

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/MisAusenciasViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/MisAusenciasViewModel.kt
@@ -67,6 +67,40 @@ class MisAusenciasViewModel(
         _estadoUi.update { it.copy(mensajeError = null) }
     }
 
+    /**
+     * Ejecuta `DELETE /api/ausencias/{id}` para cancelar la solicitud indicada.
+     * En éxito marca el flag [EstadoUiMisAusencias.cancelacionExitosa] para que la
+     * pantalla muestre el Snackbar y recarga el listado. En error se rellena
+     * `mensajeError` con el texto que haya devuelto el servidor.
+     */
+    fun cancelarAusencia(idAusencia: Long) {
+        if (_estadoUi.value.cancelando) return
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(cancelando = true, mensajeError = null) }
+            ausenciaRepository.cancelarAusencia(idAusencia)
+                .onSuccess {
+                    _estadoUi.update { it.copy(cancelando = false, cancelacionExitosa = true) }
+                    cargarAusencias()
+                }
+                .onFailure { error ->
+                    _estadoUi.update {
+                        it.copy(
+                            cancelando = false,
+                            mensajeError = if (error is IOException) {
+                                MensajeUi.Recurso(R.string.error_conexion)
+                            } else {
+                                MensajeUi.Dinamico(error.message ?: "")
+                            }
+                        )
+                    }
+                }
+        }
+    }
+
+    fun cancelacionConsumida() {
+        _estadoUi.update { it.copy(cancelacionExitosa = false) }
+    }
+
     companion object {
         fun factory(contexto: Context): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory {

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
@@ -17,20 +17,26 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.EventBusy
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
@@ -68,7 +74,9 @@ fun PantallaMisAusencias(
     viewModel: MisAusenciasViewModel = viewModel(
         factory = MisAusenciasViewModel.factory(contexto.applicationContext)
     ),
-    alSolicitarNueva: () -> Unit = {}
+    alSolicitarNueva: () -> Unit = {},
+    alEditarAusencia: (RespuestaAusenciaDTO) -> Unit = {},
+    alCancelarAusencia: (RespuestaAusenciaDTO) -> Unit = {}
 ) {
     val estadoUi by viewModel.estadoUi.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -131,7 +139,9 @@ fun PantallaMisAusencias(
                 estadoUi.ausencias.isEmpty() -> EstadoVacio()
                 else -> ListaAusencias(
                     ausencias = estadoUi.ausencias,
-                    padding = PaddingValues(16.dp)
+                    padding = PaddingValues(16.dp),
+                    alEditar = alEditarAusencia,
+                    alCancelar = alCancelarAusencia
                 )
             }
         }
@@ -180,7 +190,9 @@ private fun EstadoVacio() {
 @Composable
 private fun ListaAusencias(
     ausencias: List<RespuestaAusenciaDTO>,
-    padding: PaddingValues
+    padding: PaddingValues,
+    alEditar: (RespuestaAusenciaDTO) -> Unit,
+    alCancelar: (RespuestaAusenciaDTO) -> Unit
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -188,13 +200,21 @@ private fun ListaAusencias(
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         items(ausencias, key = { it.idAusencia }) { ausencia ->
-            TarjetaAusencia(ausencia)
+            TarjetaAusencia(
+                ausencia = ausencia,
+                alEditar = { alEditar(ausencia) },
+                alCancelar = { alCancelar(ausencia) }
+            )
         }
     }
 }
 
 @Composable
-private fun TarjetaAusencia(ausencia: RespuestaAusenciaDTO) {
+private fun TarjetaAusencia(
+    ausencia: RespuestaAusenciaDTO,
+    alEditar: () -> Unit,
+    alCancelar: () -> Unit
+) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
@@ -244,6 +264,47 @@ private fun TarjetaAusencia(ausencia: RespuestaAusenciaDTO) {
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
+            }
+
+            if (ausencia.estado == "SOLICITADA") {
+                Spacer(Modifier.height(12.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Spacer(Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextButton(onClick = alEditar) {
+                        Icon(
+                            imageVector = Icons.Filled.Edit,
+                            contentDescription = null,
+                            modifier = Modifier.height(18.dp)
+                        )
+                        Spacer(Modifier.height(0.dp))
+                        Text(
+                            text = stringResource(R.string.mis_ausencias_btn_editar),
+                            modifier = Modifier.padding(start = 6.dp)
+                        )
+                    }
+                    OutlinedButton(
+                        onClick = alCancelar,
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = ColorEstadoRechazada
+                        ),
+                        modifier = Modifier.padding(start = 8.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = null,
+                            modifier = Modifier.height(18.dp)
+                        )
+                        Text(
+                            text = stringResource(R.string.mis_ausencias_btn_cancelar),
+                            modifier = Modifier.padding(start = 6.dp)
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.EventBusy
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -43,7 +44,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -75,13 +78,14 @@ fun PantallaMisAusencias(
         factory = MisAusenciasViewModel.factory(contexto.applicationContext)
     ),
     alSolicitarNueva: () -> Unit = {},
-    alEditarAusencia: (RespuestaAusenciaDTO) -> Unit = {},
-    alCancelarAusencia: (RespuestaAusenciaDTO) -> Unit = {}
+    alEditarAusencia: (RespuestaAusenciaDTO) -> Unit = {}
 ) {
     val estadoUi by viewModel.estadoUi.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val contextoLocal = LocalContext.current
     val propietarioCicloVida = LocalLifecycleOwner.current
+
+    var ausenciaAConfirmarCancelar by remember { mutableStateOf<RespuestaAusenciaDTO?>(null) }
 
     DisposableEffect(propietarioCicloVida) {
         val observador = LifecycleEventObserver { _, evento ->
@@ -94,6 +98,17 @@ fun PantallaMisAusencias(
     }
 
     val textoReintentar = stringResource(R.string.mis_ausencias_reintentar)
+    val mensajeCancelada = stringResource(R.string.mis_ausencias_cancelada_ok)
+
+    LaunchedEffect(estadoUi.cancelacionExitosa) {
+        if (estadoUi.cancelacionExitosa) {
+            snackbarHostState.showSnackbar(
+                message = mensajeCancelada,
+                duration = SnackbarDuration.Short
+            )
+            viewModel.cancelacionConsumida()
+        }
+    }
 
     LaunchedEffect(estadoUi.mensajeError) {
         estadoUi.mensajeError?.let { mensaje ->
@@ -141,10 +156,36 @@ fun PantallaMisAusencias(
                     ausencias = estadoUi.ausencias,
                     padding = PaddingValues(16.dp),
                     alEditar = alEditarAusencia,
-                    alCancelar = alCancelarAusencia
+                    alCancelar = { ausenciaAConfirmarCancelar = it }
                 )
             }
         }
+    }
+
+    ausenciaAConfirmarCancelar?.let { ausencia ->
+        AlertDialog(
+            onDismissRequest = { ausenciaAConfirmarCancelar = null },
+            title = { Text(stringResource(R.string.mis_ausencias_dialog_cancelar_titulo)) },
+            text = { Text(stringResource(R.string.mis_ausencias_dialog_cancelar_mensaje)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        ausenciaAConfirmarCancelar = null
+                        viewModel.cancelarAusencia(ausencia.idAusencia)
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = ColorEstadoRechazada
+                    )
+                ) {
+                    Text(stringResource(R.string.mis_ausencias_dialog_cancelar_confirmar))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { ausenciaAConfirmarCancelar = null }) {
+                    Text(stringResource(R.string.mis_ausencias_dialog_cancelar_volver))
+                }
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
@@ -66,8 +66,13 @@ private val ColorAvisoAmbar = Color(0xFFB26A00)
 @Composable
 fun PantallaSolicitudAusencia(
     contexto: Context = LocalContext.current,
+    datosPrerelleno: SolicitudAusenciaViewModel.PrerrellenoEdicion? = null,
     viewModel: SolicitudAusenciaViewModel = viewModel(
-        factory = SolicitudAusenciaViewModel.factory(contexto.applicationContext)
+        key = datosPrerelleno?.idAusencia?.let { "editar-$it" } ?: "crear",
+        factory = SolicitudAusenciaViewModel.factory(
+            contexto.applicationContext,
+            datosPrerelleno
+        )
     ),
     alVolver: () -> Unit = {},
     alEnvioExitoso: () -> Unit = {}
@@ -102,9 +107,15 @@ fun PantallaSolicitudAusencia(
         }
     }
 
+    val tituloRes = if (estadoUi.modoEdicion) {
+        R.string.ausencia_titulo_pantalla_editar
+    } else {
+        R.string.ausencia_titulo_pantalla
+    }
+
     Scaffold(
         topBar = {
-            TopAppBar(title = { Text(stringResource(R.string.ausencia_titulo_pantalla)) })
+            TopAppBar(title = { Text(stringResource(tituloRes)) })
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { padding ->
@@ -143,18 +154,20 @@ fun PantallaSolicitudAusencia(
                 maxLines = 6
             )
 
-            BotonAdjuntar(
-                nombreArchivo = estadoUi.nombreArchivo,
-                onAdjuntar = { selectorArchivo.launch("*/*") },
-                onQuitar = viewModel::quitarArchivo
-            )
-
-            estadoUi.avisoJustificante?.let { idAviso ->
-                Text(
-                    text = stringResource(idAviso),
-                    color = ColorAvisoAmbar,
-                    style = MaterialTheme.typography.bodySmall
+            if (!estadoUi.modoEdicion) {
+                BotonAdjuntar(
+                    nombreArchivo = estadoUi.nombreArchivo,
+                    onAdjuntar = { selectorArchivo.launch("*/*") },
+                    onQuitar = viewModel::quitarArchivo
                 )
+
+                estadoUi.avisoJustificante?.let { idAviso ->
+                    Text(
+                        text = stringResource(idAviso),
+                        color = ColorAvisoAmbar,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
             }
 
             Spacer(Modifier.height(8.dp))
@@ -171,7 +184,12 @@ fun PantallaSolicitudAusencia(
                         color = MaterialTheme.colorScheme.onPrimary
                     )
                 } else {
-                    Text(stringResource(R.string.ausencia_btn_enviar))
+                    val textoBoton = if (estadoUi.modoEdicion) {
+                        R.string.ausencia_btn_actualizar
+                    } else {
+                        R.string.ausencia_btn_enviar
+                    }
+                    Text(stringResource(textoBoton))
                 }
             }
 

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
@@ -47,10 +47,19 @@ import java.time.format.DateTimeFormatter
 class SolicitudAusenciaViewModel(
     private val ausenciaRepository: IAusenciaRepository,
     private val solicitarAusenciaUseCase: SolicitarAusenciaUseCase,
-    private val contextoAplicacion: Context
+    private val contextoAplicacion: Context,
+    datosPrerelleno: PrerrellenoEdicion? = null
 ) : ViewModel() {
 
-    private val _estadoUi = MutableStateFlow(EstadoUiSolicitudAusencia())
+    private val _estadoUi = MutableStateFlow(
+        EstadoUiSolicitudAusencia(
+            idAusenciaEditar = datosPrerelleno?.idAusencia,
+            tipoSeleccionado = datosPrerelleno?.tipo,
+            fechaInicio = datosPrerelleno?.fechaInicio,
+            fechaFin = datosPrerelleno?.fechaFin,
+            descripcion = datosPrerelleno?.descripcion.orEmpty()
+        )
+    )
     val estadoUi: StateFlow<EstadoUiSolicitudAusencia> = _estadoUi.asStateFlow()
 
     init {
@@ -165,8 +174,9 @@ class SolicitudAusenciaViewModel(
                 descripcion = estadoActual.descripcion,
                 fechaInicio = estadoActual.fechaInicio,
                 fechaFin = estadoActual.fechaFin,
-                archivoBytes = archivoBytes,
-                nombreArchivo = estadoActual.nombreArchivo
+                archivoBytes = if (estadoActual.modoEdicion) null else archivoBytes,
+                nombreArchivo = if (estadoActual.modoEdicion) null else estadoActual.nombreArchivo,
+                idAusenciaEditar = estadoActual.idAusenciaEditar
             )
 
             resultado
@@ -246,10 +256,27 @@ class SolicitudAusenciaViewModel(
         }
     }
 
+    /**
+     * Conjunto mínimo de datos necesarios para abrir la pantalla en modo edición.
+     * Solo se incluyen los campos editables por el usuario; el resto del
+     * [com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO] (estado,
+     * responsable, etc.) no pertenece al formulario.
+     */
+    data class PrerrellenoEdicion(
+        val idAusencia: Long,
+        val tipo: String,
+        val fechaInicio: LocalDate,
+        val fechaFin: LocalDate,
+        val descripcion: String?
+    )
+
     companion object {
         val FORMATO_FECHA: DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
 
-        fun factory(contexto: Context): ViewModelProvider.Factory =
+        fun factory(
+            contexto: Context,
+            datosPrerelleno: PrerrellenoEdicion? = null
+        ): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory {
                 @Suppress("UNCHECKED_CAST")
                 override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -268,7 +295,12 @@ class SolicitudAusenciaViewModel(
                         .create()
                     val repository = AusenciaRepositoryImpl(apiService, gson)
                     val useCase = SolicitarAusenciaUseCase(repository)
-                    return SolicitudAusenciaViewModel(repository, useCase, contexto) as T
+                    return SolicitudAusenciaViewModel(
+                        ausenciaRepository = repository,
+                        solicitarAusenciaUseCase = useCase,
+                        contextoAplicacion = contexto,
+                        datosPrerelleno = datosPrerelleno
+                    ) as T
                 }
             }
     }

--- a/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
@@ -4,16 +4,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.gestorrh.android.core.navigation.BarraNavegacionInferior
 import com.gestorrh.android.core.navigation.RutasDestino
 import com.gestorrh.android.ui.ausencia.PantallaMisAusencias
 import com.gestorrh.android.ui.ausencia.PantallaSolicitudAusencia
+import com.gestorrh.android.ui.ausencia.SolicitudAusenciaViewModel
 import com.gestorrh.android.ui.dashboard.PantallaDashboard
 import com.gestorrh.android.ui.perfil.PantallaPerfil
 import com.gestorrh.android.ui.turnos.PantallaMisTurnos
+import java.net.URLDecoder
+import java.time.LocalDate
 
 /**
  * Contenedor maestro de la experiencia "Post-Login".
@@ -62,15 +67,83 @@ fun PantallaPrincipal(
             composable(RutasDestino.Ausencias.ruta) {
                 PantallaMisAusencias(
                     alSolicitarNueva = {
-                        controladorNavegacionInterno.navigate(RutasDestino.SolicitarAusencia.ruta) {
+                        controladorNavegacionInterno.navigate(
+                            RutasDestino.SolicitarAusencia.RUTA_CREAR
+                        ) {
+                            launchSingleTop = true
+                        }
+                    },
+                    alEditarAusencia = { ausencia ->
+                        controladorNavegacionInterno.navigate(
+                            RutasDestino.SolicitarAusencia.rutaEditar(
+                                id = ausencia.idAusencia,
+                                tipo = ausencia.tipo,
+                                fechaInicioIso = ausencia.fechaInicio.toString(),
+                                fechaFinIso = ausencia.fechaFin.toString(),
+                                descripcion = ausencia.descripcion
+                            )
+                        ) {
                             launchSingleTop = true
                         }
                     }
                 )
             }
 
-            composable(RutasDestino.SolicitarAusencia.ruta) {
+            composable(
+                route = RutasDestino.SolicitarAusencia.ruta,
+                arguments = listOf(
+                    navArgument(RutasDestino.SolicitarAusencia.ARG_ID) {
+                        type = NavType.LongType
+                        defaultValue = -1L
+                    },
+                    navArgument(RutasDestino.SolicitarAusencia.ARG_TIPO) {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    },
+                    navArgument(RutasDestino.SolicitarAusencia.ARG_INICIO) {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    },
+                    navArgument(RutasDestino.SolicitarAusencia.ARG_FIN) {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    },
+                    navArgument(RutasDestino.SolicitarAusencia.ARG_DESCRIPCION) {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    }
+                )
+            ) { entrada ->
+                val args = entrada.arguments
+                val id = args?.getLong(RutasDestino.SolicitarAusencia.ARG_ID) ?: -1L
+                val tipoArg = args?.getString(RutasDestino.SolicitarAusencia.ARG_TIPO)
+                val inicioArg = args?.getString(RutasDestino.SolicitarAusencia.ARG_INICIO)
+                val finArg = args?.getString(RutasDestino.SolicitarAusencia.ARG_FIN)
+                val descripcionArg = args?.getString(RutasDestino.SolicitarAusencia.ARG_DESCRIPCION)
+
+                val datosEdicion = if (
+                    id > 0 && !tipoArg.isNullOrBlank() &&
+                    !inicioArg.isNullOrBlank() && !finArg.isNullOrBlank()
+                ) {
+                    SolicitudAusenciaViewModel.PrerrellenoEdicion(
+                        idAusencia = id,
+                        tipo = tipoArg,
+                        fechaInicio = LocalDate.parse(inicioArg),
+                        fechaFin = LocalDate.parse(finArg),
+                        descripcion = descripcionArg
+                            ?.takeIf { it.isNotBlank() }
+                            ?.let { URLDecoder.decode(it, "UTF-8") }
+                    )
+                } else {
+                    null
+                }
+
                 PantallaSolicitudAusencia(
+                    datosPrerelleno = datosEdicion,
                     alVolver = {
                         controladorNavegacionInterno.popBackStack(
                             route = RutasDestino.Ausencias.ruta,

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -128,4 +128,9 @@
     <string name="mis_ausencias_estado_rechazada">REJECTED</string>
     <string name="mis_ausencias_btn_editar">Edit</string>
     <string name="mis_ausencias_btn_cancelar">Cancel</string>
+    <string name="mis_ausencias_dialog_cancelar_titulo">Cancel request</string>
+    <string name="mis_ausencias_dialog_cancelar_mensaje">Are you sure you want to cancel this time off request? This action cannot be undone.</string>
+    <string name="mis_ausencias_dialog_cancelar_confirmar">Confirm</string>
+    <string name="mis_ausencias_dialog_cancelar_volver">Back</string>
+    <string name="mis_ausencias_cancelada_ok">Request cancelled</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -90,6 +90,8 @@
 
     <!-- Time Off Request Screen -->
     <string name="ausencia_titulo_pantalla">Request time off</string>
+    <string name="ausencia_titulo_pantalla_editar">Edit request</string>
+    <string name="ausencia_btn_actualizar">Update request</string>
     <string name="ausencia_label_tipo">Time off type</string>
     <string name="ausencia_cargando_tipos">Loading types…</string>
     <string name="ausencia_label_fecha_inicio">Start date</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -124,4 +124,6 @@
     <string name="mis_ausencias_estado_solicitada">PENDING</string>
     <string name="mis_ausencias_estado_aprobada">APPROVED</string>
     <string name="mis_ausencias_estado_rechazada">REJECTED</string>
+    <string name="mis_ausencias_btn_editar">Edit</string>
+    <string name="mis_ausencias_btn_cancelar">Cancel</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,4 +128,9 @@
     <string name="mis_ausencias_estado_rechazada">RECHAZADA</string>
     <string name="mis_ausencias_btn_editar">Editar</string>
     <string name="mis_ausencias_btn_cancelar">Cancelar</string>
+    <string name="mis_ausencias_dialog_cancelar_titulo">Cancelar solicitud</string>
+    <string name="mis_ausencias_dialog_cancelar_mensaje">¿Seguro que deseas cancelar esta solicitud de ausencia? Esta acción no se puede deshacer.</string>
+    <string name="mis_ausencias_dialog_cancelar_confirmar">Confirmar</string>
+    <string name="mis_ausencias_dialog_cancelar_volver">Volver</string>
+    <string name="mis_ausencias_cancelada_ok">Solicitud cancelada</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,8 @@
 
     <!-- Pantalla Solicitud de Ausencia -->
     <string name="ausencia_titulo_pantalla">Solicitar ausencia</string>
+    <string name="ausencia_titulo_pantalla_editar">Editar solicitud</string>
+    <string name="ausencia_btn_actualizar">Actualizar solicitud</string>
     <string name="ausencia_label_tipo">Tipo de ausencia</string>
     <string name="ausencia_cargando_tipos">Cargando tipos…</string>
     <string name="ausencia_label_fecha_inicio">Fecha de inicio</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,4 +124,6 @@
     <string name="mis_ausencias_estado_solicitada">SOLICITADA</string>
     <string name="mis_ausencias_estado_aprobada">APROBADA</string>
     <string name="mis_ausencias_estado_rechazada">RECHAZADA</string>
+    <string name="mis_ausencias_btn_editar">Editar</string>
+    <string name="mis_ausencias_btn_cancelar">Cancelar</string>
 </resources>


### PR DESCRIPTION
Closes #14

Amplía P1-04 para permitir al empleado modificar o cancelar sus ausencias mientras aún estén en estado `SOLICITADA`. Ausencias ya `APROBADA` o `RECHAZADA` permanecen inmutables en la UI.

## Resumen
- Cada tarjeta de una ausencia `SOLICITADA` muestra dos acciones en el pie: **Editar** (`Icons.Filled.Edit`) y **Cancelar** (`Icons.Filled.Delete` teñido en rojo `#D32F2F`). Las tarjetas `APROBADA`/`RECHAZADA` no muestran ninguna acción.
- **Editar** reutiliza `PantallaSolicitudAusencia` en modo edición: el formulario se pre-rellena con `tipo`, `fechaInicio`, `fechaFin` y `descripcion`. El título pasa a `"Editar solicitud"` y el botón principal a `"Actualizar solicitud"`. El bloque de adjuntos queda **oculto** en edición (la gestión de adjuntos es P2-07).
- Al guardar en modo edición se invoca `PUT /api/ausencias/{id}` con el `PeticionAusenciaDTO` como JSON (sin multipart, sin parte `archivo`). Se reutiliza `SolicitarAusenciaUseCase` con un nuevo parámetro opcional `idAusenciaEditar` que rutea la operación al repositorio correspondiente.
- **Cancelar** muestra un `AlertDialog` con título "Cancelar solicitud", mensaje de confirmación y botones "Confirmar" / "Volver". Si se confirma, ejecuta `DELETE /api/ausencias/{id}`, enseña el Snackbar "Solicitud cancelada" y refresca el listado. En error se muestra el mensaje `message` del servidor en el Snackbar existente.

## Cambios técnicos
- **Data layer**
  - `AusenciaApiService`: nuevos `@PUT("api/ausencias/{id}")` y `@DELETE("api/ausencias/{id}")`.
  - `IAusenciaRepository` + `AusenciaRepositoryImpl`: `actualizarAusencia(id, peticion)` y `cancelarAusencia(id)` con extracción del `message` del `errorBody` y dispatcher `IO`.
  - `ApiClient`: añadido `JsonSerializer<LocalDate>` al Gson compartido para que el `@Body` del PUT se serialice como ISO-8601.
- **Domain layer**
  - `SolicitarAusenciaUseCase`: parámetro opcional `idAusenciaEditar`; si viene no nulo delega a `actualizarAusencia`, si no a `crearAusencia`.
- **Presentation layer**
  - `EstadoUiSolicitudAusencia`: nuevo `idAusenciaEditar` y propiedad derivada `modoEdicion`.
  - `SolicitudAusenciaViewModel`: acepta `PrerrellenoEdicion?` (id, tipo, fechas, descripción), inicializa el estado con esos valores y el factory manual lo propaga. El botón de adjuntar y su aviso solo se dibujan en modo creación.
  - `EstadoUiMisAusencias` + `MisAusenciasViewModel`: nuevos `cancelando` y `cancelacionExitosa`, función `cancelarAusencia(id)` con bloqueo de reentradas y recarga automática tras éxito.
  - `PantallaMisAusencias`: acciones por tarjeta, `AlertDialog` de confirmación, Snackbar de éxito.
- **Navegación**
  - `RutasDestino.SolicitarAusencia` pasa a aceptar argumentos opcionales `id`, `tipo`, `inicio`, `fin`, `descripcion` (URL-encoded). Helper `rutaEditar(...)` y constante `RUTA_CREAR` para construir las URLs sin strings sueltos.
  - `PantallaPrincipal` registra los `navArgument`, reconstruye `PrerrellenoEdicion` a partir de los argumentos y lo pasa a la pantalla.
- **Strings**: `ausencia_titulo_pantalla_editar`, `ausencia_btn_actualizar`, `mis_ausencias_btn_editar`, `mis_ausencias_btn_cancelar`, `mis_ausencias_dialog_cancelar_*`, `mis_ausencias_cancelada_ok` en `values/` y `values-en/`.

## Commits
1. `feat: añadir botones editar y cancelar en tarjetas de ausencia solicitada (#14)` — UI de las acciones por tarjeta.
2. `feat: modo edición del formulario de ausencia vía PUT (#14)` — navegación, prerrelleno y envío PUT sin multipart.
3. `feat: cancelar ausencia con confirmación vía DELETE (#14)` — `AlertDialog`, llamada DELETE y Snackbar de confirmación.

## Fuera de alcance
- Gestión de adjuntos en edición — se deja para P2-07 tal como indica la issue.

## Plan de prueba
- [ ] Las ausencias `SOLICITADA` muestran los botones Editar/Cancelar; las `APROBADA`/`RECHAZADA` no.
- [ ] Editar abre la pantalla con los campos pre-rellenos, título "Editar solicitud" y botón "Actualizar solicitud". Tras actualizar se vuelve a la lista y aparecen los cambios.
- [ ] En modo edición el bloque de adjuntos no se muestra.
- [ ] Cancelar abre el diálogo; "Volver" lo descarta, "Confirmar" borra la ausencia y muestra el Snackbar "Solicitud cancelada".
- [ ] Si el servidor devuelve error al cancelar/actualizar, el Snackbar muestra el `message` devuelto por la API.