### PR TITLE
feat: adjuntar y descargar justificantes en ausencias (#21)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,11 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
 
     <application
         android:allowBackup="true"
@@ -27,6 +32,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/gestorrh/android/core/archivos/GestorArchivosJustificante.kt
+++ b/app/src/main/java/com/gestorrh/android/core/archivos/GestorArchivosJustificante.kt
@@ -1,0 +1,180 @@
+package com.gestorrh.android.core.archivos
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Utilidades de archivos para el flujo de adjuntos de ausencias.
+ *
+ * Centraliza la creación del `Uri` de destino para el intent de cámara vía
+ * [FileProvider], la compresión de imágenes tomadas con cámara para evitar uploads
+ * innecesariamente grandes, la lectura de metadatos del `ContentResolver` y la
+ * apertura de archivos descargados con el visor del sistema.
+ */
+object GestorArchivosJustificante {
+
+    private const val ANCHO_MAXIMO_IMAGEN_PX = 1920
+    private const val CALIDAD_JPEG = 80
+    private const val SUBDIRECTORIO_CAMARA = "justificantes"
+    private const val SUBDIRECTORIO_DESCARGAS = "descargas"
+
+    /**
+     * Crea un archivo temporal vacío en el caché del dispositivo y devuelve el `Uri`
+     * compartible vía [FileProvider] que puede pasarse al intent de cámara como destino.
+     */
+    fun crearUriCapturaCamara(contexto: Context): UriCaptura {
+        val directorio = File(contexto.cacheDir, SUBDIRECTORIO_CAMARA).apply { mkdirs() }
+        val archivo = File(directorio, "justificante_${System.currentTimeMillis()}.jpg")
+        archivo.createNewFile()
+        val authority = "${contexto.packageName}.fileprovider"
+        val uri = FileProvider.getUriForFile(contexto, authority, archivo)
+        return UriCaptura(uri = uri, rutaAbsoluta = archivo.absolutePath)
+    }
+
+    /**
+     * Lee los bytes del archivo indicado por [uri], comprimiéndolos si es una imagen
+     * (escalando el lado mayor a [ANCHO_MAXIMO_IMAGEN_PX] y recodificando a JPEG al
+     * [CALIDAD_JPEG] por ciento) o devolviéndolos sin modificar si es un PDF.
+     */
+    suspend fun leerBytesParaSubida(
+        contexto: Context,
+        uri: Uri,
+        esImagen: Boolean
+    ): ByteArray? = withContext(Dispatchers.IO) {
+        try {
+            if (esImagen) {
+                comprimirImagen(contexto, uri)
+            } else {
+                contexto.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Obtiene el nombre mostrable del archivo detrás de [uri] consultando el
+     * `ContentResolver`. Si no se puede resolver cae al último segmento del path.
+     */
+    suspend fun obtenerNombre(contexto: Context, uri: Uri): String? = withContext(Dispatchers.IO) {
+        try {
+            contexto.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                val indice = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (indice >= 0 && cursor.moveToFirst()) cursor.getString(indice) else null
+            } ?: uri.lastPathSegment
+        } catch (e: Exception) {
+            uri.lastPathSegment
+        }
+    }
+
+    /**
+     * Persiste [bytes] en un archivo temporal bajo el caché y devuelve un `Uri`
+     * compartible vía [FileProvider], adecuado para abrir el contenido con el visor
+     * del sistema mediante `Intent.ACTION_VIEW`.
+     */
+    suspend fun guardarEnCacheYObtenerUri(
+        contexto: Context,
+        bytes: ByteArray,
+        nombreArchivo: String
+    ): Uri = withContext(Dispatchers.IO) {
+        val directorio = File(contexto.cacheDir, SUBDIRECTORIO_DESCARGAS).apply { mkdirs() }
+        val archivo = File(directorio, nombreArchivo)
+        FileOutputStream(archivo).use { it.write(bytes) }
+        val authority = "${contexto.packageName}.fileprovider"
+        FileProvider.getUriForFile(contexto, authority, archivo)
+    }
+
+    /**
+     * Lanza un `Intent.ACTION_VIEW` con el [uri] y el tipo MIME inferido del nombre
+     * para que el sistema muestre el justificante con la aplicación preferida del usuario.
+     */
+    fun abrirConVisorSistema(contexto: Context, uri: Uri, nombreArchivo: String) {
+        val mime = mimeDesdeNombre(nombreArchivo)
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, mime)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        contexto.startActivity(intent)
+    }
+
+    /** Devuelve `true` si [nombre] termina con una extensión de imagen soportada. */
+    fun esImagenPorNombre(nombre: String?): Boolean {
+        val ext = nombre?.substringAfterLast('.', "")?.lowercase().orEmpty()
+        return ext == "jpg" || ext == "jpeg" || ext == "png"
+    }
+
+    /** Devuelve el tipo MIME adecuado para el nombre dado o `application/octet-stream`. */
+    fun mimeDesdeNombre(nombre: String?): String {
+        val ext = nombre?.substringAfterLast('.', "")?.lowercase().orEmpty()
+        return when (ext) {
+            "pdf" -> "application/pdf"
+            "jpg", "jpeg" -> "image/jpeg"
+            "png" -> "image/png"
+            else -> "application/octet-stream"
+        }
+    }
+
+    private fun comprimirImagen(contexto: Context, uri: Uri): ByteArray? {
+        val opcionesLectura = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        contexto.contentResolver.openInputStream(uri)?.use {
+            BitmapFactory.decodeStream(it, null, opcionesLectura)
+        } ?: return null
+
+        val anchoOriginal = opcionesLectura.outWidth
+        val altoOriginal = opcionesLectura.outHeight
+        if (anchoOriginal <= 0 || altoOriginal <= 0) return null
+
+        val ladoMayor = maxOf(anchoOriginal, altoOriginal)
+        val factorSubmuestreo = calcularInSampleSize(ladoMayor, ANCHO_MAXIMO_IMAGEN_PX)
+        val opcionesDecodificado = BitmapFactory.Options().apply {
+            inSampleSize = factorSubmuestreo
+        }
+        val bitmap = contexto.contentResolver.openInputStream(uri)?.use {
+            BitmapFactory.decodeStream(it, null, opcionesDecodificado)
+        } ?: return null
+
+        val bitmapEscalado = escalarSiNecesario(bitmap, ANCHO_MAXIMO_IMAGEN_PX)
+        val salida = ByteArrayOutputStream()
+        bitmapEscalado.compress(Bitmap.CompressFormat.JPEG, CALIDAD_JPEG, salida)
+        if (bitmapEscalado !== bitmap) bitmapEscalado.recycle()
+        bitmap.recycle()
+        return salida.toByteArray()
+    }
+
+    private fun calcularInSampleSize(ladoMayor: Int, limite: Int): Int {
+        var factor = 1
+        var valor = ladoMayor
+        while (valor / 2 >= limite) {
+            valor /= 2
+            factor *= 2
+        }
+        return factor
+    }
+
+    private fun escalarSiNecesario(bitmap: Bitmap, limite: Int): Bitmap {
+        val ladoMayor = maxOf(bitmap.width, bitmap.height)
+        if (ladoMayor <= limite) return bitmap
+        val factor = limite.toFloat() / ladoMayor.toFloat()
+        val nuevoAncho = (bitmap.width * factor).toInt().coerceAtLeast(1)
+        val nuevoAlto = (bitmap.height * factor).toInt().coerceAtLeast(1)
+        return Bitmap.createScaledBitmap(bitmap, nuevoAncho, nuevoAlto, true)
+    }
+
+    /**
+     * Datos devueltos al crear el `Uri` de captura de cámara: el [uri] que recibe
+     * el intent y la [rutaAbsoluta] del archivo físico (útil para leer los bytes
+     * tras la captura sin pasar por el `ContentResolver`).
+     */
+    data class UriCaptura(val uri: Uri, val rutaAbsoluta: String)
+}

--- a/app/src/main/java/com/gestorrh/android/core/navigation/RutasDestino.kt
+++ b/app/src/main/java/com/gestorrh/android/core/navigation/RutasDestino.kt
@@ -35,7 +35,7 @@ sealed class RutasDestino(
      * rellenos en la URL).
      */
     data object SolicitarAusencia : RutasDestino(
-        ruta = "ausencias/solicitar?id={id}&tipo={tipo}&inicio={inicio}&fin={fin}&descripcion={descripcion}",
+        ruta = "ausencias/solicitar?id={id}&tipo={tipo}&inicio={inicio}&fin={fin}&descripcion={descripcion}&justificante={justificante}",
         tituloResId = R.string.nav_ausencias,
         icono = Icons.Filled.EventBusy
     ) {
@@ -44,22 +44,29 @@ sealed class RutasDestino(
         const val ARG_INICIO: String = "inicio"
         const val ARG_FIN: String = "fin"
         const val ARG_DESCRIPCION: String = "descripcion"
+        const val ARG_JUSTIFICANTE: String = "justificante"
 
         /** URL de entrada sin argumentos: abre el formulario en modo creación. */
         const val RUTA_CREAR: String = "ausencias/solicitar"
 
         /**
          * Construye la URL de edición con los datos de la ausencia seleccionada.
-         * La descripción se URL-encodea porque puede contener espacios o signos.
+         * La descripción y el nombre del justificante se URL-encodean porque pueden
+         * contener espacios, acentos o signos reservados.
          */
         fun rutaEditar(
             id: Long,
             tipo: String,
             fechaInicioIso: String,
             fechaFinIso: String,
-            descripcion: String?
+            descripcion: String?,
+            justificante: String?
         ): String {
             val descCodificada = descripcion
+                ?.takeIf { it.isNotBlank() }
+                ?.let { java.net.URLEncoder.encode(it, "UTF-8") }
+                .orEmpty()
+            val justCodificado = justificante
                 ?.takeIf { it.isNotBlank() }
                 ?.let { java.net.URLEncoder.encode(it, "UTF-8") }
                 .orEmpty()
@@ -68,7 +75,8 @@ sealed class RutasDestino(
                 "&tipo=$tipo" +
                 "&inicio=$fechaInicioIso" +
                 "&fin=$fechaFinIso" +
-                "&descripcion=$descCodificada"
+                "&descripcion=$descCodificada" +
+                "&justificante=$justCodificado"
         }
     }
 }

--- a/app/src/main/java/com/gestorrh/android/data/network/ausencia/AusenciaApiService.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/ausencia/AusenciaApiService.kt
@@ -1,8 +1,8 @@
 package com.gestorrh.android.data.network.ausencia
 
 import okhttp3.MultipartBody
+import okhttp3.ResponseBody
 import retrofit2.Response
-import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
@@ -29,14 +29,21 @@ interface AusenciaApiService {
         @Query("estado") estado: String? = null
     ): Response<List<RespuestaAusenciaDTO>>
 
+    @Multipart
     @PUT("api/ausencias/{id}")
     suspend fun actualizarAusencia(
         @Path("id") id: Long,
-        @Body peticion: PeticionAusenciaDTO
+        @Part datos: MultipartBody.Part,
+        @Part archivo: MultipartBody.Part?
     ): Response<RespuestaAusenciaDTO>
 
     @DELETE("api/ausencias/{id}")
     suspend fun cancelarAusencia(
         @Path("id") id: Long
     ): Response<Unit>
+
+    @GET("api/ausencias/justificantes/{nombreArchivo}")
+    suspend fun descargarJustificante(
+        @Path("nombreArchivo") nombreArchivo: String
+    ): Response<ResponseBody>
 }

--- a/app/src/main/java/com/gestorrh/android/data/repository/ausencia/AusenciaRepositoryImpl.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/ausencia/AusenciaRepositoryImpl.kt
@@ -46,19 +46,8 @@ class AusenciaRepositoryImpl(
         nombreArchivo: String?
     ): Result<RespuestaAusenciaDTO> = withContext(Dispatchers.IO) {
         try {
-            val datosPart = MultipartBody.Part.createFormData(
-                "datos",
-                null,
-                gson.toJson(peticion).toRequestBody("application/json".toMediaTypeOrNull())
-            )
-
-            val archivoPart = archivoBytes?.let { bytes ->
-                MultipartBody.Part.createFormData(
-                    "archivo",
-                    nombreArchivo ?: "justificante",
-                    bytes.toRequestBody("application/octet-stream".toMediaTypeOrNull())
-                )
-            }
+            val datosPart = construirPartDatos(peticion)
+            val archivoPart = construirPartArchivo(archivoBytes, nombreArchivo)
 
             val respuesta = apiService.crearAusencia(datosPart, archivoPart)
             if (respuesta.isSuccessful && respuesta.body() != null) {
@@ -101,10 +90,15 @@ class AusenciaRepositoryImpl(
 
     override suspend fun actualizarAusencia(
         idAusencia: Long,
-        peticion: PeticionAusenciaDTO
+        peticion: PeticionAusenciaDTO,
+        archivoBytes: ByteArray?,
+        nombreArchivo: String?
     ): Result<RespuestaAusenciaDTO> = withContext(Dispatchers.IO) {
         try {
-            val respuesta = apiService.actualizarAusencia(idAusencia, peticion)
+            val datosPart = construirPartDatos(peticion)
+            val archivoPart = construirPartArchivo(archivoBytes, nombreArchivo)
+
+            val respuesta = apiService.actualizarAusencia(idAusencia, datosPart, archivoPart)
             if (respuesta.isSuccessful && respuesta.body() != null) {
                 Result.success(respuesta.body()!!)
             } else {
@@ -142,6 +136,58 @@ class AusenciaRepositoryImpl(
                 Result.failure(e)
             }
         }
+
+    override suspend fun descargarJustificante(nombreArchivo: String): Result<ByteArray> =
+        withContext(Dispatchers.IO) {
+            try {
+                val respuesta = apiService.descargarJustificante(nombreArchivo)
+                if (respuesta.isSuccessful && respuesta.body() != null) {
+                    Result.success(respuesta.body()!!.bytes())
+                } else {
+                    Result.failure(
+                        Exception(
+                            extraerMensajeError(respuesta.errorBody())
+                                ?: "Error ${respuesta.code()} al descargar el justificante"
+                        )
+                    )
+                }
+            } catch (e: IOException) {
+                Result.failure(e)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    private fun construirPartDatos(peticion: PeticionAusenciaDTO): MultipartBody.Part {
+        return MultipartBody.Part.createFormData(
+            "datos",
+            null,
+            gson.toJson(peticion).toRequestBody("application/json".toMediaTypeOrNull())
+        )
+    }
+
+    private fun construirPartArchivo(
+        archivoBytes: ByteArray?,
+        nombreArchivo: String?
+    ): MultipartBody.Part? {
+        if (archivoBytes == null) return null
+        val tipoMime = tipoMimeDesdeNombre(nombreArchivo)
+        return MultipartBody.Part.createFormData(
+            "archivo",
+            nombreArchivo ?: "justificante",
+            archivoBytes.toRequestBody(tipoMime.toMediaTypeOrNull())
+        )
+    }
+
+    private fun tipoMimeDesdeNombre(nombre: String?): String {
+        val extension = nombre?.substringAfterLast('.', "")?.lowercase().orEmpty()
+        return when (extension) {
+            "pdf" -> "application/pdf"
+            "jpg", "jpeg" -> "image/jpeg"
+            "png" -> "image/png"
+            else -> "application/octet-stream"
+        }
+    }
 
     private fun extraerMensajeError(errorBody: ResponseBody?): String? {
         return try {

--- a/app/src/main/java/com/gestorrh/android/domain/repository/IAusenciaRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/IAusenciaRepository.kt
@@ -6,10 +6,11 @@ import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
 /**
  * Contrato de dominio para las operaciones sobre ausencias del empleado autenticado.
  *
- * Concentra las dos operaciones que la pantalla de solicitud necesita: leer el
- * diccionario de tipos disponibles desde el servidor (para alimentar el desplegable
- * sin acoplarlo al enum local) y enviar una nueva solicitud usando `multipart/form-data`
- * con la parte JSON `datos` y la parte binaria opcional `archivo`.
+ * Concentra las operaciones necesarias para el flujo de creación, edición, listado
+ * y gestión de justificantes: lectura del diccionario de tipos, envío de solicitudes
+ * con `multipart/form-data` (parte JSON `datos` y parte binaria opcional `archivo`),
+ * consulta del listado propio, actualización y cancelación, y descarga del justificante
+ * ya persistido en el servidor.
  *
  * Las implementaciones devuelven [Result] envolviendo el cuerpo de respuesta en caso
  * de éxito o una [Throwable] cuyo mensaje sea apto para mostrar al usuario directamente
@@ -47,14 +48,19 @@ interface IAusenciaRepository {
     suspend fun obtenerMisAusencias(estado: String? = null): Result<List<RespuestaAusenciaDTO>>
 
     /**
-     * Actualiza una ausencia existente mediante `PUT /api/ausencias/{id}` enviando
-     * [peticion] como JSON. El servidor solo permite la operación si la ausencia está
+     * Actualiza una ausencia existente mediante `PUT /api/ausencias/{id}` usando
+     * `multipart/form-data`. El servidor solo permite la operación si la ausencia está
      * en estado `SOLICITADA`; en caso contrario devuelve 409/400 y el mensaje se
      * propaga tal cual desde el campo `message` del cuerpo de error.
+     *
+     * @param archivoBytes Bytes del nuevo justificante o `null` si no se desea sustituirlo.
+     * @param nombreArchivo Nombre original del nuevo archivo (`filename` del multipart).
      */
     suspend fun actualizarAusencia(
         idAusencia: Long,
-        peticion: PeticionAusenciaDTO
+        peticion: PeticionAusenciaDTO,
+        archivoBytes: ByteArray?,
+        nombreArchivo: String?
     ): Result<RespuestaAusenciaDTO>
 
     /**
@@ -62,4 +68,10 @@ interface IAusenciaRepository {
      * Solo permitido si la ausencia está en estado `SOLICITADA`.
      */
     suspend fun cancelarAusencia(idAusencia: Long): Result<Unit>
+
+    /**
+     * Descarga los bytes del justificante asociado a una ausencia desde
+     * `GET /api/ausencias/justificantes/{nombreArchivo}`.
+     */
+    suspend fun descargarJustificante(nombreArchivo: String): Result<ByteArray>
 }

--- a/app/src/main/java/com/gestorrh/android/domain/usecase/ausencia/SolicitarAusenciaUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/ausencia/SolicitarAusenciaUseCase.kt
@@ -17,9 +17,11 @@ import java.time.LocalDate
  * Reglas aplicadas:
  * - `fechaInicio` debe ser hoy o futura.
  * - `fechaFin` debe ser igual o posterior a `fechaInicio`.
+ * - El archivo adjunto (si existe) debe tener extensión soportada (pdf/jpg/jpeg/png)
+ *   y no superar el tamaño máximo admitido.
  *
- * Si la entrada es válida invoca a [IAusenciaRepository.crearAusencia] reenviando el
- * justificante opcional sin modificarlo.
+ * Si la entrada es válida invoca al método correspondiente del repositorio (crear o
+ * actualizar) reenviando el justificante opcional sin modificarlo.
  */
 class SolicitarAusenciaUseCase(
     private val repository: IAusenciaRepository
@@ -29,6 +31,8 @@ class SolicitarAusenciaUseCase(
         data object FechaInicioPasada : ErrorValidacion("fechaInicio_pasada")
         data object FechaFinAnterior : ErrorValidacion("fechaFin_anterior")
         data object TipoVacio : ErrorValidacion("tipo_vacio")
+        data object ArchivoTipoNoSoportado : ErrorValidacion("archivo_tipo_no_soportado")
+        data object ArchivoDemasiadoGrande : ErrorValidacion("archivo_demasiado_grande")
     }
 
     suspend operator fun invoke(
@@ -50,6 +54,14 @@ class SolicitarAusenciaUseCase(
         if (fechaFin == null || fechaFin.isBefore(fechaInicio)) {
             return Result.failure(ErrorValidacion.FechaFinAnterior)
         }
+        if (archivoBytes != null) {
+            if (!extensionSoportada(nombreArchivo)) {
+                return Result.failure(ErrorValidacion.ArchivoTipoNoSoportado)
+            }
+            if (archivoBytes.size > TAMANO_MAXIMO_BYTES) {
+                return Result.failure(ErrorValidacion.ArchivoDemasiadoGrande)
+            }
+        }
 
         val peticion = PeticionAusenciaDTO(
             tipo = tipo,
@@ -58,9 +70,19 @@ class SolicitarAusenciaUseCase(
             fechaFin = fechaFin
         )
         return if (idAusenciaEditar != null) {
-            repository.actualizarAusencia(idAusenciaEditar, peticion)
+            repository.actualizarAusencia(idAusenciaEditar, peticion, archivoBytes, nombreArchivo)
         } else {
             repository.crearAusencia(peticion, archivoBytes, nombreArchivo)
         }
+    }
+
+    private fun extensionSoportada(nombre: String?): Boolean {
+        val extension = nombre?.substringAfterLast('.', "")?.lowercase().orEmpty()
+        return extension in EXTENSIONES_SOPORTADAS
+    }
+
+    companion object {
+        const val TAMANO_MAXIMO_BYTES: Long = 10L * 1024 * 1024
+        val EXTENSIONES_SOPORTADAS: Set<String> = setOf("pdf", "jpg", "jpeg", "png")
     }
 }

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiMisAusencias.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiMisAusencias.kt
@@ -11,11 +11,18 @@ import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
  * @property ausencias Listado de solicitudes del empleado autenticado tal como llega de
  *           `GET /api/ausencias/me` (el servidor ya aplica el orden deseado).
  * @property mensajeError Error a mostrar en el Snackbar o `null` si no hay error pendiente.
+ * @property descargandoJustificanteDe Identificador de la ausencia cuyo justificante se
+ *           está descargando en este momento, o `null` si no hay descarga en curso. Sirve
+ *           para bloquear la acción repetida sobre la misma tarjeta.
+ * @property abrirJustificante Evento de un solo uso con el `Uri` y el nombre del archivo
+ *           a abrir con el visor del sistema; la pantalla lo consume tras el lanzamiento.
  */
 data class EstadoUiMisAusencias(
     val cargando: Boolean = false,
     val ausencias: List<RespuestaAusenciaDTO> = emptyList(),
     val mensajeError: MensajeUi? = null,
     val cancelando: Boolean = false,
-    val cancelacionExitosa: Boolean = false
+    val cancelacionExitosa: Boolean = false,
+    val descargandoJustificanteDe: Long? = null,
+    val abrirJustificante: JustificanteParaAbrir? = null
 )

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiSolicitudAusencia.kt
@@ -14,6 +14,10 @@ data class EstadoUiSolicitudAusencia(
     val descripcion: String = "",
     val archivoUri: Uri? = null,
     val nombreArchivo: String? = null,
+    val esImagen: Boolean = false,
+    val nombreJustificanteExistente: String? = null,
+    val eliminarJustificanteExistente: Boolean = false,
+    val descargandoJustificante: Boolean = false,
     val errorTipo: Int? = null,
     @StringRes val errorFechaInicio: Int? = null,
     @StringRes val errorFechaFin: Int? = null,
@@ -21,10 +25,16 @@ data class EstadoUiSolicitudAusencia(
     val enviando: Boolean = false,
     val mensajeError: MensajeUi? = null,
     val envioExitoso: Boolean = false,
+    val abrirJustificante: JustificanteParaAbrir? = null,
     val idAusenciaEditar: Long? = null
 ) {
     val modoEdicion: Boolean
         get() = idAusenciaEditar != null
+
+    val hayJustificanteExistenteVisible: Boolean
+        get() = nombreJustificanteExistente != null
+            && !eliminarJustificanteExistente
+            && archivoUri == null
 
     val formularioValido: Boolean
         get() = !tipoSeleccionado.isNullOrBlank()
@@ -33,3 +43,12 @@ data class EstadoUiSolicitudAusencia(
             && !fechaFin.isBefore(fechaInicio)
             && !fechaInicio.isBefore(LocalDate.now())
 }
+
+/**
+ * Evento de un solo uso emitido por el ViewModel cuando un justificante ya ha sido
+ * descargado y cacheado: la pantalla lo consume lanzando `Intent.ACTION_VIEW`.
+ */
+data class JustificanteParaAbrir(
+    val uri: android.net.Uri,
+    val nombreArchivo: String
+)

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/MisAusenciasViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/MisAusenciasViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.gestorrh.android.R
+import com.gestorrh.android.core.archivos.GestorArchivosJustificante
 import com.gestorrh.android.core.network.ApiClient
 import com.gestorrh.android.core.security.SessionManager
 import com.gestorrh.android.core.ui.MensajeUi
@@ -28,14 +29,12 @@ import java.io.IOException
  * refrescar al regresar de la pantalla de solicitud de P1-03) como al gesto de
  * pull-to-refresh.
  *
- * La petición se ejecuta en `Dispatchers.IO` dentro del repositorio, por lo que el
- * ViewModel solo orquesta el lanzamiento en [viewModelScope] y mantiene el flag
- * `cargando` para que la UI pueda distinguir entre carga inicial y refresco manual.
- *
- * @param ausenciaRepository Acceso al endpoint de listado de ausencias propias.
+ * Además gestiona la descarga del justificante asociado a una ausencia para abrirlo
+ * con el visor del sistema del dispositivo desde la propia tarjeta del listado.
  */
 class MisAusenciasViewModel(
-    private val ausenciaRepository: IAusenciaRepository
+    private val ausenciaRepository: IAusenciaRepository,
+    private val contextoAplicacion: Context
 ) : ViewModel() {
 
     private val _estadoUi = MutableStateFlow(EstadoUiMisAusencias())
@@ -67,12 +66,6 @@ class MisAusenciasViewModel(
         _estadoUi.update { it.copy(mensajeError = null) }
     }
 
-    /**
-     * Ejecuta `DELETE /api/ausencias/{id}` para cancelar la solicitud indicada.
-     * En éxito marca el flag [EstadoUiMisAusencias.cancelacionExitosa] para que la
-     * pantalla muestre el Snackbar y recarga el listado. En error se rellena
-     * `mensajeError` con el texto que haya devuelto el servidor.
-     */
     fun cancelarAusencia(idAusencia: Long) {
         if (_estadoUi.value.cancelando) return
         viewModelScope.launch {
@@ -101,6 +94,46 @@ class MisAusenciasViewModel(
         _estadoUi.update { it.copy(cancelacionExitosa = false) }
     }
 
+    /**
+     * Descarga el justificante de la ausencia indicada y guarda los bytes en el
+     * caché del dispositivo, exponiendo el `Uri` resultante vía
+     * [EstadoUiMisAusencias.abrirJustificante] para que la pantalla lance el visor.
+     */
+    fun descargarJustificante(idAusencia: Long, nombreArchivo: String) {
+        if (_estadoUi.value.descargandoJustificanteDe != null) return
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(descargandoJustificanteDe = idAusencia) }
+            ausenciaRepository.descargarJustificante(nombreArchivo)
+                .onSuccess { bytes ->
+                    val uri = GestorArchivosJustificante.guardarEnCacheYObtenerUri(
+                        contextoAplicacion, bytes, nombreArchivo
+                    )
+                    _estadoUi.update {
+                        it.copy(
+                            descargandoJustificanteDe = null,
+                            abrirJustificante = JustificanteParaAbrir(uri, nombreArchivo)
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _estadoUi.update {
+                        it.copy(
+                            descargandoJustificanteDe = null,
+                            mensajeError = if (error is IOException) {
+                                MensajeUi.Recurso(R.string.error_conexion)
+                            } else {
+                                MensajeUi.Dinamico(error.message ?: "")
+                            }
+                        )
+                    }
+                }
+        }
+    }
+
+    fun aperturaJustificanteConsumida() {
+        _estadoUi.update { it.copy(abrirJustificante = null) }
+    }
+
     companion object {
         fun factory(contexto: Context): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory {
@@ -110,7 +143,7 @@ class MisAusenciasViewModel(
                     val retrofit = ApiClient.crearRetrofit(sessionManager)
                     val apiService = retrofit.create(AusenciaApiService::class.java)
                     val repository = AusenciaRepositoryImpl(apiService, Gson())
-                    return MisAusenciasViewModel(repository) as T
+                    return MisAusenciasViewModel(repository, contexto) as T
                 }
             }
     }

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.EventBusy
@@ -29,6 +30,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
@@ -60,6 +62,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gestorrh.android.R
+import com.gestorrh.android.core.archivos.GestorArchivosJustificante
 import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
 import java.time.format.DateTimeFormatter
@@ -110,6 +113,15 @@ fun PantallaMisAusencias(
         }
     }
 
+    LaunchedEffect(estadoUi.abrirJustificante) {
+        estadoUi.abrirJustificante?.let { evento ->
+            GestorArchivosJustificante.abrirConVisorSistema(
+                contextoLocal, evento.uri, evento.nombreArchivo
+            )
+            viewModel.aperturaJustificanteConsumida()
+        }
+    }
+
     LaunchedEffect(estadoUi.mensajeError) {
         estadoUi.mensajeError?.let { mensaje ->
             val texto = when (mensaje) {
@@ -154,9 +166,15 @@ fun PantallaMisAusencias(
                 estadoUi.ausencias.isEmpty() -> EstadoVacio()
                 else -> ListaAusencias(
                     ausencias = estadoUi.ausencias,
+                    descargandoJustificanteDe = estadoUi.descargandoJustificanteDe,
                     padding = PaddingValues(16.dp),
                     alEditar = alEditarAusencia,
-                    alCancelar = { ausenciaAConfirmarCancelar = it }
+                    alCancelar = { ausenciaAConfirmarCancelar = it },
+                    alDescargarJustificante = { ausencia ->
+                        ausencia.justificante?.let { nombre ->
+                            viewModel.descargarJustificante(ausencia.idAusencia, nombre)
+                        }
+                    }
                 )
             }
         }
@@ -231,9 +249,11 @@ private fun EstadoVacio() {
 @Composable
 private fun ListaAusencias(
     ausencias: List<RespuestaAusenciaDTO>,
+    descargandoJustificanteDe: Long?,
     padding: PaddingValues,
     alEditar: (RespuestaAusenciaDTO) -> Unit,
-    alCancelar: (RespuestaAusenciaDTO) -> Unit
+    alCancelar: (RespuestaAusenciaDTO) -> Unit,
+    alDescargarJustificante: (RespuestaAusenciaDTO) -> Unit
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -243,8 +263,10 @@ private fun ListaAusencias(
         items(ausencias, key = { it.idAusencia }) { ausencia ->
             TarjetaAusencia(
                 ausencia = ausencia,
+                descargandoJustificante = descargandoJustificanteDe == ausencia.idAusencia,
                 alEditar = { alEditar(ausencia) },
-                alCancelar = { alCancelar(ausencia) }
+                alCancelar = { alCancelar(ausencia) },
+                alDescargarJustificante = { alDescargarJustificante(ausencia) }
             )
         }
     }
@@ -253,8 +275,10 @@ private fun ListaAusencias(
 @Composable
 private fun TarjetaAusencia(
     ausencia: RespuestaAusenciaDTO,
+    descargandoJustificante: Boolean,
     alEditar: () -> Unit,
-    alCancelar: () -> Unit
+    alCancelar: () -> Unit,
+    alDescargarJustificante: () -> Unit
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -272,6 +296,27 @@ private fun TarjetaAusencia(
                     fontWeight = FontWeight.SemiBold,
                     modifier = Modifier.weight(1f)
                 )
+                if (!ausencia.justificante.isNullOrBlank()) {
+                    IconButton(
+                        onClick = alDescargarJustificante,
+                        enabled = !descargandoJustificante
+                    ) {
+                        if (descargandoJustificante) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.height(18.dp),
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Filled.AttachFile,
+                                contentDescription = stringResource(
+                                    R.string.mis_ausencias_cd_descargar_justificante
+                                ),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+                }
                 ChipEstado(estado = ausencia.estado)
             }
 

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
@@ -1,11 +1,16 @@
 package com.gestorrh.android.ui.ausencia
 
+import android.Manifest
 import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,12 +18,19 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.FileOpen
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.PictureAsPdf
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
@@ -29,6 +41,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -39,28 +52,39 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import android.graphics.BitmapFactory
+import androidx.compose.foundation.background
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import com.gestorrh.android.R
+import com.gestorrh.android.core.archivos.GestorArchivosJustificante
 import com.gestorrh.android.core.ui.MensajeUi
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 
-private val ColorAvisoAmbar = Color(0xFFB26A00)
+private val ColorAvisoAmbar = Color(0xFFF57C00)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -82,10 +106,35 @@ fun PantallaSolicitudAusencia(
     val contextoLocal = LocalContext.current
     val mensajeExito = stringResource(R.string.ausencia_envio_exitoso)
 
+    var mostrarSelectorFuente by remember { mutableStateOf(false) }
+    var uriCapturaPendiente by remember { mutableStateOf<GestorArchivosJustificante.UriCaptura?>(null) }
+
     val selectorArchivo = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri ->
-        viewModel.seleccionarArchivo(uri)
+        viewModel.seleccionarArchivoSeleccionado(uri)
+    }
+
+    val selectorCamara = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicture()
+    ) { exito ->
+        val pendiente = uriCapturaPendiente
+        if (exito && pendiente != null) {
+            viewModel.registrarFotoCamara(pendiente.uri, pendiente.rutaAbsoluta)
+        }
+        uriCapturaPendiente = null
+    }
+
+    val solicitudPermisoCamara = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { concedido ->
+        if (concedido) {
+            val captura = GestorArchivosJustificante.crearUriCapturaCamara(contextoLocal)
+            uriCapturaPendiente = captura
+            selectorCamara.launch(captura.uri)
+        } else {
+            viewModel.errorMostrado()
+        }
     }
 
     LaunchedEffect(estadoUi.mensajeError) {
@@ -104,6 +153,15 @@ fun PantallaSolicitudAusencia(
             snackbarHostState.showSnackbar(mensajeExito, duration = SnackbarDuration.Short)
             viewModel.envioConsumido()
             alEnvioExitoso()
+        }
+    }
+
+    LaunchedEffect(estadoUi.abrirJustificante) {
+        estadoUi.abrirJustificante?.let { evento ->
+            GestorArchivosJustificante.abrirConVisorSistema(
+                contextoLocal, evento.uri, evento.nombreArchivo
+            )
+            viewModel.aperturaJustificanteConsumida()
         }
     }
 
@@ -154,20 +212,20 @@ fun PantallaSolicitudAusencia(
                 maxLines = 6
             )
 
-            if (!estadoUi.modoEdicion) {
-                BotonAdjuntar(
-                    nombreArchivo = estadoUi.nombreArchivo,
-                    onAdjuntar = { selectorArchivo.launch("*/*") },
-                    onQuitar = viewModel::quitarArchivo
-                )
+            SeccionAdjunto(
+                estadoUi = estadoUi,
+                onAdjuntar = { mostrarSelectorFuente = true },
+                onQuitar = viewModel::quitarArchivo,
+                onDescargarExistente = viewModel::descargarJustificanteExistente,
+                onEliminarExistente = viewModel::eliminarJustificanteExistente
+            )
 
-                estadoUi.avisoJustificante?.let { idAviso ->
-                    Text(
-                        text = stringResource(idAviso),
-                        color = ColorAvisoAmbar,
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
+            estadoUi.avisoJustificante?.let { idAviso ->
+                Text(
+                    text = stringResource(idAviso),
+                    color = ColorAvisoAmbar,
+                    style = MaterialTheme.typography.bodySmall
+                )
             }
 
             Spacer(Modifier.height(8.dp))
@@ -200,6 +258,229 @@ fun PantallaSolicitudAusencia(
             ) {
                 Text(stringResource(R.string.ausencia_btn_cancelar))
             }
+        }
+    }
+
+    if (mostrarSelectorFuente) {
+        SelectorFuenteAdjunto(
+            onCerrar = { mostrarSelectorFuente = false },
+            onCamaraSeleccionada = {
+                mostrarSelectorFuente = false
+                val permiso = ContextCompat.checkSelfPermission(
+                    contextoLocal, Manifest.permission.CAMERA
+                )
+                if (permiso == PackageManager.PERMISSION_GRANTED) {
+                    val captura = GestorArchivosJustificante.crearUriCapturaCamara(contextoLocal)
+                    uriCapturaPendiente = captura
+                    selectorCamara.launch(captura.uri)
+                } else {
+                    solicitudPermisoCamara.launch(Manifest.permission.CAMERA)
+                }
+            },
+            onArchivoSeleccionado = {
+                mostrarSelectorFuente = false
+                selectorArchivo.launch("*/*")
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SelectorFuenteAdjunto(
+    onCerrar: () -> Unit,
+    onCamaraSeleccionada: () -> Unit,
+    onArchivoSeleccionado: () -> Unit
+) {
+    val estadoSheet = rememberModalBottomSheetState()
+    ModalBottomSheet(
+        onDismissRequest = onCerrar,
+        sheetState = estadoSheet
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.ausencia_selector_titulo),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            OpcionSelector(
+                icono = Icons.Filled.CameraAlt,
+                texto = stringResource(R.string.ausencia_selector_camara),
+                onClick = onCamaraSeleccionada
+            )
+            OpcionSelector(
+                icono = Icons.Filled.FolderOpen,
+                texto = stringResource(R.string.ausencia_selector_archivo),
+                onClick = onArchivoSeleccionado
+            )
+            Spacer(Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+private fun OpcionSelector(
+    icono: androidx.compose.ui.graphics.vector.ImageVector,
+    texto: String,
+    onClick: () -> Unit
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Icon(imageVector = icono, contentDescription = null)
+        Spacer(Modifier.size(12.dp))
+        Text(text = texto, modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun SeccionAdjunto(
+    estadoUi: EstadoUiSolicitudAusencia,
+    onAdjuntar: () -> Unit,
+    onQuitar: () -> Unit,
+    onDescargarExistente: () -> Unit,
+    onEliminarExistente: () -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (estadoUi.hayJustificanteExistenteVisible) {
+            JustificanteExistente(
+                nombre = estadoUi.nombreJustificanteExistente!!,
+                descargando = estadoUi.descargandoJustificante,
+                onDescargar = onDescargarExistente,
+                onEliminar = onEliminarExistente
+            )
+        }
+
+        OutlinedButton(
+            onClick = onAdjuntar,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(Icons.Filled.AttachFile, contentDescription = null)
+            Spacer(Modifier.size(8.dp))
+            val textoBoton = if (estadoUi.hayJustificanteExistenteVisible) {
+                R.string.ausencia_btn_reemplazar
+            } else {
+                R.string.ausencia_btn_adjuntar
+            }
+            Text(stringResource(textoBoton))
+        }
+
+        if (estadoUi.archivoUri != null && estadoUi.nombreArchivo != null) {
+            PreviaArchivoSeleccionado(
+                uri = estadoUi.archivoUri,
+                nombre = estadoUi.nombreArchivo,
+                esImagen = estadoUi.esImagen,
+                onQuitar = onQuitar
+            )
+        }
+    }
+}
+
+@Composable
+private fun JustificanteExistente(
+    nombre: String,
+    descargando: Boolean,
+    onDescargar: () -> Unit,
+    onEliminar: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Filled.FileOpen,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Spacer(Modifier.size(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(R.string.ausencia_justificante_actual),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                text = nombre,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium
+            )
+        }
+        IconButton(onClick = onDescargar, enabled = !descargando) {
+            if (descargando) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Filled.Download,
+                    contentDescription = stringResource(R.string.ausencia_cd_descargar_justificante)
+                )
+            }
+        }
+        IconButton(onClick = onEliminar) {
+            Icon(
+                imageVector = Icons.Filled.Delete,
+                contentDescription = stringResource(R.string.ausencia_cd_eliminar_justificante_existente),
+                tint = MaterialTheme.colorScheme.error
+            )
+        }
+    }
+}
+
+@Composable
+private fun PreviaArchivoSeleccionado(
+    uri: Uri,
+    nombre: String,
+    esImagen: Boolean,
+    onQuitar: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (esImagen) {
+            MiniaturaImagen(
+                uri = uri,
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(8.dp))
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.PictureAsPdf,
+                    contentDescription = null,
+                    modifier = Modifier.size(40.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+        Spacer(Modifier.size(12.dp))
+        Text(
+            text = nombre,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.weight(1f)
+        )
+        IconButton(onClick = onQuitar) {
+            Icon(
+                Icons.Filled.Close,
+                contentDescription = stringResource(R.string.ausencia_cd_quitar_archivo)
+            )
         }
     }
 }
@@ -309,40 +590,28 @@ private fun CampoFecha(
 }
 
 @Composable
-private fun BotonAdjuntar(
-    nombreArchivo: String?,
-    onAdjuntar: () -> Unit,
-    onQuitar: () -> Unit
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        OutlinedButton(
-            onClick = onAdjuntar,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Icon(Icons.Filled.AttachFile, contentDescription = null)
-            Spacer(Modifier.size(8.dp))
-            Text(stringResource(R.string.ausencia_btn_adjuntar))
-        }
-        if (nombreArchivo != null) {
-            Box(modifier = Modifier.fillMaxWidth()) {
-                Text(
-                    text = nombreArchivo,
-                    modifier = Modifier
-                        .align(Alignment.CenterStart)
-                        .padding(end = 40.dp),
-                    style = MaterialTheme.typography.bodySmall,
-                    fontWeight = FontWeight.Medium
-                )
-                IconButton(
-                    onClick = onQuitar,
-                    modifier = Modifier.align(Alignment.CenterEnd)
-                ) {
-                    Icon(
-                        Icons.Filled.Close,
-                        contentDescription = stringResource(R.string.ausencia_cd_quitar_archivo)
-                    )
-                }
+private fun MiniaturaImagen(uri: Uri, modifier: Modifier = Modifier) {
+    val contexto = LocalContext.current
+    val bitmap by produceState<android.graphics.Bitmap?>(initialValue = null, uri) {
+        value = withContext(Dispatchers.IO) {
+            try {
+                contexto.contentResolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it) }
+            } catch (e: Exception) {
+                null
             }
+        }
+    }
+    Box(
+        modifier = modifier.background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center
+    ) {
+        bitmap?.let {
+            Image(
+                bitmap = it.asImageBitmap(),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
         }
     }
 }

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
@@ -2,11 +2,11 @@ package com.gestorrh.android.ui.ausencia
 
 import android.content.Context
 import android.net.Uri
-import android.provider.OpenableColumns
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.gestorrh.android.R
+import com.gestorrh.android.core.archivos.GestorArchivosJustificante
 import com.gestorrh.android.core.network.ApiClient
 import com.gestorrh.android.core.security.SessionManager
 import com.gestorrh.android.core.ui.MensajeUi
@@ -15,13 +15,11 @@ import com.gestorrh.android.data.repository.ausencia.AusenciaRepositoryImpl
 import com.gestorrh.android.domain.repository.IAusenciaRepository
 import com.gestorrh.android.domain.usecase.ausencia.SolicitarAusenciaUseCase
 import com.google.gson.GsonBuilder
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.io.IOException
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -33,11 +31,17 @@ import java.time.format.DateTimeFormatter
  * del formulario, incluida la lista de tipos cargada desde `GET /api/ausencias/tipos`,
  * los valores actuales de los campos, los errores inline por campo y el resultado del
  * envío. La pantalla solo emite eventos: la lógica de validación, la conversión del
- * `Uri` adjunto a bytes y la construcción del `multipart` viven aquí o en el UseCase.
+ * `Uri` adjunto a bytes (con compresión de imagen cuando procede) y la construcción
+ * del `multipart` viven aquí o en el UseCase.
  *
  * Bloquea reentradas en [enviar] mediante el flag `enviando` para evitar el doble envío
  * por doble clic, y traduce los errores de validación del UseCase a recursos de string
  * para que la pantalla los muestre directamente con `stringResource`.
+ *
+ * En modo edición se precarga el nombre del justificante ya persistido en el servidor
+ * y se ofrece descargarlo, reemplazarlo por uno nuevo (seleccionando un archivo local,
+ * que sustituirá al anterior al hacer `PUT`) o eliminarlo (se envía `PUT` sin parte
+ * archivo y con la marca correspondiente).
  *
  * @param ausenciaRepository Acceso a los endpoints de ausencias.
  * @param solicitarAusenciaUseCase Encapsula validaciones locales y la llamada al repositorio.
@@ -57,7 +61,8 @@ class SolicitudAusenciaViewModel(
             tipoSeleccionado = datosPrerelleno?.tipo,
             fechaInicio = datosPrerelleno?.fechaInicio,
             fechaFin = datosPrerelleno?.fechaFin,
-            descripcion = datosPrerelleno?.descripcion.orEmpty()
+            descripcion = datosPrerelleno?.descripcion.orEmpty(),
+            nombreJustificanteExistente = datosPrerelleno?.justificante
         )
     )
     val estadoUi: StateFlow<EstadoUiSolicitudAusencia> = _estadoUi.asStateFlow()
@@ -93,7 +98,7 @@ class SolicitudAusenciaViewModel(
             it.copy(
                 tipoSeleccionado = tipo,
                 errorTipo = null,
-                avisoJustificante = calcularAviso(tipo, it.archivoUri != null)
+                avisoJustificante = calcularAviso(tipo, hayAdjuntoEfectivo(it))
             )
         }
     }
@@ -129,16 +134,47 @@ class SolicitudAusenciaViewModel(
         _estadoUi.update { it.copy(descripcion = texto) }
     }
 
-    fun seleccionarArchivo(uri: Uri?) {
+    /**
+     * Registra un archivo seleccionado por el usuario desde el selector de archivos
+     * o desde el `content://` devuelto por `GetContent`. Valida su nombre y tipo,
+     * y si es aceptable lo deja como adjunto pendiente de subida.
+     */
+    fun seleccionarArchivoSeleccionado(uri: Uri?) {
+        if (uri == null) return
         viewModelScope.launch {
-            val nombre = uri?.let { obtenerNombreArchivo(it) }
+            val nombre = GestorArchivosJustificante.obtenerNombre(contextoAplicacion, uri)
+            aplicarArchivo(uri, nombre)
+        }
+    }
+
+    /**
+     * Registra una foto tomada con cámara dado el `Uri` y la ruta física creadas
+     * previamente por el `GestorArchivosJustificante`. Genera un nombre con
+     * extensión `.jpg` para que los validadores y el `multipart` lo traten como imagen.
+     */
+    fun registrarFotoCamara(uri: Uri, rutaAbsoluta: String) {
+        val nombre = rutaAbsoluta.substringAfterLast('/', "justificante.jpg")
+        aplicarArchivo(uri, nombre)
+    }
+
+    private fun aplicarArchivo(uri: Uri, nombreOriginal: String?) {
+        val nombre = nombreOriginal?.takeIf { it.isNotBlank() } ?: "justificante"
+        val esImagen = GestorArchivosJustificante.esImagenPorNombre(nombre)
+        val esPdf = nombre.substringAfterLast('.', "").lowercase() == "pdf"
+        if (!esImagen && !esPdf) {
             _estadoUi.update {
-                it.copy(
-                    archivoUri = uri,
-                    nombreArchivo = nombre,
-                    avisoJustificante = calcularAviso(it.tipoSeleccionado, uri != null)
-                )
+                it.copy(mensajeError = MensajeUi.Recurso(R.string.ausencia_error_tipo_archivo))
             }
+            return
+        }
+        _estadoUi.update {
+            it.copy(
+                archivoUri = uri,
+                nombreArchivo = nombre,
+                esImagen = esImagen,
+                eliminarJustificanteExistente = false,
+                avisoJustificante = calcularAviso(it.tipoSeleccionado, true)
+            )
         }
     }
 
@@ -147,9 +183,65 @@ class SolicitudAusenciaViewModel(
             it.copy(
                 archivoUri = null,
                 nombreArchivo = null,
-                avisoJustificante = calcularAviso(it.tipoSeleccionado, false)
+                esImagen = false,
+                avisoJustificante = calcularAviso(it.tipoSeleccionado, hayAdjuntoEfectivo(it.copy(archivoUri = null)))
             )
         }
+    }
+
+    /**
+     * Marca el justificante ya persistido en el servidor para ser eliminado en el
+     * próximo `PUT`. La parte `archivo` no se enviará y el servidor debe limpiar la
+     * referencia si recibe la marca correspondiente.
+     */
+    fun eliminarJustificanteExistente() {
+        _estadoUi.update {
+            it.copy(
+                eliminarJustificanteExistente = true,
+                avisoJustificante = calcularAviso(it.tipoSeleccionado, hayAdjuntoEfectivo(it.copy(eliminarJustificanteExistente = true)))
+            )
+        }
+    }
+
+    /**
+     * Descarga el justificante ya persistido en el servidor, lo guarda en el caché
+     * y publica el `Uri` resultante en [EstadoUiSolicitudAusencia.abrirJustificante]
+     * para que la pantalla lo abra con el visor del sistema.
+     */
+    fun descargarJustificanteExistente() {
+        val nombre = _estadoUi.value.nombreJustificanteExistente ?: return
+        if (_estadoUi.value.descargandoJustificante) return
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(descargandoJustificante = true) }
+            ausenciaRepository.descargarJustificante(nombre)
+                .onSuccess { bytes ->
+                    val uri = GestorArchivosJustificante.guardarEnCacheYObtenerUri(
+                        contextoAplicacion, bytes, nombre
+                    )
+                    _estadoUi.update {
+                        it.copy(
+                            descargandoJustificante = false,
+                            abrirJustificante = JustificanteParaAbrir(uri, nombre)
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _estadoUi.update {
+                        it.copy(
+                            descargandoJustificante = false,
+                            mensajeError = if (error is IOException) {
+                                MensajeUi.Recurso(R.string.error_conexion)
+                            } else {
+                                MensajeUi.Dinamico(error.message ?: "")
+                            }
+                        )
+                    }
+                }
+        }
+    }
+
+    fun aperturaJustificanteConsumida() {
+        _estadoUi.update { it.copy(abrirJustificante = null) }
     }
 
     fun errorMostrado() {
@@ -167,15 +259,22 @@ class SolicitudAusenciaViewModel(
         viewModelScope.launch {
             _estadoUi.update { it.copy(enviando = true, mensajeError = null) }
 
-            val archivoBytes = estadoActual.archivoUri?.let { leerBytes(it) }
+            val archivoBytes = estadoActual.archivoUri?.let { uri ->
+                GestorArchivosJustificante.leerBytesParaSubida(
+                    contextoAplicacion, uri, estadoActual.esImagen
+                )
+            }
+            val nombreParaSubir = estadoActual.archivoUri?.let {
+                nombreNormalizadoParaSubida(estadoActual.nombreArchivo, estadoActual.esImagen)
+            }
 
             val resultado = solicitarAusenciaUseCase(
                 tipo = estadoActual.tipoSeleccionado,
                 descripcion = estadoActual.descripcion,
                 fechaInicio = estadoActual.fechaInicio,
                 fechaFin = estadoActual.fechaFin,
-                archivoBytes = if (estadoActual.modoEdicion) null else archivoBytes,
-                nombreArchivo = if (estadoActual.modoEdicion) null else estadoActual.nombreArchivo,
+                archivoBytes = archivoBytes,
+                nombreArchivo = nombreParaSubir,
                 idAusenciaEditar = estadoActual.idAusenciaEditar
             )
 
@@ -208,6 +307,20 @@ class SolicitudAusenciaViewModel(
                                     errorTipo = R.string.ausencia_error_tipo_vacio
                                 )
                             }
+                        SolicitarAusenciaUseCase.ErrorValidacion.ArchivoTipoNoSoportado ->
+                            _estadoUi.update {
+                                it.copy(
+                                    enviando = false,
+                                    mensajeError = MensajeUi.Recurso(R.string.ausencia_error_tipo_archivo)
+                                )
+                            }
+                        SolicitarAusenciaUseCase.ErrorValidacion.ArchivoDemasiadoGrande ->
+                            _estadoUi.update {
+                                it.copy(
+                                    enviando = false,
+                                    mensajeError = MensajeUi.Recurso(R.string.ausencia_error_archivo_grande)
+                                )
+                            }
                         is IOException ->
                             _estadoUi.update {
                                 it.copy(
@@ -229,6 +342,22 @@ class SolicitudAusenciaViewModel(
         }
     }
 
+    private fun hayAdjuntoEfectivo(estado: EstadoUiSolicitudAusencia): Boolean {
+        if (estado.archivoUri != null) return true
+        return estado.nombreJustificanteExistente != null
+            && !estado.eliminarJustificanteExistente
+    }
+
+    private fun nombreNormalizadoParaSubida(nombre: String?, esImagen: Boolean): String {
+        val base = nombre?.takeIf { it.isNotBlank() } ?: "justificante"
+        val extension = base.substringAfterLast('.', "").lowercase()
+        return if (esImagen && extension != "jpg" && extension != "jpeg" && extension != "png") {
+            "$base.jpg"
+        } else {
+            base
+        }
+    }
+
     private fun calcularAviso(tipo: String?, hayArchivo: Boolean): Int? {
         return if (tipo == "MEDICA" && !hayArchivo) {
             R.string.ausencia_aviso_justificante_medica
@@ -237,37 +366,19 @@ class SolicitudAusenciaViewModel(
         }
     }
 
-    private suspend fun leerBytes(uri: Uri): ByteArray? = withContext(Dispatchers.IO) {
-        try {
-            contextoAplicacion.contentResolver.openInputStream(uri)?.use { it.readBytes() }
-        } catch (e: Exception) {
-            null
-        }
-    }
-
-    private suspend fun obtenerNombreArchivo(uri: Uri): String? = withContext(Dispatchers.IO) {
-        try {
-            contextoAplicacion.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-                val indice = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-                if (indice >= 0 && cursor.moveToFirst()) cursor.getString(indice) else null
-            } ?: uri.lastPathSegment
-        } catch (e: Exception) {
-            uri.lastPathSegment
-        }
-    }
-
     /**
      * Conjunto mínimo de datos necesarios para abrir la pantalla en modo edición.
-     * Solo se incluyen los campos editables por el usuario; el resto del
-     * [com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO] (estado,
-     * responsable, etc.) no pertenece al formulario.
+     * Solo se incluyen los campos editables por el usuario y la referencia al
+     * justificante existente (si lo hubiera), para que la pantalla ofrezca las
+     * opciones de descarga, sustitución o eliminación.
      */
     data class PrerrellenoEdicion(
         val idAusencia: Long,
         val tipo: String,
         val fechaInicio: LocalDate,
         val fechaFin: LocalDate,
-        val descripcion: String?
+        val descripcion: String?,
+        val justificante: String? = null
     )
 
     companion object {

--- a/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
@@ -80,7 +80,8 @@ fun PantallaPrincipal(
                                 tipo = ausencia.tipo,
                                 fechaInicioIso = ausencia.fechaInicio.toString(),
                                 fechaFinIso = ausencia.fechaFin.toString(),
-                                descripcion = ausencia.descripcion
+                                descripcion = ausencia.descripcion,
+                                justificante = ausencia.justificante
                             )
                         ) {
                             launchSingleTop = true
@@ -115,6 +116,11 @@ fun PantallaPrincipal(
                         type = NavType.StringType
                         nullable = true
                         defaultValue = null
+                    },
+                    navArgument(RutasDestino.SolicitarAusencia.ARG_JUSTIFICANTE) {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
                     }
                 )
             ) { entrada ->
@@ -124,6 +130,7 @@ fun PantallaPrincipal(
                 val inicioArg = args?.getString(RutasDestino.SolicitarAusencia.ARG_INICIO)
                 val finArg = args?.getString(RutasDestino.SolicitarAusencia.ARG_FIN)
                 val descripcionArg = args?.getString(RutasDestino.SolicitarAusencia.ARG_DESCRIPCION)
+                val justificanteArg = args?.getString(RutasDestino.SolicitarAusencia.ARG_JUSTIFICANTE)
 
                 val datosEdicion = if (
                     id > 0 && !tipoArg.isNullOrBlank() &&
@@ -135,6 +142,9 @@ fun PantallaPrincipal(
                         fechaInicio = LocalDate.parse(inicioArg),
                         fechaFin = LocalDate.parse(finArg),
                         descripcion = descripcionArg
+                            ?.takeIf { it.isNotBlank() }
+                            ?.let { URLDecoder.decode(it, "UTF-8") },
+                        justificante = justificanteArg
                             ?.takeIf { it.isNotBlank() }
                             ?.let { URLDecoder.decode(it, "UTF-8") }
                     )

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -98,7 +98,16 @@
     <string name="ausencia_label_fecha_fin">End date</string>
     <string name="ausencia_label_descripcion">Description (optional)</string>
     <string name="ausencia_btn_adjuntar">Attach supporting document</string>
+    <string name="ausencia_btn_reemplazar">Replace supporting document</string>
     <string name="ausencia_cd_quitar_archivo">Remove attachment</string>
+    <string name="ausencia_selector_titulo">Attach supporting document</string>
+    <string name="ausencia_selector_camara">Take photo with camera</string>
+    <string name="ausencia_selector_archivo">Pick a file</string>
+    <string name="ausencia_justificante_actual">Current attachment</string>
+    <string name="ausencia_cd_descargar_justificante">Download attachment</string>
+    <string name="ausencia_cd_eliminar_justificante_existente">Remove current attachment</string>
+    <string name="ausencia_error_tipo_archivo">Unsupported format. Only PDF, JPG or PNG are allowed.</string>
+    <string name="ausencia_error_archivo_grande">File exceeds the maximum allowed size (10 MB).</string>
     <string name="ausencia_btn_enviar">Submit request</string>
     <string name="ausencia_btn_cancelar">Cancel</string>
     <string name="ausencia_dialog_aceptar">OK</string>
@@ -133,4 +142,5 @@
     <string name="mis_ausencias_dialog_cancelar_confirmar">Confirm</string>
     <string name="mis_ausencias_dialog_cancelar_volver">Back</string>
     <string name="mis_ausencias_cancelada_ok">Request cancelled</string>
+    <string name="mis_ausencias_cd_descargar_justificante">Download attachment</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,7 +98,16 @@
     <string name="ausencia_label_fecha_fin">Fecha de fin</string>
     <string name="ausencia_label_descripcion">Descripción (opcional)</string>
     <string name="ausencia_btn_adjuntar">Adjuntar justificante</string>
+    <string name="ausencia_btn_reemplazar">Reemplazar justificante</string>
     <string name="ausencia_cd_quitar_archivo">Quitar archivo adjunto</string>
+    <string name="ausencia_selector_titulo">Adjuntar justificante</string>
+    <string name="ausencia_selector_camara">Tomar foto con cámara</string>
+    <string name="ausencia_selector_archivo">Seleccionar archivo</string>
+    <string name="ausencia_justificante_actual">Justificante actual</string>
+    <string name="ausencia_cd_descargar_justificante">Descargar justificante</string>
+    <string name="ausencia_cd_eliminar_justificante_existente">Eliminar justificante actual</string>
+    <string name="ausencia_error_tipo_archivo">Formato no soportado. Solo se admiten PDF, JPG o PNG.</string>
+    <string name="ausencia_error_archivo_grande">El archivo supera el tamaño máximo permitido (10 MB).</string>
     <string name="ausencia_btn_enviar">Enviar solicitud</string>
     <string name="ausencia_btn_cancelar">Cancelar</string>
     <string name="ausencia_dialog_aceptar">Aceptar</string>
@@ -133,4 +142,5 @@
     <string name="mis_ausencias_dialog_cancelar_confirmar">Confirmar</string>
     <string name="mis_ausencias_dialog_cancelar_volver">Volver</string>
     <string name="mis_ausencias_cancelada_ok">Solicitud cancelada</string>
+    <string name="mis_ausencias_cd_descargar_justificante">Descargar justificante</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="camara_justificantes"
+        path="justificantes/" />
+    <cache-path
+        name="descargas_justificantes"
+        path="descargas/" />
+</paths>


### PR DESCRIPTION
Closes #21

## Resumen
Mejora completa de la gestión de adjuntos en el flujo de ausencias.

### Selector de archivo
- BottomSheet con dos opciones: "Tomar foto con cámara" (`TakePicture`) y "Seleccionar archivo" (`GetContent`).
- FileProvider configurado en `AndroidManifest.xml` + `res/xml/file_paths.xml`.
- Permiso `CAMERA` solicitado en runtime.
- Compresión automática de imágenes de cámara: reescalado a máx. 1920px y JPEG calidad 80%.

### Previsualización
- Miniatura 72dp para imágenes (decodificada con `BitmapFactory` + `produceState`, sin dependencias externas).
- Icono PDF sobre fondo destacado cuando el archivo es `.pdf`.
- Botón "X" para deseleccionar el adjunto.

### Modo edición
- Se muestra el justificante existente con su nombre, botón de descarga 📥 y botón de eliminación 🗑️.
- Al seleccionar un nuevo archivo, sustituye al anterior en el próximo `PUT`.
- Si se elimina explícitamente, se envía `PUT` sin la parte `archivo`.
- Descarga vía `GET /api/ausencias/justificantes/{nombreArchivo}` → cache + `Intent.ACTION_VIEW`.

### Advertencia ámbar
- Texto no bloqueante en `#F57C00` cuando `tipo == MEDICA` y no hay adjunto.

### Listado "Mis ausencias"
- Icono 📎 en la tarjeta cuando `justificante != null`.
- Al pulsarlo, descarga y abre el archivo con el visor del sistema.

### Validación
- Extensiones soportadas: `pdf`, `jpg`, `jpeg`, `png`.
- Tamaño máximo local: 10 MB.
- Mensajes de error localizados en `strings.xml` / `strings-en.xml`.

### Cambios técnicos relevantes
- `AusenciaApiService.actualizarAusencia` pasa a `@Multipart @PUT` (antes `@Body` JSON) para soportar archivo en edición.
- Nuevo endpoint `GET /api/ausencias/justificantes/{nombreArchivo}` en el service y en `IAusenciaRepository`.
- Nueva utilidad `core/archivos/GestorArchivosJustificante.kt` (FileProvider, compresión, descarga, apertura con visor).
- `SolicitarAusenciaUseCase` valida extensión y tamaño y propaga el archivo también en edición.
- Factories manuales mantenidas — no se ha introducido ninguna dependencia nueva.

## Test plan
- [ ] Crear ausencia seleccionando archivo PDF → se previsualiza el icono PDF y se envía multipart.
- [ ] Crear ausencia tomando foto con cámara → se comprime antes de enviar.
- [ ] Crear ausencia seleccionando imagen galería → miniatura visible y envío OK.
- [ ] Editar ausencia con justificante → se descarga y abre con el visor del sistema.
- [ ] Editar y reemplazar justificante existente → el servidor recibe el nuevo archivo.
- [ ] Editar y eliminar justificante existente → se envía `PUT` sin adjunto.
- [ ] Seleccionar archivo no soportado (.docx) → snackbar con error claro.
- [ ] Listado "Mis ausencias" con una ausencia con justificante → icono 📎 clicable que descarga y abre.
- [ ] Tipo MEDICA sin adjunto → advertencia ámbar visible, envío permitido.