### PR TITLE
Feature/p2 07 adjuntos ausencias

### DIFF
--- a/app/src/main/java/com/gestorrh/android/core/archivos/GestorArchivosJustificante.kt
+++ b/app/src/main/java/com/gestorrh/android/core/archivos/GestorArchivosJustificante.kt
@@ -1,5 +1,6 @@
 package com.gestorrh.android.core.archivos
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -97,15 +98,22 @@ object GestorArchivosJustificante {
     /**
      * Lanza un `Intent.ACTION_VIEW` con el [uri] y el tipo MIME inferido del nombre
      * para que el sistema muestre el justificante con la aplicación preferida del usuario.
+     * Devuelve `true` si se ha podido lanzar un visor y `false` si no hay ninguna
+     * aplicación instalada capaz de abrir el tipo MIME indicado.
      */
-    fun abrirConVisorSistema(contexto: Context, uri: Uri, nombreArchivo: String) {
+    fun abrirConVisorSistema(contexto: Context, uri: Uri, nombreArchivo: String): Boolean {
         val mime = mimeDesdeNombre(nombreArchivo)
         val intent = Intent(Intent.ACTION_VIEW).apply {
             setDataAndType(uri, mime)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        contexto.startActivity(intent)
+        return try {
+            contexto.startActivity(intent)
+            true
+        } catch (e: ActivityNotFoundException) {
+            false
+        }
     }
 
     /** Devuelve `true` si [nombre] termina con una extensión de imagen soportada. */

--- a/app/src/main/java/com/gestorrh/android/data/network/ausencia/PeticionAusenciaDTO.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/ausencia/PeticionAusenciaDTO.kt
@@ -2,9 +2,20 @@ package com.gestorrh.android.data.network.ausencia
 
 import java.time.LocalDate
 
+/**
+ * Cuerpo JSON (parte `datos` del `multipart`) enviado a `POST /api/ausencias` y
+ * `PUT /api/ausencias/{id}`.
+ *
+ * @property eliminarJustificante Solo relevante en modo edición cuando la parte
+ *           `archivo` no se envía: si es `true` el servidor debe borrar el
+ *           justificante actual; si es `false` debe mantenerlo intacto. En modo
+ *           creación o cuando se adjunta un archivo nuevo se envía `null` para
+ *           que el servidor ignore el flag.
+ */
 data class PeticionAusenciaDTO(
     val tipo: String,
     val descripcion: String?,
     val fechaInicio: LocalDate,
-    val fechaFin: LocalDate
+    val fechaFin: LocalDate,
+    val eliminarJustificante: Boolean? = null
 )

--- a/app/src/main/java/com/gestorrh/android/domain/usecase/ausencia/SolicitarAusenciaUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/ausencia/SolicitarAusenciaUseCase.kt
@@ -43,6 +43,7 @@ class SolicitarAusenciaUseCase(
         archivoBytes: ByteArray?,
         nombreArchivo: String?,
         idAusenciaEditar: Long? = null,
+        eliminarJustificante: Boolean? = null,
         hoy: LocalDate = LocalDate.now()
     ): Result<RespuestaAusenciaDTO> {
         if (tipo.isNullOrBlank()) {
@@ -63,11 +64,20 @@ class SolicitarAusenciaUseCase(
             }
         }
 
+        // Solo en modo edición y sin archivo nuevo tiene sentido propagar el flag:
+        // si hay archivo nuevo el servidor lo reemplaza; en modo creación no existe
+        // justificante previo que eliminar.
+        val flagEliminar = if (idAusenciaEditar != null && archivoBytes == null) {
+            eliminarJustificante
+        } else {
+            null
+        }
         val peticion = PeticionAusenciaDTO(
             tipo = tipo,
             descripcion = descripcion?.takeIf { it.isNotBlank() },
             fechaInicio = fechaInicio,
-            fechaFin = fechaFin
+            fechaFin = fechaFin,
+            eliminarJustificante = flagEliminar
         )
         return if (idAusenciaEditar != null) {
             repository.actualizarAusencia(idAusenciaEditar, peticion, archivoBytes, nombreArchivo)

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/MisAusenciasViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/MisAusenciasViewModel.kt
@@ -134,6 +134,17 @@ class MisAusenciasViewModel(
         _estadoUi.update { it.copy(abrirJustificante = null) }
     }
 
+    /**
+     * Notifica que el sistema no ha podido abrir el justificante porque no hay
+     * ninguna aplicación instalada capaz de gestionar su tipo MIME. Se muestra
+     * un mensaje en el Snackbar reutilizando el canal de errores.
+     */
+    fun notificarSinVisorDisponible() {
+        _estadoUi.update {
+            it.copy(mensajeError = MensajeUi.Recurso(R.string.ausencia_error_sin_visor))
+        }
+    }
+
     companion object {
         fun factory(contexto: Context): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory {

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
@@ -115,10 +115,13 @@ fun PantallaMisAusencias(
 
     LaunchedEffect(estadoUi.abrirJustificante) {
         estadoUi.abrirJustificante?.let { evento ->
-            GestorArchivosJustificante.abrirConVisorSistema(
+            val abierto = GestorArchivosJustificante.abrirConVisorSistema(
                 contextoLocal, evento.uri, evento.nombreArchivo
             )
             viewModel.aperturaJustificanteConsumida()
+            if (!abierto) {
+                viewModel.notificarSinVisorDisponible()
+            }
         }
     }
 

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
@@ -158,10 +158,13 @@ fun PantallaSolicitudAusencia(
 
     LaunchedEffect(estadoUi.abrirJustificante) {
         estadoUi.abrirJustificante?.let { evento ->
-            GestorArchivosJustificante.abrirConVisorSistema(
+            val abierto = GestorArchivosJustificante.abrirConVisorSistema(
                 contextoLocal, evento.uri, evento.nombreArchivo
             )
             viewModel.aperturaJustificanteConsumida()
+            if (!abierto) {
+                viewModel.notificarSinVisorDisponible()
+            }
         }
     }
 

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
@@ -244,6 +244,17 @@ class SolicitudAusenciaViewModel(
         _estadoUi.update { it.copy(abrirJustificante = null) }
     }
 
+    /**
+     * Notifica que el sistema no ha podido abrir el justificante porque no hay
+     * ninguna aplicación instalada capaz de gestionar su tipo MIME. Se muestra
+     * un mensaje en el Snackbar reutilizando el canal de errores.
+     */
+    fun notificarSinVisorDisponible() {
+        _estadoUi.update {
+            it.copy(mensajeError = MensajeUi.Recurso(R.string.ausencia_error_sin_visor))
+        }
+    }
+
     fun errorMostrado() {
         _estadoUi.update { it.copy(mensajeError = null) }
     }

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
@@ -268,6 +268,18 @@ class SolicitudAusenciaViewModel(
                 nombreNormalizadoParaSubida(estadoActual.nombreArchivo, estadoActual.esImagen)
             }
 
+            // En edición sin archivo nuevo propagamos el flag para que el servidor sepa
+            // si debe borrar el justificante existente (true) o mantenerlo (false).
+            val flagEliminar = if (
+                estadoActual.idAusenciaEditar != null &&
+                archivoBytes == null &&
+                estadoActual.nombreJustificanteExistente != null
+            ) {
+                estadoActual.eliminarJustificanteExistente
+            } else {
+                null
+            }
+
             val resultado = solicitarAusenciaUseCase(
                 tipo = estadoActual.tipoSeleccionado,
                 descripcion = estadoActual.descripcion,
@@ -275,7 +287,8 @@ class SolicitudAusenciaViewModel(
                 fechaFin = estadoActual.fechaFin,
                 archivoBytes = archivoBytes,
                 nombreArchivo = nombreParaSubir,
-                idAusenciaEditar = estadoActual.idAusenciaEditar
+                idAusenciaEditar = estadoActual.idAusenciaEditar,
+                eliminarJustificante = flagEliminar
             )
 
             resultado

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -108,6 +108,7 @@
     <string name="ausencia_cd_eliminar_justificante_existente">Remove current attachment</string>
     <string name="ausencia_error_tipo_archivo">Unsupported format. Only PDF, JPG or PNG are allowed.</string>
     <string name="ausencia_error_archivo_grande">File exceeds the maximum allowed size (10 MB).</string>
+    <string name="ausencia_error_sin_visor">No app available to open this file type.</string>
     <string name="ausencia_btn_enviar">Submit request</string>
     <string name="ausencia_btn_cancelar">Cancel</string>
     <string name="ausencia_dialog_aceptar">OK</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,7 @@
     <string name="ausencia_cd_eliminar_justificante_existente">Eliminar justificante actual</string>
     <string name="ausencia_error_tipo_archivo">Formato no soportado. Solo se admiten PDF, JPG o PNG.</string>
     <string name="ausencia_error_archivo_grande">El archivo supera el tamaño máximo permitido (10 MB).</string>
+    <string name="ausencia_error_sin_visor">No hay ninguna aplicación disponible para abrir este tipo de archivo.</string>
     <string name="ausencia_btn_enviar">Enviar solicitud</string>
     <string name="ausencia_btn_cancelar">Cancelar</string>
     <string name="ausencia_dialog_aceptar">Aceptar</string>


### PR DESCRIPTION
# Fix: Gestión completa de justificantes existentes en ausencias

## Problema

La funcionalidad de adjuntar justificantes en ausencias (P2-07) estaba parcialmente implementada pero tenía varios fallos críticos de UX:

1. **En el listado de ausencias:** No había indicador visual cuando una ausencia tenía justificante adjunto
2. **En modo edición:** No se mostraba información sobre el justificante existente ni opciones para descargarlo o eliminarlo
3. **Gestión ambigua:** No se distinguía entre "mantener justificante existente" vs "eliminar justificante" al editar sin adjuntar archivo nuevo

## Cambios implementados

### 1. Listado de ausencias - Indicador visual
- ✅ Icono 📎 (`AttachFile`) visible en cards con justificante adjunto
- ✅ Al hacer clic descarga y abre el archivo con el visor del sistema
- ✅ Loading indicator durante la descarga
- ✅ Manejo de errores si no hay visor disponible

### 2. Modo edición - Gestión de justificante existente
- ✅ Sección "Justificante actual" que muestra el nombre del archivo
- ✅ Icono de descarga 📥 para ver el justificante actual
- ✅ Botón "Eliminar justificante" que permite eliminarlo sin subir uno nuevo
- ✅ Al adjuntar archivo nuevo, reemplaza automáticamente al existente

### 3. Lógica de backend
- ✅ Nuevo campo `eliminarJustificante: Boolean?` en `PeticionAusenciaDTO`
- ✅ `SolicitarAusenciaUseCase` distingue entre:
  - Crear ausencia con/sin adjunto → `eliminarJustificante = null`
  - Editar sin tocar justificante → mantiene el existente
  - Editar con nuevo archivo → reemplaza al existente
  - Editar marcando "eliminar" → envía flag `true` al backend

### 4. Manejo de errores
- ✅ Captura `ActivityNotFoundException` cuando no hay visor disponible
- ✅ Snackbar con mensaje claro: "No hay aplicación para abrir este tipo de archivo"
- ✅ Strings localizados (ES/EN)

## Archivos modificados

**Data Layer:**
- `PeticionAusenciaDTO.kt` - Nuevo campo `eliminarJustificante`
- `AusenciaApiService.kt` - Método `descargarJustificante()`
- `AusenciaRepository.kt` - Implementación de descarga

**Domain Layer:**
- `SolicitarAusenciaUseCase.kt` - Lógica de flag `eliminarJustificante`

**Presentation Layer:**
- `SolicitudAusenciaViewModel.kt` - Estado y lógica de justificante existente
- `PantallaSolicitudAusencia.kt` - UI de gestión de justificante en modo edición
- `MisAusenciasViewModel.kt` - Descarga de justificantes desde listado
- `PantallaMisAusencias.kt` - Icono 📎 y descarga

**Utils:**
- `GestorArchivosJustificante.kt` - Manejo de `ActivityNotFoundException`

**Resources:**
- `strings.xml` / `strings-en.xml` - Nuevos strings

## Testing manual realizado

- [x] Crear ausencia sin justificante → se crea correctamente
- [x] Crear ausencia con justificante → se sube correctamente
- [x] Editar ausencia sin justificante → se puede adjuntar nuevo
- [x] Editar ausencia con justificante:
  - [x] Se muestra nombre del archivo actual
  - [x] Se puede descargar y abrir
  - [x] Se puede eliminar sin subir uno nuevo
  - [x] Se puede reemplazar por uno nuevo
  - [x] Si no se toca, se mantiene el existente
- [x] En listado, icono 📎 solo aparece en ausencias con justificante
- [x] Al hacer clic en 📎, descarga y abre correctamente
- [x] Si no hay visor, muestra mensaje de error apropiado

## Capturas de pantalla

_(Opcional: añade capturas mostrando el icono 📎 en el listado y la sección de justificante actual en modo edición)_

## Checklist

- [x] El código compila sin errores
- [x] Cero strings hardcodeados
- [x] Factories manuales (no Koin)
- [x] Conventional Commits aplicados
- [x] Funciona correctamente en modo crear y editar
- [x] Manejo de errores implementado