### PR TITLE
chore: restaurar logs de diagnóstico del flujo de adjuntos (#21)

### DIFF
--- a/app/src/main/java/com/gestorrh/android/core/archivos/GestorArchivosJustificante.kt
+++ b/app/src/main/java/com/gestorrh/android/core/archivos/GestorArchivosJustificante.kt
@@ -7,6 +7,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.provider.OpenableColumns
+import android.util.Log
 import androidx.core.content.FileProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -24,6 +25,7 @@ import java.io.FileOutputStream
  */
 object GestorArchivosJustificante {
 
+    private const val TAG_DIAG = "DiagAdjunto"
     private const val ANCHO_MAXIMO_IMAGEN_PX = 1920
     private const val CALIDAD_JPEG = 80
     private const val SUBDIRECTORIO_CAMARA = "justificantes"
@@ -52,15 +54,26 @@ object GestorArchivosJustificante {
         uri: Uri,
         esImagen: Boolean
     ): ByteArray? = withContext(Dispatchers.IO) {
-        try {
+        val mimeResolver = runCatching { contexto.contentResolver.getType(uri) }.getOrNull()
+        Log.d(
+            TAG_DIAG,
+            "leerBytesParaSubida:entrada scheme=${uri.scheme} esImagen=$esImagen mimeResolver=$mimeResolver"
+        )
+        val bytes = try {
             if (esImagen) {
                 comprimirImagen(contexto, uri)
             } else {
                 contexto.contentResolver.openInputStream(uri)?.use { it.readBytes() }
             }
         } catch (e: Exception) {
+            Log.e(TAG_DIAG, "leerBytesParaSubida:excepcion ${e.javaClass.simpleName}: ${e.message}", e)
             null
         }
+        Log.d(
+            TAG_DIAG,
+            "leerBytesParaSubida:salida bytesNull=${bytes == null} size=${bytes?.size ?: -1}"
+        )
+        bytes
     }
 
     /**
@@ -135,22 +148,37 @@ object GestorArchivosJustificante {
 
     private fun comprimirImagen(contexto: Context, uri: Uri): ByteArray? {
         val opcionesLectura = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-        contexto.contentResolver.openInputStream(uri)?.use {
-            BitmapFactory.decodeStream(it, null, opcionesLectura)
-        } ?: return null
+        val streamBounds = contexto.contentResolver.openInputStream(uri)
+        if (streamBounds == null) {
+            Log.w(TAG_DIAG, "comprimirImagen: openInputStream#1 devolvio null")
+            return null
+        }
+        streamBounds.use { BitmapFactory.decodeStream(it, null, opcionesLectura) }
 
         val anchoOriginal = opcionesLectura.outWidth
         val altoOriginal = opcionesLectura.outHeight
-        if (anchoOriginal <= 0 || altoOriginal <= 0) return null
+        Log.d(TAG_DIAG, "comprimirImagen: bounds ancho=$anchoOriginal alto=$altoOriginal")
+        if (anchoOriginal <= 0 || altoOriginal <= 0) {
+            Log.w(TAG_DIAG, "comprimirImagen: dimensiones invalidas, abortando")
+            return null
+        }
 
         val ladoMayor = maxOf(anchoOriginal, altoOriginal)
         val factorSubmuestreo = calcularInSampleSize(ladoMayor, ANCHO_MAXIMO_IMAGEN_PX)
         val opcionesDecodificado = BitmapFactory.Options().apply {
             inSampleSize = factorSubmuestreo
         }
-        val bitmap = contexto.contentResolver.openInputStream(uri)?.use {
+        val streamDecode = contexto.contentResolver.openInputStream(uri)
+        if (streamDecode == null) {
+            Log.w(TAG_DIAG, "comprimirImagen: openInputStream#2 devolvio null")
+            return null
+        }
+        val bitmap = streamDecode.use {
             BitmapFactory.decodeStream(it, null, opcionesDecodificado)
-        } ?: return null
+        } ?: run {
+            Log.w(TAG_DIAG, "comprimirImagen: decodeStream devolvio null")
+            return null
+        }
 
         val bitmapEscalado = escalarSiNecesario(bitmap, ANCHO_MAXIMO_IMAGEN_PX)
         val salida = ByteArrayOutputStream()

--- a/app/src/main/java/com/gestorrh/android/data/repository/ausencia/AusenciaRepositoryImpl.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/ausencia/AusenciaRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.gestorrh.android.data.network.ausencia.AusenciaApiService
 import com.gestorrh.android.data.network.ausencia.PeticionAusenciaDTO
 import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
 import com.gestorrh.android.domain.repository.IAusenciaRepository
+import android.util.Log
 import com.google.gson.Gson
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -170,8 +171,18 @@ class AusenciaRepositoryImpl(
         archivoBytes: ByteArray?,
         nombreArchivo: String?
     ): MultipartBody.Part? {
-        if (archivoBytes == null) return null
+        if (archivoBytes == null) {
+            Log.d(
+                "DiagAdjunto",
+                "construirPartArchivo: bytes null -> no se envia parte archivo"
+            )
+            return null
+        }
         val tipoMime = tipoMimeDesdeNombre(nombreArchivo)
+        Log.d(
+            "DiagAdjunto",
+            "construirPartArchivo: incluyendo parte archivo size=${archivoBytes.size} mime=$tipoMime"
+        )
         return MultipartBody.Part.createFormData(
             "archivo",
             nombreArchivo ?: "justificante",

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
@@ -2,6 +2,7 @@ package com.gestorrh.android.ui.ausencia
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -161,6 +162,10 @@ class SolicitudAusenciaViewModel(
         val nombre = nombreOriginal?.takeIf { it.isNotBlank() } ?: "justificante"
         val esImagen = GestorArchivosJustificante.esImagenPorNombre(nombre)
         val esPdf = nombre.substringAfterLast('.', "").lowercase() == "pdf"
+        Log.d(
+            "DiagAdjunto",
+            "aplicarArchivo: scheme=${uri.scheme} tieneNombre=${nombreOriginal != null} esImagen=$esImagen esPdf=$esPdf"
+        )
         if (!esImagen && !esPdf) {
             _estadoUi.update {
                 it.copy(mensajeError = MensajeUi.Recurso(R.string.ausencia_error_tipo_archivo))
@@ -270,6 +275,11 @@ class SolicitudAusenciaViewModel(
         viewModelScope.launch {
             _estadoUi.update { it.copy(enviando = true, mensajeError = null) }
 
+            Log.d(
+                "DiagAdjunto",
+                "enviar:estado archivoUri=${estadoActual.archivoUri != null} nombre=${estadoActual.nombreArchivo != null} esImagen=${estadoActual.esImagen} modoEdicion=${estadoActual.modoEdicion}"
+            )
+
             val archivoBytes = estadoActual.archivoUri?.let { uri ->
                 GestorArchivosJustificante.leerBytesParaSubida(
                     contextoAplicacion, uri, estadoActual.esImagen
@@ -278,6 +288,11 @@ class SolicitudAusenciaViewModel(
             val nombreParaSubir = estadoActual.archivoUri?.let {
                 nombreNormalizadoParaSubida(estadoActual.nombreArchivo, estadoActual.esImagen)
             }
+
+            Log.d(
+                "DiagAdjunto",
+                "enviar:preUseCase bytesNull=${archivoBytes == null} size=${archivoBytes?.size ?: -1} nombreNull=${nombreParaSubir == null}"
+            )
 
             // En edición sin archivo nuevo propagamos el flag para que el servidor sepa
             // si debe borrar el justificante existente (true) o mantenerlo (false).


### PR DESCRIPTION
Restauro los Log.d/Log.w/Log.e del flujo de adjuntos: tras mergear a main se volvió a detectar el bug de justificantes y los logs siguen siendo útiles para diagnosticarlo. Solo publican booleans, tamaños y flags: no filtran nombres ni contenido del archivo.