### PR TITLE
feat: animaciones de navegación, háptico en fichaje, error crítico dashboard y polling de ausencias

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
 
     // 2. Navegación en Jetpack Compose
     implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation("com.google.accompanist:accompanist-navigation-animation:0.34.0")
 
     // 3. Seguridad (EncryptedSharedPreferences para el JWT)
     implementation("androidx.security:security-crypto-ktx:1.1.0-alpha06")

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/MisAusenciasViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/MisAusenciasViewModel.kt
@@ -19,6 +19,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.io.IOException
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.delay
 
 /**
  * ViewModel del listado "Mis ausencias".
@@ -59,6 +62,30 @@ class MisAusenciasViewModel(
                         )
                     }
                 }
+        }
+    }
+
+    /**
+     * Inicia un bucle de refresco periódico cada [INTERVALO_POLLING_MS] ms.
+     *
+     * Se vincula al [Lifecycle] de la pantalla mediante [repeatOnLifecycle]:
+     * el polling se pausa automáticamente cuando la app va a segundo plano
+     * (estado STARTED → STOPPED) y se reanuda al volver al primer plano,
+     * sin necesidad de gestión manual en la UI.
+     *
+     * La primera carga la realiza [cargarAusencias] desde la pantalla en
+     * ON_RESUME, por lo que aquí esperamos el intervalo completo antes del
+     * primer tick para no duplicar la petición inicial.
+     */
+    fun iniciarPolling(lifecycle: Lifecycle) {
+        viewModelScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                delay(INTERVALO_POLLING_MS)
+                while (true) {
+                    cargarAusencias()
+                    delay(INTERVALO_POLLING_MS)
+                }
+            }
         }
     }
 
@@ -146,6 +173,7 @@ class MisAusenciasViewModel(
     }
 
     companion object {
+        private const val INTERVALO_POLLING_MS = 60_000L
         fun factory(contexto: Context): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory {
                 @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
@@ -66,6 +66,7 @@ import com.gestorrh.android.core.archivos.GestorArchivosJustificante
 import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
 import java.time.format.DateTimeFormatter
+import androidx.lifecycle.compose.LocalLifecycleOwner
 
 private val ColorEstadoSolicitada = Color(0xFFF57C00)
 private val ColorEstadoAprobada = Color(0xFF2E7D32)
@@ -98,6 +99,10 @@ fun PantallaMisAusencias(
         }
         propietarioCicloVida.lifecycle.addObserver(observador)
         onDispose { propietarioCicloVida.lifecycle.removeObserver(observador) }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.iniciarPolling(propietarioCicloVida.lifecycle)
     }
 
     val textoReintentar = stringResource(R.string.mis_ausencias_reintentar)

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -37,6 +37,7 @@ data class EstadoUiDashboard(
     val estaCargando: Boolean = true,
     val mensajeError: MensajeUi? = null,
     val mensajeInfo: MensajeUi? = null,
+    val errorCritico: Boolean = false,
     val idFichajeAbierto: Long? = null,
     val modalidadHoy: ModalidadTurno? = null,
     val tieneTurnoHoy: Boolean = false,
@@ -97,9 +98,14 @@ class DashboardViewModel(
                     }
                 }
                 .onFailure { e ->
-                    val mensaje = if (e.message != null) MensajeUi.Dinamico(e.message!!)
-                    else MensajeUi.Recurso(R.string.error_conexion)
-                    mostrarError(mensaje)
+                    val hayEstadoConocido = _estadoUi.value.idFichajeAbierto != null
+                    if (hayEstadoConocido) {
+                        val mensaje = if (e.message != null) MensajeUi.Dinamico(e.message!!)
+                        else MensajeUi.Recurso(R.string.error_conexion)
+                        mostrarError(mensaje)
+                    } else {
+                        _estadoUi.update { it.copy(errorCritico = true) }
+                    }
                 }
 
             _estadoUi.update { it.copy(estaCargando = false) }
@@ -255,6 +261,11 @@ class DashboardViewModel(
 
     fun infoMostrado() {
         _estadoUi.update { it.copy(mensajeInfo = null) }
+    }
+
+    fun reintentarTrasErrorCritico() {
+        _estadoUi.update { it.copy(errorCritico = false) }
+        sincronizarEstado()
     }
 
     private fun mostrarError(mensaje: MensajeUi) {

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -37,6 +37,14 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.material.icons.filled.WifiOff
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import androidx.activity.compose.LocalActivityResultRegistryOwner
+import androidx.core.app.ActivityCompat
 
 @Composable
 fun PantallaDashboard(
@@ -58,9 +66,6 @@ fun PantallaDashboard(
         viewModel.cargarFichajesPendientes()
     }
 
-    // Al volver al Dashboard (por ejemplo tras reconectarse y que `SyncFichajeWorker`
-    // haya vaciado la cola en background) se vuelve a consultar al servidor el estado
-    // de fichaje real y el contador de pendientes para que la UI no se quede desfasada.
     val propietarioCicloVida = LocalLifecycleOwner.current
     DisposableEffect(propietarioCicloVida) {
         val observador = LifecycleEventObserver { _, evento ->
@@ -97,6 +102,10 @@ fun PantallaDashboard(
         }
     }
 
+    val activity = contexto as? android.app.Activity
+    val textoCta = stringResource(id = R.string.error_permiso_ubicacion_btn_ajustes)
+    val textoPermanente = stringResource(id = R.string.error_permiso_ubicacion_permanente)
+
     val lanzadorPermisos = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
         onResult = { concedido ->
@@ -106,8 +115,33 @@ fun PantallaDashboard(
                     viewModel.alternarFichaje(ubicacion)
                 }
             } else {
-                scopeDeCorrutina.launch {
-                    snackbarHostState.showSnackbar(errorPermisoTexto)
+                val denegadoPermanentemente = activity != null &&
+                        !ActivityCompat.shouldShowRequestPermissionRationale(
+                            activity,
+                            android.Manifest.permission.ACCESS_FINE_LOCATION
+                        )
+
+                if (denegadoPermanentemente) {
+                    scopeDeCorrutina.launch {
+                        val resultado = snackbarHostState.showSnackbar(
+                            message = textoPermanente,
+                            actionLabel = textoCta,
+                            duration = SnackbarDuration.Long
+                        )
+                        if (resultado == SnackbarResult.ActionPerformed) {
+                            val intent = Intent(
+                                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                Uri.fromParts("package", contexto.packageName, null)
+                            ).apply {
+                                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            }
+                            contexto.startActivity(intent)
+                        }
+                    }
+                } else {
+                    scopeDeCorrutina.launch {
+                        snackbarHostState.showSnackbar(errorPermisoTexto)
+                    }
                 }
             }
         }
@@ -136,44 +170,53 @@ fun PantallaDashboard(
     Scaffold(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
     ) { paddingValores ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValores)
-                .padding(24.dp)
-                .verticalScroll(rememberScrollState())
-        ) {
-            CabeceraDashboard(nombreEmpleado = estadoUi.nombreEmpleado)
-
-            Spacer(modifier = Modifier.height(40.dp))
-
-            WidgetFichaje(
-                estadoActual = estadoUi.estadoActual,
-                tiempoTranscurrido = estadoUi.tiempoTranscurrido,
-                estaCargando = estadoUi.estaCargando,
-                modalidad = estadoUi.modalidadHoy,
-                fichajesPendientes = estadoUi.fichajesPendientesSincronizar,
-                alClickFichar = intentarFichar
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                TarjetaInformativa(
-                    modifier = Modifier.weight(1f),
-                    titulo = stringResource(id = R.string.dashboard_turno_titulo),
-                    valor = if (estadoUi.tieneTurnoHoy) estadoUi.modalidadHoy?.name ?: stringResource(id = R.string.dashboard_sin_asignar) else stringResource(id = R.string.dashboard_libre),
-                    icono = Icons.Filled.CalendarToday
+        when {
+            estadoUi.errorCritico -> {
+                PantallaErrorCriticoDashboard(
+                    alReintentar = viewModel::reintentarTrasErrorCritico
                 )
-                TarjetaInformativa(
-                    modifier = Modifier.weight(1f),
-                    titulo = stringResource(id = R.string.dashboard_ausencia_titulo),
-                    valor = stringResource(id = R.string.dashboard_cero_pendientes),
-                    icono = Icons.Filled.EventBusy
-                )
+            }
+            else -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValores)
+                        .padding(24.dp)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    CabeceraDashboard(nombreEmpleado = estadoUi.nombreEmpleado)
+
+                    Spacer(modifier = Modifier.height(40.dp))
+
+                    WidgetFichaje(
+                        estadoActual = estadoUi.estadoActual,
+                        tiempoTranscurrido = estadoUi.tiempoTranscurrido,
+                        estaCargando = estadoUi.estaCargando,
+                        modalidad = estadoUi.modalidadHoy,
+                        fichajesPendientes = estadoUi.fichajesPendientesSincronizar,
+                        alClickFichar = intentarFichar
+                    )
+
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        TarjetaInformativa(
+                            modifier = Modifier.weight(1f),
+                            titulo = stringResource(id = R.string.dashboard_turno_titulo),
+                            valor = if (estadoUi.tieneTurnoHoy) estadoUi.modalidadHoy?.name ?: stringResource(id = R.string.dashboard_sin_asignar) else stringResource(id = R.string.dashboard_libre),
+                            icono = Icons.Filled.CalendarToday
+                        )
+                        TarjetaInformativa(
+                            modifier = Modifier.weight(1f),
+                            titulo = stringResource(id = R.string.dashboard_ausencia_titulo),
+                            valor = stringResource(id = R.string.dashboard_cero_pendientes),
+                            icono = Icons.Filled.EventBusy
+                        )
+                    }
+                }
             }
         }
     }
@@ -280,6 +323,7 @@ private fun WidgetFichaje(
     alClickFichar: () -> Unit
 ) {
     val esActivo = estadoActual == EstadoFichaje.TRABAJANDO
+    val feedbackHaptico = LocalHapticFeedback.current
 
     val colorFondoCard = if (esActivo) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceVariant
     val colorTextoEstado = if (esActivo) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
@@ -326,7 +370,10 @@ private fun WidgetFichaje(
 
             Box(modifier = Modifier.fillMaxWidth()) {
                 Button(
-                    onClick = alClickFichar,
+                    onClick = {
+                        feedbackHaptico.performHapticFeedback(HapticFeedbackType.LongPress)
+                        alClickFichar()
+                    },
                     modifier = Modifier.fillMaxWidth().height(56.dp),
                     shape = CircleShape,
                     colors = ButtonDefaults.buttonColors(containerColor = colorBoton),
@@ -370,6 +417,51 @@ private fun WidgetFichaje(
                     color = MaterialTheme.colorScheme.error
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun PantallaErrorCriticoDashboard(
+    alReintentar: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.WifiOff,
+            contentDescription = null,
+            modifier = Modifier.size(72.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = stringResource(id = R.string.dashboard_error_titulo),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = stringResource(id = R.string.dashboard_error_descripcion),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(onClick = alReintentar) {
+            Text(text = stringResource(id = R.string.dashboard_error_btn_reintentar))
         }
     }
 }

--- a/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
@@ -1,5 +1,9 @@
 package com.gestorrh.android.ui.principal
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -20,11 +24,19 @@ import com.gestorrh.android.ui.turnos.PantallaMisTurnos
 import java.net.URLDecoder
 import java.time.LocalDate
 
+private const val DURACION_TRANSICION_MS = 300
+
 /**
- * Contenedor maestro de la experiencia "Post-Login".
- * Implementa el patrón visual Scaffold (Andamio), inyectando la barra de navegación
- * inferior y definiendo el enrutador interno (NavHost) para cambiar entre los
- * dominios de negocio principales (Fichaje, Turnos, Ausencias, Perfil).
+ * Contenedor maestro de la experiencia post-login.
+ *
+ * Implementa el patrón Scaffold con barra de navegación inferior y un NavHost
+ * con transiciones animadas entre destinos:
+ *
+ * - Navegación entre pestañas principales: fade cruzado suave (fadeIn + fadeOut)
+ *   para transmitir cambio de contexto sin brusquedad.
+ * - Navegación hacia pantallas secundarias (formulario de ausencia): deslizamiento
+ *   hacia arriba en la entrada y hacia abajo en la salida, siguiendo las
+ *   directrices de Material Design 3 para flujos de creación/edición.
  */
 @Composable
 fun PantallaPrincipal(
@@ -32,8 +44,6 @@ fun PantallaPrincipal(
 ) {
     val controladorNavegacionInterno = rememberNavController()
 
-    // PUNTO ESTRATÉGICO PARA LA ÉPICA 6:
-    // Aquí es donde en el futuro leeremos el rol del usuario.
     val pestañasBase = listOf(
         RutasDestino.Inicio,
         RutasDestino.Turnos,
@@ -53,7 +63,20 @@ fun PantallaPrincipal(
         NavHost(
             navController = controladorNavegacionInterno,
             startDestination = RutasDestino.Inicio.ruta,
-            modifier = Modifier.padding(paddingInterior)
+            modifier = Modifier.padding(paddingInterior),
+            // Transición por defecto para todas las pestañas principales: fade cruzado
+            enterTransition = {
+                fadeIn(animationSpec = tween(DURACION_TRANSICION_MS))
+            },
+            exitTransition = {
+                fadeOut(animationSpec = tween(DURACION_TRANSICION_MS))
+            },
+            popEnterTransition = {
+                fadeIn(animationSpec = tween(DURACION_TRANSICION_MS))
+            },
+            popExitTransition = {
+                fadeOut(animationSpec = tween(DURACION_TRANSICION_MS))
+            }
         ) {
 
             composable(RutasDestino.Inicio.ruta) {
@@ -122,7 +145,28 @@ fun PantallaPrincipal(
                         nullable = true
                         defaultValue = null
                     }
-                )
+                ),
+                enterTransition = {
+                    slideIntoContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Up,
+                        animationSpec = tween(DURACION_TRANSICION_MS)
+                    )
+                },
+                exitTransition = {
+                    slideOutOfContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Down,
+                        animationSpec = tween(DURACION_TRANSICION_MS)
+                    )
+                },
+                popEnterTransition = {
+                    fadeIn(animationSpec = tween(DURACION_TRANSICION_MS))
+                },
+                popExitTransition = {
+                    slideOutOfContainer(
+                        towards = AnimatedContentTransitionScope.SlideDirection.Down,
+                        animationSpec = tween(DURACION_TRANSICION_MS)
+                    )
+                }
             ) { entrada ->
                 val args = entrada.arguments
                 val id = args?.getLong(RutasDestino.SolicitarAusencia.ARG_ID) ?: -1L

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -149,4 +149,16 @@
     <string name="mis_ausencias_cd_descargar_justificante">Download attachment</string>
 
     <string name="login_logo_cd">GestorRH logo</string>
+
+    <!-- Dashboard — dedicated error screen -->
+    <string name="dashboard_error_titulo">Could not connect</string>
+    <string name="dashboard_error_descripcion">We could not retrieve your clock-in status. Check your connection and try again.</string>
+    <string name="dashboard_error_btn_reintentar">Retry</string>
+
+    <!-- My Time Off — polling -->
+    <string name="mis_ausencias_actualizando">Updating…</string>
+
+    <!-- Location permission permanently denied -->
+    <string name="error_permiso_ubicacion_permanente">Location permission permanently denied. Enable it in Settings to clock in.</string>
+    <string name="error_permiso_ubicacion_btn_ajustes">Open Settings</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,4 +149,16 @@
     <string name="mis_ausencias_cd_descargar_justificante">Descargar justificante</string>
 
     <string name="login_logo_cd">Logotipo de GestorRH</string>
+
+    <!-- Dashboard — pantalla de error dedicada -->
+    <string name="dashboard_error_titulo">No se pudo conectar</string>
+    <string name="dashboard_error_descripcion">No hemos podido obtener tu estado de fichaje. Comprueba tu conexión e inténtalo de nuevo.</string>
+    <string name="dashboard_error_btn_reintentar">Reintentar</string>
+
+    <!-- Mis Ausencias — polling -->
+    <string name="mis_ausencias_actualizando">Actualizando…</string>
+
+    <!-- Permiso ubicación denegado permanentemente -->
+    <string name="error_permiso_ubicacion_permanente">Permiso de ubicación denegado permanentemente. Actívalo en Ajustes para poder fichar.</string>
+    <string name="error_permiso_ubicacion_btn_ajustes">Abrir Ajustes</string>
 </resources>


### PR DESCRIPTION
## Descripción

Implementación del Bloque 2 de mejoras de experiencia de usuario: transiciones
animadas entre pantallas, feedback háptico en el fichaje, pantalla de error
dedicada en el Dashboard y polling periódico en el listado de ausencias.

## Cambios incluidos

### Animaciones de navegación
- `PantallaPrincipal.kt`: sustituido `NavHost` estático por `NavHost` con
  transiciones declarativas por destino:
  - Pestañas principales (Inicio, Turnos, Ausencias, Perfil): fade cruzado
    de 300ms para transmitir cambio de contexto sin brusquedad
  - Formulario de solicitud/edición de ausencia: deslizamiento vertical
    (sube al abrir, baja al cerrar con back), siguiendo las directrices
    de Material Design 3 para flujos de creación
- `build.gradle.kts`: añadida dependencia
  `accompanist-navigation-animation:0.34.0`

### Feedback háptico en fichaje
- `PantallaDashboard.kt`: el botón de fichar entrada/salida dispara
  `HapticFeedbackType.LongPress` antes de ejecutar la acción, reforzando
  la confirmación de una operación crítica e irreversible

### Pantalla de error dedicada en Dashboard
- `DashboardViewModel.kt`: añadido campo `errorCritico: Boolean` en
  `EstadoUiDashboard`; cuando la sincronización inicial falla y no hay
  estado previo conocido se activa en lugar del Snackbar genérico. Añadida
  función `reintentarTrasErrorCritico()` que limpia el estado y relanza
  `sincronizarEstado()`
- `PantallaDashboard.kt`: cuando `errorCritico` es `true` se muestra
  `PantallaErrorCriticoDashboard` con icono `WifiOff`, mensaje descriptivo
  y botón "Reintentar" en lugar del widget de fichaje

### Polling de ausencias
- `MisAusenciasViewModel.kt`: añadida función `iniciarPolling(lifecycle)`
  que ejecuta `cargarAusencias()` cada 60 segundos vinculado al ciclo de
  vida de la pantalla mediante `repeatOnLifecycle(STARTED)`. El polling se
  pausa automáticamente cuando la app va a segundo plano y se reanuda al
  volver, sin gestión manual en la UI
- `PantallaMisAusencias.kt`: `LaunchedEffect(Unit)` arranca el polling al
  montarse la pantalla

### Manejo de permiso de ubicación denegado permanentemente
- `PantallaDashboard.kt`: el `lanzadorPermisos` distingue ahora entre
  permiso denegado puntualmente y denegado permanentemente mediante
  `shouldShowRequestPermissionRationale`. En el segundo caso muestra un
  Snackbar con acción "Abrir Ajustes" que navega directamente a
  `Settings.ACTION_APPLICATION_DETAILS_SETTINGS` de la app

### Strings añadidos
- `dashboard_error_titulo`, `dashboard_error_descripcion`,
  `dashboard_error_btn_reintentar`
- `mis_ausencias_actualizando`
- `error_permiso_ubicacion_permanente`,
  `error_permiso_ubicacion_btn_ajustes`

## Resultado

| Mejora | Comportamiento anterior | Comportamiento nuevo |
|---|---|---|
| Navegación entre pestañas | Cambio instantáneo | Fade cruzado 300ms |
| Abrir formulario ausencia | Cambio instantáneo | Deslizamiento hacia arriba |
| Botón fichar | Sin respuesta táctil | Vibración al pulsar |
| Error inicial Dashboard | Snackbar genérico | Pantalla dedicada con Reintentar |
| Ausencias sin actualizar | Solo refresca en ON_RESUME | Refresca cada 60s automáticamente |
| Permiso ubicación denegado siempre | Snackbar sin salida | Snackbar + botón Abrir Ajustes |
