### PR TITLE
feat: pantalla historial de fichajes personales (#34)

### DIFF
--- a/app/src/main/java/com/gestorrh/android/core/navigation/RutasDestino.kt
+++ b/app/src/main/java/com/gestorrh/android/core/navigation/RutasDestino.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.EventBusy
 import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.gestorrh.android.R
@@ -34,6 +35,17 @@ sealed class RutasDestino(
      * argumentos opcionales `id`, `tipo`, `inicio`, `fin` y `descripcion` ya
      * rellenos en la URL).
      */
+    /**
+     * Destino interno para el historial de fichajes personales del empleado autenticado.
+     * No aparece en la barra de navegación inferior: se alcanza desde la pestaña de
+     * [Perfil] o desde el botón secundario de la pantalla de [Inicio] (fichaje).
+     */
+    data object HistorialFichajes : RutasDestino(
+        ruta = "fichajes/historial",
+        tituloResId = R.string.historial_fichajes_titulo,
+        icono = Icons.Filled.History
+    )
+
     data object SolicitarAusencia : RutasDestino(
         ruta = "ausencias/solicitar?id={id}&tipo={tipo}&inicio={inicio}&fin={fin}&descripcion={descripcion}&justificante={justificante}",
         tituloResId = R.string.nav_ausencias,

--- a/app/src/main/java/com/gestorrh/android/data/network/fichaje/FichajeApiService.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/fichaje/FichajeApiService.kt
@@ -5,6 +5,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.PUT
+import retrofit2.http.Query
 
 interface FichajeApiService {
 
@@ -16,4 +17,10 @@ interface FichajeApiService {
 
     @PUT("api/fichajes/salida")
     suspend fun ficharSalida(@Body peticion: PeticionFichajeSalidaDTO): Response<RespuestaFichajeDTO>
+
+    @GET("api/fichajes")
+    suspend fun obtenerHistorial(
+        @Query("fechaInicio") fechaInicio: String,
+        @Query("fechaFin") fechaFin: String
+    ): Response<List<RespuestaFichajeDTO>>
 }

--- a/app/src/main/java/com/gestorrh/android/data/network/fichaje/FichajeResponses.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/fichaje/FichajeResponses.kt
@@ -1,5 +1,6 @@
 package com.gestorrh.android.data.network.fichaje
 
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class RespuestaEstadoFichajeDTO(
@@ -16,7 +17,7 @@ data class RespuestaFichajeDTO(
     val nombreEmpleado: String,
     val idAsignacion: Long?,
     val descripcionTurno: String?,
-    val fecha: String,
+    val fecha: LocalDate,
     val horaEntrada: LocalDateTime,
     val horaSalida: LocalDateTime?,
     val incidencias: String?

--- a/app/src/main/java/com/gestorrh/android/data/repository/FichajeRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/FichajeRepository.kt
@@ -9,6 +9,7 @@ import com.gestorrh.android.domain.repository.IFichajeRepository
 import okhttp3.ResponseBody
 import org.json.JSONException
 import org.json.JSONObject
+import java.time.LocalDate
 
 /**
  * Implementación de [IFichajeRepository] que delega en el servicio Retrofit [FichajeApiService].
@@ -57,6 +58,27 @@ class FichajeRepository(private val apiService: FichajeApiService) : IFichajeRep
             } else {
                 val mensaje = extraerMensajeError(respuesta.errorBody())
                     ?: "Error ${respuesta.code()} al fichar salida"
+                Result.failure(Exception(mensaje))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun obtenerHistorialFichajes(
+        fechaInicio: LocalDate,
+        fechaFin: LocalDate
+    ): Result<List<RespuestaFichajeDTO>> {
+        return try {
+            val respuesta = apiService.obtenerHistorial(
+                fechaInicio = fechaInicio.toString(),
+                fechaFin = fechaFin.toString()
+            )
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                val mensaje = extraerMensajeError(respuesta.errorBody())
+                    ?: "Error ${respuesta.code()} al obtener el historial de fichajes"
                 Result.failure(Exception(mensaje))
             }
         } catch (e: Exception) {

--- a/app/src/main/java/com/gestorrh/android/domain/repository/IFichajeRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/IFichajeRepository.kt
@@ -4,6 +4,7 @@ import com.gestorrh.android.data.network.fichaje.PeticionFichajeEntradaDTO
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeSalidaDTO
 import com.gestorrh.android.data.network.fichaje.RespuestaEstadoFichajeDTO
 import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
+import java.time.LocalDate
 
 /**
  * Contrato de la capa de dominio para las operaciones de fichaje.
@@ -37,4 +38,18 @@ interface IFichajeRepository {
      *         mensaje de error del servidor.
      */
     suspend fun ficharSalida(peticion: PeticionFichajeSalidaDTO): Result<RespuestaFichajeDTO>
+
+    /**
+     * Recupera el historial de fichajes del empleado autenticado dentro de un rango
+     * cerrado de fechas. El servidor filtra automáticamente por el JWT.
+     *
+     * @param fechaInicio Primer día incluido en la consulta.
+     * @param fechaFin Último día incluido en la consulta.
+     * @return [Result.success] con la lista de fichajes (puede venir vacía), o
+     *         [Result.failure] con el mensaje de error del servidor o de red.
+     */
+    suspend fun obtenerHistorialFichajes(
+        fechaInicio: LocalDate,
+        fechaFin: LocalDate
+    ): Result<List<RespuestaFichajeDTO>>
 }

--- a/app/src/main/java/com/gestorrh/android/domain/usecase/fichaje/ObtenerHistorialFichajesUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/fichaje/ObtenerHistorialFichajesUseCase.kt
@@ -1,0 +1,35 @@
+package com.gestorrh.android.domain.usecase.fichaje
+
+import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
+import com.gestorrh.android.domain.repository.IFichajeRepository
+import java.time.LocalDate
+
+/**
+ * Caso de uso que obtiene el historial de fichajes del empleado autenticado
+ * dentro de un rango cerrado de fechas y lo entrega ya ordenado para presentación.
+ *
+ * El servidor filtra automáticamente la lista por el JWT del cliente, por lo que no
+ * es necesario pasar el `idEmpleado`. Tras delegar la consulta al repositorio, esta
+ * capa ordena los fichajes por hora de entrada de forma descendente, dejando el más
+ * reciente en primera posición — orden esperado por la pantalla de historial.
+ *
+ * @property fichajeRepository Contrato de dominio para las operaciones de fichaje.
+ */
+class ObtenerHistorialFichajesUseCase(
+    private val fichajeRepository: IFichajeRepository
+) {
+
+    /**
+     * @param fechaInicio Primer día del rango (inclusive).
+     * @param fechaFin Último día del rango (inclusive).
+     * @return [Result.success] con la lista ordenada del más reciente al más antiguo,
+     *         o [Result.failure] con el mensaje de error propagado por el servidor.
+     */
+    suspend operator fun invoke(
+        fechaInicio: LocalDate,
+        fechaFin: LocalDate
+    ): Result<List<RespuestaFichajeDTO>> {
+        return fichajeRepository.obtenerHistorialFichajes(fechaInicio, fechaFin)
+            .map { fichajes -> fichajes.sortedByDescending { it.horaEntrada } }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.EventBusy
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.*
@@ -40,6 +41,7 @@ import java.util.Locale
 
 @Composable
 fun PantallaDashboard(
+    alVerHistorial: () -> Unit,
     contexto: android.content.Context = LocalContext.current,
     viewModel: DashboardViewModel = viewModel(
         factory = DashboardViewModelFactory(contexto.applicationContext)
@@ -155,6 +157,21 @@ fun PantallaDashboard(
                 fichajesPendientes = estadoUi.fichajesPendientesSincronizar,
                 alClickFichar = intentarFichar
             )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedButton(
+                onClick = alVerHistorial,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.History,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(stringResource(id = R.string.dashboard_btn_ver_historial))
+            }
 
             Spacer(modifier = Modifier.height(32.dp))
 

--- a/app/src/main/java/com/gestorrh/android/ui/historial/EstadoUiHistorialFichajes.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/historial/EstadoUiHistorialFichajes.kt
@@ -1,0 +1,22 @@
+package com.gestorrh.android.ui.historial
+
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
+import java.time.LocalDate
+
+/**
+ * Estado inmutable de la pantalla de historial de fichajes personales.
+ *
+ * @property fichajes Lista visible ya ordenada (más reciente primero).
+ * @property cargando Indica si hay una petición en curso al servidor.
+ * @property mensajeError Mensaje a mostrar en Snackbar cuando una operación falla.
+ * @property fechaInicio Inicio del rango seleccionado, por defecto hoy menos 30 días.
+ * @property fechaFin Fin del rango seleccionado, por defecto hoy.
+ */
+data class EstadoUiHistorialFichajes(
+    val fichajes: List<RespuestaFichajeDTO> = emptyList(),
+    val cargando: Boolean = false,
+    val mensajeError: MensajeUi? = null,
+    val fechaInicio: LocalDate = LocalDate.now().minusDays(30),
+    val fechaFin: LocalDate = LocalDate.now()
+)

--- a/app/src/main/java/com/gestorrh/android/ui/historial/HistorialFichajesViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/historial/HistorialFichajesViewModel.kt
@@ -1,0 +1,103 @@
+package com.gestorrh.android.ui.historial
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.gestorrh.android.R
+import com.gestorrh.android.core.network.ApiClient
+import com.gestorrh.android.core.security.SessionManager
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.fichaje.FichajeApiService
+import com.gestorrh.android.data.repository.FichajeRepository
+import com.gestorrh.android.domain.usecase.fichaje.ObtenerHistorialFichajesUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+
+/**
+ * Manejador de estado y lógica de presentación para la pantalla de historial de
+ * fichajes personales del empleado autenticado.
+ *
+ * Mantiene el rango de fechas seleccionado por el usuario y dispara la consulta al
+ * caso de uso cada vez que se aplica el filtro. El estado se expone como un único
+ * [StateFlow] con [EstadoUiHistorialFichajes] para que la UI sea puramente reactiva.
+ *
+ * Por defecto, en la primera carga, se solicitan los fichajes del último mes
+ * (hoy menos 30 días → hoy).
+ *
+ * @property obtenerHistorialFichajesUseCase Caso de uso que devuelve la lista ya ordenada.
+ */
+class HistorialFichajesViewModel(
+    private val obtenerHistorialFichajesUseCase: ObtenerHistorialFichajesUseCase
+) : ViewModel() {
+
+    private val _estadoUi = MutableStateFlow(EstadoUiHistorialFichajes())
+    val estadoUi: StateFlow<EstadoUiHistorialFichajes> = _estadoUi.asStateFlow()
+
+    init {
+        cargarFichajes()
+    }
+
+    /**
+     * Lanza la consulta al servidor con el rango actualmente seleccionado y refresca
+     * la lista. Bloquea la UI durante la petición a través de [EstadoUiHistorialFichajes.cargando].
+     */
+    fun cargarFichajes() {
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(cargando = true, mensajeError = null) }
+
+            val rango = _estadoUi.value
+            obtenerHistorialFichajesUseCase(
+                fechaInicio = rango.fechaInicio,
+                fechaFin = rango.fechaFin
+            )
+                .onSuccess { fichajes ->
+                    _estadoUi.update { it.copy(cargando = false, fichajes = fichajes) }
+                }
+                .onFailure { e ->
+                    val mensaje = if (e.message != null) MensajeUi.Dinamico(e.message!!)
+                    else MensajeUi.Recurso(R.string.error_conexion)
+                    _estadoUi.update {
+                        it.copy(cargando = false, mensajeError = mensaje)
+                    }
+                }
+        }
+    }
+
+    fun actualizarFechaInicio(nuevaFecha: LocalDate) {
+        _estadoUi.update { it.copy(fechaInicio = nuevaFecha) }
+    }
+
+    fun actualizarFechaFin(nuevaFecha: LocalDate) {
+        _estadoUi.update { it.copy(fechaFin = nuevaFecha) }
+    }
+
+    fun aplicarFiltro() {
+        cargarFichajes()
+    }
+
+    fun errorMostrado() {
+        _estadoUi.update { it.copy(mensajeError = null) }
+    }
+
+    companion object {
+        fun crearFactory(contexto: Context): ViewModelProvider.Factory {
+            return object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val contextoApp = contexto.applicationContext
+                    val sessionManager = SessionManager(contextoApp)
+                    val retrofit = ApiClient.crearRetrofit(sessionManager)
+                    val apiService = retrofit.create(FichajeApiService::class.java)
+                    val repository = FichajeRepository(apiService)
+                    val useCase = ObtenerHistorialFichajesUseCase(repository)
+                    return HistorialFichajesViewModel(useCase) as T
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/historial/PantallaHistorialFichajes.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/historial/PantallaHistorialFichajes.kt
@@ -1,0 +1,317 @@
+package com.gestorrh.android.ui.historial
+
+import android.app.DatePickerDialog
+import android.content.Context
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.gestorrh.android.R
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+private val ColorEnCurso = Color(0xFF2E7D32)
+private val ColorIncidencia = Color(0xFFD32F2F)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PantallaHistorialFichajes(
+    alVolver: () -> Unit,
+    contexto: Context = LocalContext.current,
+    viewModel: HistorialFichajesViewModel = viewModel(
+        factory = HistorialFichajesViewModel.crearFactory(contexto.applicationContext)
+    )
+) {
+    val estadoUi by viewModel.estadoUi.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val contextoLocal = LocalContext.current
+
+    LaunchedEffect(estadoUi.mensajeError) {
+        estadoUi.mensajeError?.let { mensajeUi ->
+            val texto = when (mensajeUi) {
+                is MensajeUi.Recurso -> contextoLocal.getString(mensajeUi.idRecurso)
+                is MensajeUi.Dinamico -> mensajeUi.texto
+            }
+            snackbarHostState.showSnackbar(texto)
+            viewModel.errorMostrado()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.historial_fichajes_titulo)) },
+                navigationIcon = {
+                    IconButton(onClick = alVolver) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.historial_fichajes_cd_volver)
+                        )
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingInterior ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingInterior)
+        ) {
+            FilaFiltrosFechas(
+                fechaInicio = estadoUi.fechaInicio,
+                fechaFin = estadoUi.fechaFin,
+                cargando = estadoUi.cargando,
+                alCambiarFechaInicio = viewModel::actualizarFechaInicio,
+                alCambiarFechaFin = viewModel::actualizarFechaFin,
+                alAplicarFiltro = viewModel::aplicarFiltro
+            )
+
+            HorizontalDivider()
+
+            when {
+                estadoUi.cargando -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                estadoUi.fichajes.isEmpty() -> {
+                    EstadoVacio()
+                }
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        items(
+                            items = estadoUi.fichajes,
+                            key = { it.idFichaje }
+                        ) { fichaje ->
+                            TarjetaFichaje(fichaje = fichaje)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilaFiltrosFechas(
+    fechaInicio: LocalDate,
+    fechaFin: LocalDate,
+    cargando: Boolean,
+    alCambiarFechaInicio: (LocalDate) -> Unit,
+    alCambiarFechaFin: (LocalDate) -> Unit,
+    alAplicarFiltro: () -> Unit
+) {
+    val contexto = LocalContext.current
+    val formateador = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            BotonSelectorFecha(
+                etiqueta = stringResource(R.string.historial_fichajes_fecha_inicio),
+                fecha = fechaInicio,
+                formateador = formateador,
+                modifier = Modifier.weight(1f),
+                alSeleccionar = {
+                    mostrarDatePicker(contexto, fechaInicio, alCambiarFechaInicio)
+                }
+            )
+            BotonSelectorFecha(
+                etiqueta = stringResource(R.string.historial_fichajes_fecha_fin),
+                fecha = fechaFin,
+                formateador = formateador,
+                modifier = Modifier.weight(1f),
+                alSeleccionar = {
+                    mostrarDatePicker(contexto, fechaFin, alCambiarFechaFin)
+                }
+            )
+        }
+
+        Button(
+            onClick = alAplicarFiltro,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !cargando
+        ) {
+            Text(stringResource(R.string.historial_fichajes_aplicar_filtro))
+        }
+    }
+}
+
+@Composable
+private fun BotonSelectorFecha(
+    etiqueta: String,
+    fecha: LocalDate,
+    formateador: DateTimeFormatter,
+    modifier: Modifier = Modifier,
+    alSeleccionar: () -> Unit
+) {
+    OutlinedButton(
+        onClick = alSeleccionar,
+        modifier = modifier
+    ) {
+        Column(horizontalAlignment = Alignment.Start) {
+            Text(
+                text = etiqueta,
+                style = MaterialTheme.typography.labelSmall
+            )
+            Text(
+                text = fecha.format(formateador),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+
+@Composable
+private fun TarjetaFichaje(fichaje: RespuestaFichajeDTO) {
+    val formateadorFecha = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
+    val formateadorHora = remember { DateTimeFormatter.ofPattern("HH:mm") }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = fichaje.fecha.format(formateadorFecha),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold
+            )
+
+            fichaje.descripcionTurno?.let { turno ->
+                Text(
+                    text = turno,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column {
+                    Text(
+                        text = stringResource(R.string.historial_fichajes_hora_entrada),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = fichaje.horaEntrada.format(formateadorHora),
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        text = stringResource(R.string.historial_fichajes_hora_salida),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    if (fichaje.horaSalida != null) {
+                        Text(
+                            text = fichaje.horaSalida.format(formateadorHora),
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    } else {
+                        Text(
+                            text = stringResource(R.string.historial_fichajes_en_curso),
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            color = ColorEnCurso
+                        )
+                    }
+                }
+            }
+
+            fichaje.incidencias?.let { incidencia ->
+                Surface(
+                    shape = MaterialTheme.shapes.small,
+                    color = ColorIncidencia
+                ) {
+                    Text(
+                        text = incidencia,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EstadoVacio() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.History,
+            contentDescription = null,
+            modifier = Modifier.size(72.dp),
+            tint = MaterialTheme.colorScheme.outlineVariant
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.historial_fichajes_vacio),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+private fun mostrarDatePicker(
+    contexto: Context,
+    fechaInicial: LocalDate,
+    alSeleccionar: (LocalDate) -> Unit
+) {
+    DatePickerDialog(
+        contexto,
+        { _, year, month, dayOfMonth ->
+            alSeleccionar(LocalDate.of(year, month + 1, dayOfMonth))
+        },
+        fechaInicial.year,
+        fechaInicial.monthValue - 1,
+        fechaInicial.dayOfMonth
+    ).show()
+}

--- a/app/src/main/java/com/gestorrh/android/ui/perfil/PantallaPerfil.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/perfil/PantallaPerfil.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
@@ -31,6 +32,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun PantallaPerfil(
     alCerrarSesion: () -> Unit,
+    alVerHistorialFichajes: () -> Unit,
     viewModel: PerfilViewModel = viewModel(factory = PerfilViewModel.crearFactory(LocalContext.current))
 ) {
     val estado by viewModel.estadoUi.collectAsState()
@@ -193,7 +195,8 @@ fun PantallaPerfil(
                     perfil = perfilActual,
                     modifier = Modifier.padding(paddingInterior),
                     alCambiarPassword = { viewModel.mostrarDialogCambioPassword() },
-                    alCerrarSesion = { viewModel.mostrarDialogLogout() }
+                    alCerrarSesion = { viewModel.mostrarDialogLogout() },
+                    alVerHistorialFichajes = alVerHistorialFichajes
                 )
             }
         }
@@ -205,7 +208,8 @@ private fun ContenidoPerfil(
     perfil: RespuestaEmpleadoDTO,
     modifier: Modifier = Modifier,
     alCambiarPassword: () -> Unit,
-    alCerrarSesion: () -> Unit
+    alCerrarSesion: () -> Unit,
+    alVerHistorialFichajes: () -> Unit
 ) {
     Column(
         modifier = modifier
@@ -270,6 +274,17 @@ private fun ContenidoPerfil(
         )
 
         Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedButton(
+            onClick = alVerHistorialFichajes,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(imageVector = Icons.Filled.History, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(stringResource(R.string.perfil_btn_ver_mis_fichajes))
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
 
         OutlinedButton(
             onClick = alCambiarPassword,

--- a/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
@@ -15,6 +15,7 @@ import com.gestorrh.android.ui.ausencia.PantallaMisAusencias
 import com.gestorrh.android.ui.ausencia.PantallaSolicitudAusencia
 import com.gestorrh.android.ui.ausencia.SolicitudAusenciaViewModel
 import com.gestorrh.android.ui.dashboard.PantallaDashboard
+import com.gestorrh.android.ui.historial.PantallaHistorialFichajes
 import com.gestorrh.android.ui.perfil.PantallaPerfil
 import com.gestorrh.android.ui.turnos.PantallaMisTurnos
 import java.net.URLDecoder
@@ -57,7 +58,15 @@ fun PantallaPrincipal(
         ) {
 
             composable(RutasDestino.Inicio.ruta) {
-                PantallaDashboard()
+                PantallaDashboard(
+                    alVerHistorial = {
+                        controladorNavegacionInterno.navigate(
+                            RutasDestino.HistorialFichajes.ruta
+                        ) {
+                            launchSingleTop = true
+                        }
+                    }
+                )
             }
 
             composable(RutasDestino.Turnos.ruta) {
@@ -170,7 +179,22 @@ fun PantallaPrincipal(
             }
 
             composable(RutasDestino.Perfil.ruta) {
-                PantallaPerfil(alCerrarSesion = alCerrarSesion)
+                PantallaPerfil(
+                    alCerrarSesion = alCerrarSesion,
+                    alVerHistorialFichajes = {
+                        controladorNavegacionInterno.navigate(
+                            RutasDestino.HistorialFichajes.ruta
+                        ) {
+                            launchSingleTop = true
+                        }
+                    }
+                )
+            }
+
+            composable(RutasDestino.HistorialFichajes.ruta) {
+                PantallaHistorialFichajes(
+                    alVolver = { controladorNavegacionInterno.popBackStack() }
+                )
             }
         }
     }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -149,4 +149,17 @@
     <string name="mis_ausencias_cd_descargar_justificante">Download attachment</string>
 
     <string name="login_logo_cd">GestorRH logo</string>
+
+    <!-- Time tracking history screen -->
+    <string name="historial_fichajes_titulo">Time tracking history</string>
+    <string name="historial_fichajes_vacio">No records in this period</string>
+    <string name="historial_fichajes_fecha_inicio">From</string>
+    <string name="historial_fichajes_fecha_fin">To</string>
+    <string name="historial_fichajes_aplicar_filtro">Apply filter</string>
+    <string name="historial_fichajes_hora_entrada">Clock in</string>
+    <string name="historial_fichajes_hora_salida">Clock out</string>
+    <string name="historial_fichajes_en_curso">In progress</string>
+    <string name="historial_fichajes_cd_volver">Back</string>
+    <string name="perfil_btn_ver_mis_fichajes">View my records</string>
+    <string name="dashboard_btn_ver_historial">View history</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,4 +149,17 @@
     <string name="mis_ausencias_cd_descargar_justificante">Descargar justificante</string>
 
     <string name="login_logo_cd">Logotipo de GestorRH</string>
+
+    <!-- Pantalla Historial de Fichajes -->
+    <string name="historial_fichajes_titulo">Historial de fichajes</string>
+    <string name="historial_fichajes_vacio">No hay fichajes en este periodo</string>
+    <string name="historial_fichajes_fecha_inicio">Desde</string>
+    <string name="historial_fichajes_fecha_fin">Hasta</string>
+    <string name="historial_fichajes_aplicar_filtro">Aplicar filtro</string>
+    <string name="historial_fichajes_hora_entrada">Entrada</string>
+    <string name="historial_fichajes_hora_salida">Salida</string>
+    <string name="historial_fichajes_en_curso">En curso</string>
+    <string name="historial_fichajes_cd_volver">Volver</string>
+    <string name="perfil_btn_ver_mis_fichajes">Ver mis fichajes</string>
+    <string name="dashboard_btn_ver_historial">Ver historial</string>
 </resources>


### PR DESCRIPTION
Closes #34

## Resumen
- Nueva pantalla `PantallaHistorialFichajes` con filtro por rango de fechas (por defecto últimos 30 días) y listado de fichajes ordenados del más reciente al más antiguo.
- Cada tarjeta muestra fecha, turno, hora de entrada, hora de salida ("En curso" en verde si el fichaje sigue abierto) y badge rojo cuando hay incidencias.
- Acceso desde la pestaña de Perfil (botón "Ver mis fichajes") y desde el dashboard de fichaje (botón "Ver historial" debajo del widget principal).

## Cambios por capa
- **Data:** `FichajeApiService.obtenerHistorial`, `FichajeRepository.obtenerHistorialFichajes` y conversión de `RespuestaFichajeDTO.fecha` a `LocalDate`.
- **Domain:** `IFichajeRepository.obtenerHistorialFichajes` y nuevo `ObtenerHistorialFichajesUseCase` que ordena la lista por `horaEntrada` descendente.
- **Presentation:** `EstadoUiHistorialFichajes`, `HistorialFichajesViewModel` con factory manual, y `PantallaHistorialFichajes` con `DatePickerDialog` para los selectores.
- **Navegación:** nueva ruta `RutasDestino.HistorialFichajes` registrada en `PantallaPrincipal` y enlazada desde Perfil y Dashboard.
- **Strings:** añadidas en `values/strings.xml` y `values-en/strings.xml`.

## Test plan
- [ ] `./gradlew assembleDebug` compila sin errores.
- [ ] `./gradlew test` pasa.
- [ ] Verificar manualmente: botones "Ver mis fichajes" en Perfil y "Ver historial" en Dashboard navegan a la pantalla.
- [ ] Por defecto muestra los fichajes del último mes.
- [ ] Se puede cambiar el rango con `DatePicker` y aplicar filtro.
- [ ] Fichajes ordenados del más reciente al más antiguo.
- [ ] Fichajes abiertos muestran "En curso" en verde y las incidencias en badge rojo.
- [ ] Si no hay fichajes en el rango se muestra el estado vacío.