### PR TITLE
feat: fichaje offline con WorkManager (#22)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,4 +100,7 @@ dependencies {
 
     // 6. Lifecycle Compose (collectAsStateWithLifecycle)
     implementation(libs.androidx.lifecycle.runtime.compose)
+
+    // 7. WorkManager (sincronización diferida de fichajes offline)
+    implementation(libs.androidx.work.runtime.ktx)
 }

--- a/app/src/main/java/com/gestorrh/android/core/network/ConectividadUtils.kt
+++ b/app/src/main/java/com/gestorrh/android/core/network/ConectividadUtils.kt
@@ -1,0 +1,18 @@
+package com.gestorrh.android.core.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+/**
+ * Comprueba si el dispositivo tiene conectividad validada a Internet.
+ * Se consultan las capacidades del `activeNetwork` para evitar falsos positivos
+ * cuando hay interfaz de red activa pero sin acceso real al exterior.
+ */
+fun Context.hayConexion(): Boolean {
+    val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager ?: return false
+    val red = cm.activeNetwork ?: return false
+    val capacidades = cm.getNetworkCapabilities(red) ?: return false
+    return capacidades.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+        capacidades.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+}

--- a/app/src/main/java/com/gestorrh/android/data/local/GestorRhDatabase.kt
+++ b/app/src/main/java/com/gestorrh/android/data/local/GestorRhDatabase.kt
@@ -4,20 +4,49 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.gestorrh.android.data.local.dao.AsignacionDao
+import com.gestorrh.android.data.local.dao.FichajePendienteDao
 import com.gestorrh.android.data.local.entity.AsignacionEntity
+import com.gestorrh.android.data.local.entity.FichajePendienteEntity
 
 @Database(
-    entities = [AsignacionEntity::class],
-    version = 1,
+    entities = [AsignacionEntity::class, FichajePendienteEntity::class],
+    version = 2,
     exportSchema = false
 )
 abstract class GestorRhDatabase : RoomDatabase() {
 
     abstract fun asignacionDao(): AsignacionDao
 
+    abstract fun fichajePendienteDao(): FichajePendienteDao
+
     companion object {
         private const val NOMBRE_BASE_DATOS = "gestorrh.db"
+
+        /**
+         * Migración de la versión 1 a la 2: añade la tabla `fichajes_pendientes` para
+         * soportar la cola offline de fichajes sincronizada por `SyncFichajeWorker`.
+         * Se define explícitamente para preservar la caché local de asignaciones de los
+         * usuarios que ya tengan la aplicación instalada al desplegar esta versión.
+         */
+        val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS fichajes_pendientes (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        tipo TEXT NOT NULL,
+                        latitud REAL,
+                        longitud REAL,
+                        timestamp INTEGER NOT NULL,
+                        intentos INTEGER NOT NULL DEFAULT 0
+                    )
+                    """.trimIndent()
+                )
+            }
+        }
 
         @Volatile
         private var instancia: GestorRhDatabase? = null
@@ -29,6 +58,7 @@ abstract class GestorRhDatabase : RoomDatabase() {
                     GestorRhDatabase::class.java,
                     NOMBRE_BASE_DATOS
                 )
+                    .addMigrations(MIGRATION_1_2)
                     .fallbackToDestructiveMigration(dropAllTables = true)
                     .build()
                     .also { instancia = it }

--- a/app/src/main/java/com/gestorrh/android/data/local/dao/FichajePendienteDao.kt
+++ b/app/src/main/java/com/gestorrh/android/data/local/dao/FichajePendienteDao.kt
@@ -1,0 +1,37 @@
+package com.gestorrh.android.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import com.gestorrh.android.data.local.entity.FichajePendienteEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Acceso a la tabla `fichajes_pendientes` utilizada para la cola offline de fichajes.
+ * Los fichajes se listan por `timestamp` ascendente para garantizar que las entradas
+ * se reenvían antes que las salidas, respetando la secuencia que el usuario registró.
+ */
+@Dao
+interface FichajePendienteDao {
+
+    @Query("SELECT * FROM fichajes_pendientes ORDER BY timestamp ASC")
+    suspend fun obtenerTodos(): List<FichajePendienteEntity>
+
+    @Insert
+    suspend fun insertar(fichaje: FichajePendienteEntity): Long
+
+    @Query("DELETE FROM fichajes_pendientes WHERE id = :id")
+    suspend fun eliminar(id: Long)
+
+    @Query("SELECT COUNT(*) FROM fichajes_pendientes")
+    suspend fun contarPendientes(): Int
+
+    @Query("SELECT COUNT(*) FROM fichajes_pendientes")
+    fun observarContadorPendientes(): Flow<Int>
+
+    @Query("SELECT COUNT(*) FROM fichajes_pendientes WHERE tipo = :tipo")
+    suspend fun contarPorTipo(tipo: String): Int
+
+    @Query("UPDATE fichajes_pendientes SET intentos = intentos + 1 WHERE id = :id")
+    suspend fun incrementarIntentos(id: Long)
+}

--- a/app/src/main/java/com/gestorrh/android/data/local/entity/FichajePendienteEntity.kt
+++ b/app/src/main/java/com/gestorrh/android/data/local/entity/FichajePendienteEntity.kt
@@ -1,0 +1,26 @@
+package com.gestorrh.android.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Fichaje generado en un entorno sin conectividad. Se persiste localmente hasta que
+ * `SyncFichajeWorker` logre entregarlo al backend. El campo `timestamp` almacena el
+ * instante real del clic en milisegundos (epoch) para preservar el orden cronológico
+ * cuando se reenvíen varios fichajes acumulados. `intentos` se utiliza como métrica
+ * interna de diagnóstico para detectar fichajes que no pueden sincronizarse.
+ */
+@Entity(tableName = "fichajes_pendientes")
+data class FichajePendienteEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val tipo: String,
+    val latitud: Double?,
+    val longitud: Double?,
+    val timestamp: Long,
+    val intentos: Int = 0
+) {
+    companion object {
+        const val TIPO_ENTRADA = "ENTRADA"
+        const val TIPO_SALIDA = "SALIDA"
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/data/sync/FichajeSyncManager.kt
+++ b/app/src/main/java/com/gestorrh/android/data/sync/FichajeSyncManager.kt
@@ -1,0 +1,40 @@
+package com.gestorrh.android.data.sync
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkRequest
+import java.util.concurrent.TimeUnit
+
+/**
+ * Punto único para encolar el `SyncFichajeWorker`. Usa `ExistingWorkPolicy.KEEP`
+ * para no duplicar trabajos cuando el usuario acumula varios fichajes offline
+ * consecutivos y un backoff exponencial para no martillear al backend cuando la
+ * causa del fallo sea transitoria.
+ */
+object FichajeSyncManager {
+
+    private const val NOMBRE_TRABAJO = "sync_fichajes"
+
+    fun encolarSincronizacion(contexto: Context) {
+        val restricciones = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val peticion = OneTimeWorkRequestBuilder<SyncFichajeWorker>()
+            .setConstraints(restricciones)
+            .setBackoffCriteria(
+                BackoffPolicy.EXPONENTIAL,
+                WorkRequest.MIN_BACKOFF_MILLIS,
+                TimeUnit.MILLISECONDS
+            )
+            .build()
+
+        WorkManager.getInstance(contexto.applicationContext)
+            .enqueueUniqueWork(NOMBRE_TRABAJO, ExistingWorkPolicy.KEEP, peticion)
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/data/sync/SyncFichajeWorker.kt
+++ b/app/src/main/java/com/gestorrh/android/data/sync/SyncFichajeWorker.kt
@@ -1,0 +1,100 @@
+package com.gestorrh.android.data.sync
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.gestorrh.android.core.network.ApiClient
+import com.gestorrh.android.core.security.SessionManager
+import com.gestorrh.android.data.local.GestorRhDatabase
+import com.gestorrh.android.data.local.entity.FichajePendienteEntity
+import com.gestorrh.android.data.network.fichaje.FichajeApiService
+import com.gestorrh.android.data.network.fichaje.PeticionFichajeEntradaDTO
+import com.gestorrh.android.data.network.fichaje.PeticionFichajeSalidaDTO
+
+/**
+ * Worker responsable de vaciar la cola de fichajes pendientes.
+ *
+ * Estrategia:
+ *  - 2xx: fichaje aceptado, se elimina de Room.
+ *  - 4xx: error definitivo (geovallado, datos inválidos); se elimina para no reintentar
+ *    indefinidamente una petición que el servidor siempre rechazará.
+ *  - 5xx o error de red: se incrementa el contador `intentos` y se devuelve `Result.retry()`
+ *    para que WorkManager aplique backoff exponencial sobre el `WorkRequest`.
+ */
+class SyncFichajeWorker(
+    contexto: Context,
+    parametros: WorkerParameters
+) : CoroutineWorker(contexto, parametros) {
+
+    private val base = applicationContext
+    private val sessionManager = SessionManager(base)
+    private val fichajePendienteDao = GestorRhDatabase.getInstance(base).fichajePendienteDao()
+    private val fichajeApiService: FichajeApiService = ApiClient.crearRetrofit(sessionManager)
+        .create(FichajeApiService::class.java)
+
+    override suspend fun doWork(): Result {
+        Log.d(TAG, "Iniciando sincronización de fichajes pendientes")
+        val pendientes = fichajePendienteDao.obtenerTodos()
+
+        if (pendientes.isEmpty()) {
+            Log.d(TAG, "No hay fichajes pendientes")
+            return Result.success()
+        }
+
+        var necesitaReintento = false
+
+        pendientes.forEach { fichaje ->
+            val resultado = procesar(fichaje)
+            if (resultado == ResultadoSync.REINTENTAR) {
+                fichajePendienteDao.incrementarIntentos(fichaje.id)
+                necesitaReintento = true
+            } else {
+                fichajePendienteDao.eliminar(fichaje.id)
+            }
+        }
+
+        return if (necesitaReintento) Result.retry() else Result.success()
+    }
+
+    private suspend fun procesar(fichaje: FichajePendienteEntity): ResultadoSync {
+        return try {
+            val respuesta = when (fichaje.tipo) {
+                FichajePendienteEntity.TIPO_ENTRADA -> fichajeApiService.ficharEntrada(
+                    PeticionFichajeEntradaDTO(fichaje.latitud, fichaje.longitud)
+                )
+                FichajePendienteEntity.TIPO_SALIDA -> fichajeApiService.ficharSalida(
+                    PeticionFichajeSalidaDTO(fichaje.latitud, fichaje.longitud)
+                )
+                else -> {
+                    Log.w(TAG, "Tipo de fichaje desconocido: ${fichaje.tipo}")
+                    return ResultadoSync.DESCARTAR
+                }
+            }
+
+            when {
+                respuesta.isSuccessful -> {
+                    Log.d(TAG, "Fichaje ${fichaje.id} sincronizado (${fichaje.tipo})")
+                    ResultadoSync.EXITO
+                }
+                respuesta.code() in 400..499 -> {
+                    Log.w(TAG, "Fichaje ${fichaje.id} rechazado (${respuesta.code()})")
+                    ResultadoSync.DESCARTAR
+                }
+                else -> {
+                    Log.e(TAG, "Error servidor sincronizando fichaje ${fichaje.id}: ${respuesta.code()}")
+                    ResultadoSync.REINTENTAR
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Excepción sincronizando fichaje ${fichaje.id}", e)
+            ResultadoSync.REINTENTAR
+        }
+    }
+
+    private enum class ResultadoSync { EXITO, DESCARTAR, REINTENTAR }
+
+    companion object {
+        private const val TAG = "SyncFichajeWorker"
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/domain/usecase/fichaje/GuardarFichajePendienteUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/fichaje/GuardarFichajePendienteUseCase.kt
@@ -1,0 +1,28 @@
+package com.gestorrh.android.domain.usecase.fichaje
+
+import com.gestorrh.android.data.local.dao.FichajePendienteDao
+import com.gestorrh.android.data.local.entity.FichajePendienteEntity
+
+/**
+ * Persiste un fichaje en la cola offline cuando no hay conectividad.
+ * `SyncFichajeWorker` consumirá esta cola en cuanto WorkManager detecte red.
+ */
+class GuardarFichajePendienteUseCase(
+    private val fichajePendienteDao: FichajePendienteDao
+) {
+    suspend operator fun invoke(
+        tipo: String,
+        latitud: Double?,
+        longitud: Double?
+    ): Result<Long> = try {
+        val entidad = FichajePendienteEntity(
+            tipo = tipo,
+            latitud = latitud,
+            longitud = longitud,
+            timestamp = System.currentTimeMillis()
+        )
+        Result.success(fichajePendienteDao.insertar(entidad))
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -7,14 +7,20 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.gestorrh.android.R
 import com.gestorrh.android.core.network.ApiClient
+import com.gestorrh.android.core.network.hayConexion
 import com.gestorrh.android.core.security.SessionManager
 import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.local.GestorRhDatabase
+import com.gestorrh.android.data.local.dao.FichajePendienteDao
+import com.gestorrh.android.data.local.entity.FichajePendienteEntity
 import com.gestorrh.android.data.network.fichaje.FichajeApiService
 import com.gestorrh.android.data.network.fichaje.ModalidadTurno
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeEntradaDTO
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeSalidaDTO
 import com.gestorrh.android.data.repository.FichajeRepository
+import com.gestorrh.android.data.sync.FichajeSyncManager
 import com.gestorrh.android.domain.repository.IFichajeRepository
+import com.gestorrh.android.domain.usecase.fichaje.GuardarFichajePendienteUseCase
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,11 +36,14 @@ data class EstadoUiDashboard(
     val tiempoTranscurrido: String = "00:00:00",
     val estaCargando: Boolean = true,
     val mensajeError: MensajeUi? = null,
+    val mensajeInfo: MensajeUi? = null,
     val idFichajeAbierto: Long? = null,
     val modalidadHoy: ModalidadTurno? = null,
     val tieneTurnoHoy: Boolean = false,
     /** Nombre completo del empleado autenticado, leído desde [SessionManager] sin llamadas de red. */
-    val nombreEmpleado: String = ""
+    val nombreEmpleado: String = "",
+    /** Número de fichajes en la cola offline a la espera de ser sincronizados por `SyncFichajeWorker`. */
+    val fichajesPendientesSincronizar: Int = 0
 )
 
 enum class EstadoFichaje {
@@ -43,7 +52,10 @@ enum class EstadoFichaje {
 
 class DashboardViewModel(
     private val fichajeRepository: IFichajeRepository,
-    private val sessionManager: SessionManager
+    private val sessionManager: SessionManager,
+    private val fichajePendienteDao: FichajePendienteDao,
+    private val guardarFichajePendienteUseCase: GuardarFichajePendienteUseCase,
+    private val contextoAplicacion: Context
 ) : ViewModel() {
 
     private val _estadoUi = MutableStateFlow(EstadoUiDashboard())
@@ -53,11 +65,11 @@ class DashboardViewModel(
     private var segundosAcumulados: Long = 0
 
     init {
-        // Carga el nombre desde el almacenamiento seguro sin llamada de red
         val nombre = sessionManager.getNombre() ?: ""
         _estadoUi.update { it.copy(nombreEmpleado = nombre) }
 
         sincronizarEstado()
+        cargarFichajesPendientes()
     }
 
     /**
@@ -95,6 +107,17 @@ class DashboardViewModel(
     }
 
     /**
+     * Cuenta los fichajes que esperan ser reenviados por `SyncFichajeWorker` y actualiza
+     * el estado para que la UI pueda mostrar el badge sobre el botón de fichaje.
+     */
+    fun cargarFichajesPendientes() {
+        viewModelScope.launch {
+            val pendientes = fichajePendienteDao.contarPendientes()
+            _estadoUi.update { it.copy(fichajesPendientesSincronizar = pendientes) }
+        }
+    }
+
+    /**
      * P0-10 y P0-12: Orquestador de Fichaje.
      * Decide si fichar entrada o salida según el estado actual.
      */
@@ -112,11 +135,33 @@ class DashboardViewModel(
         viewModelScope.launch {
             _estadoUi.update { it.copy(estaCargando = true, mensajeError = null) }
 
-            val peticion = if (modalidadHoy == ModalidadTurno.TELETRABAJO) {
-                PeticionFichajeEntradaDTO(latitud = null, longitud = null)
+            val latitud: Double?
+            val longitud: Double?
+            if (modalidadHoy == ModalidadTurno.TELETRABAJO) {
+                latitud = null
+                longitud = null
             } else {
-                PeticionFichajeEntradaDTO(latitud = ubicacion?.latitude, longitud = ubicacion?.longitude)
+                latitud = ubicacion?.latitude
+                longitud = ubicacion?.longitude
             }
+
+            if (!contextoAplicacion.hayConexion()) {
+                // Si ya existe una entrada pendiente, impedimos duplicar: el empleado
+                // no puede haber iniciado dos jornadas simultáneas offline.
+                val entradasPendientes = fichajePendienteDao.contarPorTipo(
+                    FichajePendienteEntity.TIPO_ENTRADA
+                )
+                if (entradasPendientes > 0) {
+                    mostrarError(MensajeUi.Recurso(R.string.fichaje_entrada_duplicada_offline))
+                    _estadoUi.update { it.copy(estaCargando = false) }
+                    return@launch
+                }
+                guardarOfflineYEncolar(FichajePendienteEntity.TIPO_ENTRADA, latitud, longitud)
+                _estadoUi.update { it.copy(estaCargando = false) }
+                return@launch
+            }
+
+            val peticion = PeticionFichajeEntradaDTO(latitud = latitud, longitud = longitud)
 
             fichajeRepository.ficharEntrada(peticion)
                 .onSuccess { fichaje ->
@@ -140,15 +185,24 @@ class DashboardViewModel(
     }
 
     private fun ficharSalida(ubicacion: Location?, idFichaje: Long?) {
-        if (idFichaje == null) return
-
         viewModelScope.launch {
             _estadoUi.update { it.copy(estaCargando = true, mensajeError = null) }
 
-            val peticion = PeticionFichajeSalidaDTO(
-                latitud = ubicacion?.latitude,
-                longitud = ubicacion?.longitude
-            )
+            val latitud = ubicacion?.latitude
+            val longitud = ubicacion?.longitude
+
+            if (!contextoAplicacion.hayConexion()) {
+                guardarOfflineYEncolar(FichajePendienteEntity.TIPO_SALIDA, latitud, longitud)
+                _estadoUi.update { it.copy(estaCargando = false) }
+                return@launch
+            }
+
+            if (idFichaje == null) {
+                _estadoUi.update { it.copy(estaCargando = false) }
+                return@launch
+            }
+
+            val peticion = PeticionFichajeSalidaDTO(latitud = latitud, longitud = longitud)
 
             fichajeRepository.ficharSalida(peticion)
                 .onSuccess {
@@ -171,10 +225,36 @@ class DashboardViewModel(
         }
     }
 
+    private suspend fun guardarOfflineYEncolar(
+        tipo: String,
+        latitud: Double?,
+        longitud: Double?
+    ) {
+        guardarFichajePendienteUseCase(tipo, latitud, longitud)
+            .onSuccess {
+                FichajeSyncManager.encolarSincronizacion(contextoAplicacion)
+                _estadoUi.update {
+                    it.copy(
+                        mensajeInfo = MensajeUi.Recurso(R.string.fichaje_sin_conexion),
+                        fichajesPendientesSincronizar = it.fichajesPendientesSincronizar + 1
+                    )
+                }
+            }
+            .onFailure { e ->
+                val mensaje = if (e.message != null) MensajeUi.Dinamico(e.message!!)
+                else MensajeUi.Recurso(R.string.error_desconocido)
+                mostrarError(mensaje)
+            }
+    }
+
     // ── FUNCIONES AUXILIARES ──────────────────────────────────────────────────
 
     fun errorMostrado() {
         _estadoUi.update { it.copy(mensajeError = null) }
+    }
+
+    fun infoMostrado() {
+        _estadoUi.update { it.copy(mensajeInfo = null) }
     }
 
     private fun mostrarError(mensaje: MensajeUi) {
@@ -211,13 +291,22 @@ class DashboardViewModel(
 class DashboardViewModelFactory(private val contexto: Context) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(DashboardViewModel::class.java)) {
-            val sessionManager = SessionManager(contexto)
+            val contextoAplicacion = contexto.applicationContext
+            val sessionManager = SessionManager(contextoAplicacion)
             val retrofit = ApiClient.crearRetrofit(sessionManager)
             val apiService = retrofit.create(FichajeApiService::class.java)
             val fichajeRepository = FichajeRepository(apiService)
+            val fichajePendienteDao = GestorRhDatabase.getInstance(contextoAplicacion).fichajePendienteDao()
+            val guardarFichajePendienteUseCase = GuardarFichajePendienteUseCase(fichajePendienteDao)
 
             @Suppress("UNCHECKED_CAST")
-            return DashboardViewModel(fichajeRepository, sessionManager) as T
+            return DashboardViewModel(
+                fichajeRepository = fichajeRepository,
+                sessionManager = sessionManager,
+                fichajePendienteDao = fichajePendienteDao,
+                guardarFichajePendienteUseCase = guardarFichajePendienteUseCase,
+                contextoAplicacion = contextoAplicacion
+            ) as T
         }
         throw IllegalArgumentException("Clase ViewModel desconocida")
     }

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -51,6 +51,10 @@ fun PantallaDashboard(
     val errorPermisoTexto = stringResource(id = R.string.error_permiso_ubicacion)
     val contextoLocal = LocalContext.current
 
+    LaunchedEffect(Unit) {
+        viewModel.cargarFichajesPendientes()
+    }
+
     LaunchedEffect(estadoUi.mensajeError) {
         estadoUi.mensajeError?.let { mensajeUi ->
             val textoMensaje = when (mensajeUi) {
@@ -59,6 +63,17 @@ fun PantallaDashboard(
             }
             snackbarHostState.showSnackbar(textoMensaje)
             viewModel.errorMostrado()
+        }
+    }
+
+    LaunchedEffect(estadoUi.mensajeInfo) {
+        estadoUi.mensajeInfo?.let { mensajeUi ->
+            val textoMensaje = when (mensajeUi) {
+                is MensajeUi.Recurso -> contextoLocal.getString(mensajeUi.idRecurso)
+                is MensajeUi.Dinamico -> mensajeUi.texto
+            }
+            snackbarHostState.showSnackbar(textoMensaje)
+            viewModel.infoMostrado()
         }
     }
 
@@ -117,6 +132,7 @@ fun PantallaDashboard(
                 tiempoTranscurrido = estadoUi.tiempoTranscurrido,
                 estaCargando = estadoUi.estaCargando,
                 modalidad = estadoUi.modalidadHoy,
+                fichajesPendientes = estadoUi.fichajesPendientesSincronizar,
                 alClickFichar = intentarFichar
             )
 
@@ -240,6 +256,7 @@ private fun WidgetFichaje(
     tiempoTranscurrido: String,
     estaCargando: Boolean,
     modalidad: ModalidadTurno?,
+    fichajesPendientes: Int,
     alClickFichar: () -> Unit
 ) {
     val esActivo = estadoActual == EstadoFichaje.TRABAJANDO
@@ -287,25 +304,51 @@ private fun WidgetFichaje(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            Button(
-                onClick = alClickFichar,
-                modifier = Modifier.fillMaxWidth().height(56.dp),
-                shape = CircleShape,
-                colors = ButtonDefaults.buttonColors(containerColor = colorBoton),
-                enabled = !estaCargando
-            ) {
-                if (estaCargando) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(24.dp),
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        strokeWidth = 2.dp
-                    )
-                } else {
-                    Text(
-                        text = stringResource(id = textoBoton),
-                        style = MaterialTheme.typography.labelLarge
-                    )
+            Box(modifier = Modifier.fillMaxWidth()) {
+                Button(
+                    onClick = alClickFichar,
+                    modifier = Modifier.fillMaxWidth().height(56.dp),
+                    shape = CircleShape,
+                    colors = ButtonDefaults.buttonColors(containerColor = colorBoton),
+                    enabled = !estaCargando
+                ) {
+                    if (estaCargando) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(24.dp),
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Text(
+                            text = stringResource(id = textoBoton),
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    }
                 }
+
+                if (fichajesPendientes > 0) {
+                    Badge(
+                        containerColor = MaterialTheme.colorScheme.error,
+                        contentColor = MaterialTheme.colorScheme.onError,
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .offset(x = (-4).dp, y = (-4).dp)
+                    ) {
+                        Text(
+                            text = fichajesPendientes.toString(),
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
+                }
+            }
+
+            if (fichajesPendientes > 0) {
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = stringResource(id = R.string.fichajes_pendientes, fichajesPendientes),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.error
+                )
             }
         }
     }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -31,6 +31,9 @@
     <string name="fichaje_estado_activo">Working</string>
     <string name="fichaje_btn_iniciar">CLOCK IN</string>
     <string name="fichaje_btn_finalizar">CLOCK OUT</string>
+    <string name="fichaje_sin_conexion">No connection — your clock event will be sent automatically</string>
+    <string name="fichajes_pendientes">%d clock event(s) pending sync</string>
+    <string name="fichaje_entrada_duplicada_offline">You already have a pending clock-in. You cannot register another until it is sent.</string>
 
     <string name="dashboard_hoy">Today</string>
     <string name="dashboard_sin_asignar">UNASSIGNED</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,9 @@
     <string name="fichaje_estado_activo">Trabajando</string>
     <string name="fichaje_btn_iniciar">INICIAR JORNADA</string>
     <string name="fichaje_btn_finalizar">FINALIZAR JORNADA</string>
+    <string name="fichaje_sin_conexion">Sin conexión — el fichaje se enviará automáticamente</string>
+    <string name="fichajes_pendientes">%d fichaje(s) pendiente(s) de sincronizar</string>
+    <string name="fichaje_entrada_duplicada_offline">Ya hay una entrada pendiente de sincronizar. No puedes registrar otra hasta que se envíe.</string>
 
     <string name="dashboard_hoy">Hoy</string>
     <string name="dashboard_sin_asignar">SIN ASIGNAR</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ kotlin = "2.2.10"
 composeBom = "2026.02.01"
 room = "2.7.1"
 ksp = "2.2.10-2.0.2"
+workManager = "2.9.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,6 +32,7 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workManager" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Closes #22

## Resumen
Implementa una cola local de fichajes que se vacía automáticamente cuando el dispositivo recupera conectividad, para empleados que trabajan en entornos con cobertura intermitente (sótanos, naves industriales).

## Cambios principales

### Data Layer
- Nueva entidad `FichajePendienteEntity` y DAO `FichajePendienteDao`.
- `GestorRhDatabase` actualizada a **versión 2** con `MIGRATION_1_2` que añade la tabla `fichajes_pendientes` preservando la caché local de asignaciones.

### Domain
- `GuardarFichajePendienteUseCase` encapsula la persistencia en la cola offline.

### Sincronización (WorkManager)
- `SyncFichajeWorker` (CoroutineWorker) recorre los fichajes por `timestamp` ascendente y los reenvía al backend:
  - 2xx → se elimina la entrada.
  - 4xx → se descarta (error definitivo, no reintentar).
  - 5xx o excepción de red → incrementa `intentos` y devuelve `Result.retry()` para que WorkManager aplique backoff exponencial.
- `FichajeSyncManager` encola el worker con `NetworkType.CONNECTED` y `ExistingWorkPolicy.KEEP` para no duplicar trabajos.

### Presentación
- `DashboardViewModel` detecta si hay conexión al fichar:
  - Sin red: guarda en Room, encola el worker y muestra un Snackbar informativo.
  - Bloqueo de doble entrada offline: si ya hay una `ENTRADA` pendiente, impide registrar otra.
- Badge rojo sobre el botón de fichaje con el número de fichajes en la cola, más un texto accesorio con el conteo.
- `PantallaDashboard` llama a `cargarFichajesPendientes()` al componerse.

### Recursos
- Nuevos strings (`fichaje_sin_conexion`, `fichajes_pendientes`, `fichaje_entrada_duplicada_offline`) en ES y EN.
- Añadida dependencia `androidx.work:work-runtime-ktx:2.9.0` al catálogo y al `build.gradle.kts`.

## Test plan
- [ ] Activar modo avión y pulsar "Iniciar/Finalizar Jornada": aparece Snackbar "Sin conexión..." y badge con el contador.
- [ ] Desactivar modo avión: `SyncFichajeWorker` se ejecuta (visible en Logcat con tag `SyncFichajeWorker`) y el badge desaparece.
- [ ] Con una entrada pendiente offline, intentar fichar otra entrada → aparece mensaje de error.
- [ ] Migración BD v1→v2 sin pérdida de asignaciones cacheadas.
- [ ] `./gradlew assembleDebug` compila sin errores.