### PR TITLE
feat: mejorar tarjetas informativas del dashboard

### DIFF
--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -5,6 +5,7 @@ import android.location.Location
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.google.gson.Gson
 import com.gestorrh.android.R
 import com.gestorrh.android.core.network.ApiClient
 import com.gestorrh.android.core.network.hayConexion
@@ -13,12 +14,18 @@ import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.local.GestorRhDatabase
 import com.gestorrh.android.data.local.dao.FichajePendienteDao
 import com.gestorrh.android.data.local.entity.FichajePendienteEntity
+import com.gestorrh.android.data.network.asignacion.AsignacionApiService
+import com.gestorrh.android.data.network.ausencia.AusenciaApiService
 import com.gestorrh.android.data.network.fichaje.FichajeApiService
 import com.gestorrh.android.data.network.fichaje.ModalidadTurno
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeEntradaDTO
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeSalidaDTO
 import com.gestorrh.android.data.repository.FichajeRepository
+import com.gestorrh.android.data.repository.asignacion.AsignacionRepositoryImpl
+import com.gestorrh.android.data.repository.ausencia.AusenciaRepositoryImpl
 import com.gestorrh.android.data.sync.FichajeSyncManager
+import com.gestorrh.android.domain.repository.IAsignacionRepository
+import com.gestorrh.android.domain.repository.IAusenciaRepository
 import com.gestorrh.android.domain.repository.IFichajeRepository
 import com.gestorrh.android.domain.usecase.fichaje.GuardarFichajePendienteUseCase
 import kotlinx.coroutines.Job
@@ -26,9 +33,13 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeParseException
 import java.time.temporal.ChronoUnit
 
 data class EstadoUiDashboard(
@@ -44,7 +55,33 @@ data class EstadoUiDashboard(
     /** Nombre completo del empleado autenticado, leído desde [SessionManager] sin llamadas de red. */
     val nombreEmpleado: String = "",
     /** Número de fichajes en la cola offline a la espera de ser sincronizados por `SyncFichajeWorker`. */
-    val fichajesPendientesSincronizar: Int = 0
+    val fichajesPendientesSincronizar: Int = 0,
+    /** Resumen del próximo turno asignado (hoy o futuro), o `null` si no hay ninguno. */
+    val proximoTurno: ResumenProximoTurno? = null,
+    /** Resumen de la próxima ausencia solicitada o aprobada, o `null` si no hay ninguna. */
+    val proximaAusencia: ResumenProximaAusencia? = null
+)
+
+/**
+ * Datos crudos del próximo turno expuestos al UI para que pueda formatear
+ * la fecha y el horario con los recursos localizados (`stringResource`).
+ */
+data class ResumenProximoTurno(
+    val nombreTurno: String,
+    val fecha: LocalDate,
+    val horaInicio: LocalTime?,
+    val horaFin: LocalTime?
+)
+
+/**
+ * Datos crudos de la próxima ausencia (estado `SOLICITADA` o `APROBADA`)
+ * para que el UI traduzca tipo y estado a recursos.
+ */
+data class ResumenProximaAusencia(
+    val tipo: String,
+    val fechaInicio: LocalDate,
+    val fechaFin: LocalDate,
+    val estado: String
 )
 
 enum class EstadoFichaje {
@@ -56,6 +93,8 @@ class DashboardViewModel(
     private val sessionManager: SessionManager,
     private val fichajePendienteDao: FichajePendienteDao,
     private val guardarFichajePendienteUseCase: GuardarFichajePendienteUseCase,
+    private val asignacionRepository: IAsignacionRepository,
+    private val ausenciaRepository: IAusenciaRepository,
     private val contextoAplicacion: Context
 ) : ViewModel() {
 
@@ -71,6 +110,78 @@ class DashboardViewModel(
 
         sincronizarEstado()
         cargarFichajesPendientes()
+        cargarProximoTurno()
+        cargarProximaAusencia()
+    }
+
+    /**
+     * Recupera la asignación más cercana en el futuro (incluido hoy) usando el flujo
+     * reactivo de la caché Room — la sincronización contra el backend se delega al
+     * `Repository`, que actualizará el flujo cuando termine. Si no hay asignaciones
+     * futuras o falla la lectura, el estado expuesto queda en `null`.
+     */
+    fun cargarProximoTurno() {
+        viewModelScope.launch {
+            asignacionRepository.sincronizar()
+            val asignaciones = asignacionRepository.observarAsignaciones().firstOrNull()
+                ?: return@launch
+            val hoy = LocalDate.now()
+            val proxima = asignaciones
+                .mapNotNull { entidad ->
+                    val fecha = parsearFecha(entidad.fecha) ?: return@mapNotNull null
+                    if (fecha < hoy) return@mapNotNull null
+                    ResumenProximoTurno(
+                        nombreTurno = entidad.descripcionTurno,
+                        fecha = fecha,
+                        horaInicio = parsearHora(entidad.horaInicio),
+                        horaFin = parsearHora(entidad.horaFin)
+                    )
+                }
+                .minByOrNull { it.fecha }
+            _estadoUi.update { it.copy(proximoTurno = proxima) }
+        }
+    }
+
+    /**
+     * Recupera la ausencia futura más cercana en estado `SOLICITADA` o `APROBADA`.
+     * Las ausencias rechazadas o ya finalizadas se ignoran para que la tarjeta solo
+     * informe de algo accionable. Los errores se silencian: la tarjeta cae a su
+     * estado vacío en lugar de generar ruido en el dashboard.
+     */
+    fun cargarProximaAusencia() {
+        viewModelScope.launch {
+            val resultado = ausenciaRepository.obtenerMisAusencias(estado = null)
+            val ausencias = resultado.getOrNull() ?: return@launch
+            val hoy = LocalDate.now()
+            val proxima = ausencias
+                .filter { it.estado == ESTADO_AUSENCIA_SOLICITADA || it.estado == ESTADO_AUSENCIA_APROBADA }
+                .filter { !it.fechaInicio.isBefore(hoy) }
+                .minByOrNull { it.fechaInicio }
+                ?.let { dto ->
+                    ResumenProximaAusencia(
+                        tipo = dto.tipo,
+                        fechaInicio = dto.fechaInicio,
+                        fechaFin = dto.fechaFin,
+                        estado = dto.estado
+                    )
+                }
+            _estadoUi.update { it.copy(proximaAusencia = proxima) }
+        }
+    }
+
+    private fun parsearFecha(valor: String): LocalDate? = try {
+        LocalDate.parse(valor)
+    } catch (e: DateTimeParseException) {
+        null
+    }
+
+    private fun parsearHora(valor: String?): LocalTime? {
+        if (valor.isNullOrBlank()) return null
+        return try {
+            LocalTime.parse(valor)
+        } catch (e: DateTimeParseException) {
+            null
+        }
     }
 
     /**
@@ -295,6 +406,11 @@ class DashboardViewModel(
         val segundos = segundosTotales % 60
         return String.format("%02d:%02d:%02d", horas, minutos, segundos)
     }
+
+    companion object {
+        private const val ESTADO_AUSENCIA_SOLICITADA = "SOLICITADA"
+        private const val ESTADO_AUSENCIA_APROBADA = "APROBADA"
+    }
 }
 
 // ── FACTORY MANUAL ────────────────────────────────────────────────────────────
@@ -310,12 +426,21 @@ class DashboardViewModelFactory(private val contexto: Context) : ViewModelProvid
             val fichajePendienteDao = GestorRhDatabase.getInstance(contextoAplicacion).fichajePendienteDao()
             val guardarFichajePendienteUseCase = GuardarFichajePendienteUseCase(fichajePendienteDao)
 
+            val asignacionApi = retrofit.create(AsignacionApiService::class.java)
+            val asignacionDao = GestorRhDatabase.getInstance(contextoAplicacion).asignacionDao()
+            val asignacionRepository = AsignacionRepositoryImpl(asignacionApi, asignacionDao)
+
+            val ausenciaApi = retrofit.create(AusenciaApiService::class.java)
+            val ausenciaRepository = AusenciaRepositoryImpl(ausenciaApi, Gson())
+
             @Suppress("UNCHECKED_CAST")
             return DashboardViewModel(
                 fichajeRepository = fichajeRepository,
                 sessionManager = sessionManager,
                 fichajePendienteDao = fichajePendienteDao,
                 guardarFichajePendienteUseCase = guardarFichajePendienteUseCase,
+                asignacionRepository = asignacionRepository,
+                ausenciaRepository = ausenciaRepository,
                 contextoAplicacion = contextoAplicacion
             ) as T
         }

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -10,11 +10,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.EventBusy
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -34,9 +34,14 @@ import com.gestorrh.android.R
 import com.gestorrh.android.core.location.GestorLocalizacion
 import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.network.fichaje.ModalidadTurno
+import com.gestorrh.android.ui.theme.SemanticSuccess
+import com.gestorrh.android.ui.theme.SemanticWarning
 import kotlinx.coroutines.launch
+import androidx.compose.ui.graphics.Color
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
 import java.util.Locale
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -74,6 +79,8 @@ fun PantallaDashboard(
             if (evento == Lifecycle.Event.ON_RESUME) {
                 viewModel.sincronizarEstado()
                 viewModel.cargarFichajesPendientes()
+                viewModel.cargarProximoTurno()
+                viewModel.cargarProximaAusencia()
             }
         }
         propietarioCicloVida.lifecycle.addObserver(observador)
@@ -221,17 +228,13 @@ fun PantallaDashboard(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
-                        TarjetaInformativa(
+                        TarjetaProximoTurno(
                             modifier = Modifier.weight(1f),
-                            titulo = stringResource(id = R.string.dashboard_turno_titulo),
-                            valor = if (estadoUi.tieneTurnoHoy) estadoUi.modalidadHoy?.name ?: stringResource(id = R.string.dashboard_sin_asignar) else stringResource(id = R.string.dashboard_libre),
-                            icono = Icons.Filled.CalendarToday
+                            proximoTurno = estadoUi.proximoTurno
                         )
-                        TarjetaInformativa(
+                        TarjetaProximaAusencia(
                             modifier = Modifier.weight(1f),
-                            titulo = stringResource(id = R.string.dashboard_ausencia_titulo),
-                            valor = stringResource(id = R.string.dashboard_cero_pendientes),
-                            icono = Icons.Filled.EventBusy
+                            proximaAusencia = estadoUi.proximaAusencia
                         )
                     }
                 }
@@ -300,7 +303,10 @@ private fun TarjetaInformativa(
     modifier: Modifier = Modifier,
     titulo: String,
     valor: String,
-    icono: ImageVector
+    icono: ImageVector,
+    subtitulo: String? = null,
+    detalle: String? = null,
+    colorDetalle: Color? = null
 ) {
     Card(
         modifier = modifier,
@@ -327,7 +333,140 @@ private fun TarjetaInformativa(
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface
             )
+            if (!subtitulo.isNullOrBlank()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = subtitulo,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            if (!detalle.isNullOrBlank()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = detalle,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colorDetalle ?: MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
         }
+    }
+}
+
+@Composable
+private fun TarjetaProximoTurno(
+    modifier: Modifier = Modifier,
+    proximoTurno: ResumenProximoTurno?
+) {
+    val titulo = stringResource(id = R.string.dashboard_turno_titulo)
+    if (proximoTurno == null) {
+        TarjetaInformativa(
+            modifier = modifier,
+            titulo = titulo,
+            valor = stringResource(id = R.string.dashboard_sin_turno),
+            icono = Icons.Filled.Schedule
+        )
+        return
+    }
+    TarjetaInformativa(
+        modifier = modifier,
+        titulo = titulo,
+        valor = proximoTurno.nombreTurno,
+        subtitulo = formatearFechaYHorarioTurno(
+            fecha = proximoTurno.fecha,
+            horaInicio = proximoTurno.horaInicio,
+            horaFin = proximoTurno.horaFin
+        ),
+        icono = Icons.Filled.Schedule
+    )
+}
+
+@Composable
+private fun TarjetaProximaAusencia(
+    modifier: Modifier = Modifier,
+    proximaAusencia: ResumenProximaAusencia?
+) {
+    val titulo = stringResource(id = R.string.dashboard_ausencia_titulo)
+    if (proximaAusencia == null) {
+        TarjetaInformativa(
+            modifier = modifier,
+            titulo = titulo,
+            valor = stringResource(id = R.string.dashboard_sin_ausencias),
+            icono = Icons.Filled.EventBusy
+        )
+        return
+    }
+    val (etiquetaEstado, colorEstado) = when (proximaAusencia.estado) {
+        "SOLICITADA" -> stringResource(id = R.string.dashboard_estado_ausencia_pendiente) to SemanticWarning
+        "APROBADA" -> stringResource(id = R.string.dashboard_estado_ausencia_aprobada) to SemanticSuccess
+        else -> proximaAusencia.estado to MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    TarjetaInformativa(
+        modifier = modifier,
+        titulo = titulo,
+        valor = etiquetaTipoAusenciaDashboard(proximaAusencia.tipo),
+        subtitulo = formatearRangoFechasAusencia(proximaAusencia.fechaInicio, proximaAusencia.fechaFin),
+        detalle = etiquetaEstado,
+        colorDetalle = colorEstado,
+        icono = Icons.Filled.EventBusy
+    )
+}
+
+@Composable
+private fun etiquetaTipoAusenciaDashboard(tipo: String): String {
+    val resId = when (tipo) {
+        "MEDICA" -> R.string.ausencia_tipo_medica
+        "VACACIONES" -> R.string.ausencia_tipo_vacaciones
+        "MOTIVO_PERSONAL" -> R.string.ausencia_tipo_motivo_personal
+        "OTROS" -> R.string.ausencia_tipo_otros
+        else -> null
+    }
+    return resId?.let { stringResource(it) } ?: tipo
+}
+
+@Composable
+private fun formatearFechaYHorarioTurno(
+    fecha: LocalDate,
+    horaInicio: LocalTime?,
+    horaFin: LocalTime?
+): String {
+    val formatoHora = remember { DateTimeFormatter.ofPattern("HH:mm") }
+    val formatoFecha = remember { DateTimeFormatter.ofPattern("dd/MM") }
+    val locale = Locale.getDefault()
+    val horaInicioStr = horaInicio?.format(formatoHora).orEmpty()
+    val horaFinStr = horaFin?.format(formatoHora).orEmpty()
+    val hoy = LocalDate.now()
+    return when {
+        fecha == hoy -> stringResource(
+            id = R.string.dashboard_turno_horario_hoy,
+            horaInicioStr,
+            horaFinStr
+        )
+        fecha == hoy.plusDays(1) -> stringResource(
+            id = R.string.dashboard_turno_horario_manana,
+            horaInicioStr,
+            horaFinStr
+        )
+        else -> {
+            val diaSemana = fecha.dayOfWeek.getDisplayName(TextStyle.FULL, locale)
+                .replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
+            stringResource(
+                id = R.string.dashboard_turno_horario_proximo,
+                diaSemana,
+                fecha.format(formatoFecha),
+                horaInicioStr
+            )
+        }
+    }
+}
+
+private fun formatearRangoFechasAusencia(inicio: LocalDate, fin: LocalDate): String {
+    val formatter = DateTimeFormatter.ofPattern("dd/MM")
+    return if (inicio == fin) {
+        inicio.format(formatter)
+    } else {
+        "${inicio.format(formatter)} - ${fin.format(formatter)}"
     }
 }
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -22,11 +22,15 @@
     <string name="dashboard_saludo_generico">Welcome!</string>
     <!-- Date format pattern for java.time.DateTimeFormatter -->
     <string name="dashboard_formato_fecha">EEEE, MMMM d</string>
-    <string name="dashboard_turno_titulo">Next Shift</string>
-    <string name="dashboard_turno_valor">08:00 – 16:00</string>
-    <string name="dashboard_ausencia_titulo">Time Off</string>
-    <string name="dashboard_ausencia_valor">None pending</string>
-    <string name="dashboard_placeholder_fichaje">[ P0–08 Time Clock Widget Placeholder ]</string>
+    <string name="dashboard_turno_titulo">Next shift</string>
+    <string name="dashboard_sin_turno">No shift assigned</string>
+    <string name="dashboard_ausencia_titulo">Next time off</string>
+    <string name="dashboard_sin_ausencias">No upcoming time off</string>
+    <string name="dashboard_turno_horario_hoy">Today %1$s-%2$s</string>
+    <string name="dashboard_turno_horario_manana">Tomorrow %1$s-%2$s</string>
+    <string name="dashboard_turno_horario_proximo">%1$s %2$s - %3$s</string>
+    <string name="dashboard_estado_ausencia_pendiente">Pending</string>
+    <string name="dashboard_estado_ausencia_aprobada">Approved</string>
     <string name="fichaje_estado_fuera">Off duty</string>
     <string name="fichaje_estado_activo">Working</string>
     <string name="fichaje_btn_iniciar">CLOCK IN</string>
@@ -35,10 +39,6 @@
     <string name="fichajes_pendientes">%d clock event(s) pending sync</string>
     <string name="fichaje_entrada_duplicada_offline">You already have a pending clock-in. You cannot register another until it is sent.</string>
 
-    <string name="dashboard_hoy">Today</string>
-    <string name="dashboard_sin_asignar">UNASSIGNED</string>
-    <string name="dashboard_libre">FREE</string>
-    <string name="dashboard_cero_pendientes">0 Pending</string>
     <string name="dashboard_modalidad_remota">REMOTE WORK</string>
 
     <string name="error_permiso_ubicacion">Location permission denied. Cannot clock in.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,11 +22,18 @@
     <string name="dashboard_saludo_generico">¡Bienvenido!</string>
     <!-- Patrón de formato de fecha localizado para java.time.DateTimeFormatter -->
     <string name="dashboard_formato_fecha">EEEE, d \'de\' MMMM</string>
-    <string name="dashboard_turno_titulo">Siguiente Turno</string>
-    <string name="dashboard_turno_valor">08:00 – 16:00</string>
-    <string name="dashboard_ausencia_titulo">Ausencias</string>
-    <string name="dashboard_ausencia_valor">Ninguna pendiente</string>
-    <string name="dashboard_placeholder_fichaje">[ Aquí irá el Widget de Fichaje P0–08 ]</string>
+    <string name="dashboard_turno_titulo">Próximo turno</string>
+    <string name="dashboard_sin_turno">Sin turno asignado</string>
+    <string name="dashboard_ausencia_titulo">Próxima ausencia</string>
+    <string name="dashboard_sin_ausencias">Sin ausencias próximas</string>
+    <!-- Formato del horario del próximo turno cuando es hoy: %1$s = hora inicio, %2$s = hora fin (HH:mm) -->
+    <string name="dashboard_turno_horario_hoy">Hoy %1$s-%2$s</string>
+    <!-- Formato del horario del próximo turno cuando es mañana: %1$s = hora inicio, %2$s = hora fin -->
+    <string name="dashboard_turno_horario_manana">Mañana %1$s-%2$s</string>
+    <!-- Formato del horario cuando es otro día: %1$s = día semana, %2$s = dd/MM, %3$s = hora inicio -->
+    <string name="dashboard_turno_horario_proximo">%1$s %2$s - %3$s</string>
+    <string name="dashboard_estado_ausencia_pendiente">Pendiente</string>
+    <string name="dashboard_estado_ausencia_aprobada">Aprobada</string>
     <string name="fichaje_estado_fuera">Fuera de turno</string>
     <string name="fichaje_estado_activo">Trabajando</string>
     <string name="fichaje_btn_iniciar">INICIAR JORNADA</string>
@@ -35,10 +42,6 @@
     <string name="fichajes_pendientes">%d fichaje(s) pendiente(s) de sincronizar</string>
     <string name="fichaje_entrada_duplicada_offline">Ya hay una entrada pendiente de sincronizar. No puedes registrar otra hasta que se envíe.</string>
 
-    <string name="dashboard_hoy">Hoy</string>
-    <string name="dashboard_sin_asignar">SIN ASIGNAR</string>
-    <string name="dashboard_libre">LIBRE</string>
-    <string name="dashboard_cero_pendientes">0 Pendientes</string>
     <string name="dashboard_modalidad_remota">MODALIDAD REMOTA</string>
 
     <string name="error_permiso_ubicacion">Permiso de ubicación denegado. No se puede fichar.</string>


### PR DESCRIPTION
## Resumen
- Tarjeta "Próximo turno" muestra el nombre del turno y un subtítulo con fecha y horario formateados según cercanía (Hoy, Mañana, día de la semana con dd/MM).
- Tarjeta "Próxima ausencia" muestra tipo, rango de fechas y estado coloreado (ámbar para Pendiente, verde para Aprobada). Si no hay ausencias futuras pendientes/aprobadas, queda con un mensaje vacío claro.
- El `DashboardViewModel` consume los repositorios de asignaciones y ausencias ya existentes (sin tocar la API): `IAsignacionRepository` (offline-first via Room) e `IAusenciaRepository`.
- Carga inicial en `init` y refresco en `ON_RESUME` para que las tarjetas se mantengan al día.
- `TarjetaInformativa` admite ahora `subtitulo`, `detalle` y `colorDetalle` opcionales.
- Se reutilizan `SemanticWarning` (#F57C00) y `SemanticSuccess` (#2E7D32) de la paleta del tema en lugar de hardcodear colores.
- Strings nuevos añadidos a `values/strings.xml` y `values-en/strings.xml`; eliminados los strings ya obsoletos del dashboard (`dashboard_turno_valor`, `dashboard_ausencia_valor`, `dashboard_sin_asignar`, `dashboard_libre`, `dashboard_cero_pendientes`, `dashboard_hoy`, `dashboard_placeholder_fichaje`).

## Plan de pruebas
- [ ] Abrir el Dashboard con un turno asignado para hoy: comprobar formato "Hoy HH:mm-HH:mm".
- [ ] Probar con turno mañana: "Mañana HH:mm-HH:mm".
- [ ] Probar con turno en próximos 7 días: "<DíaSemana> dd/MM - HH:mm".
- [ ] Probar sin turnos futuros: "Sin turno asignado".
- [ ] Probar con ausencia SOLICITADA futura: estado "Pendiente" en ámbar.
- [ ] Probar con ausencia APROBADA futura: estado "Aprobada" en verde.
- [ ] Probar sin ausencias futuras (solo pasadas o RECHAZADA): "Sin ausencias próximas".
- [ ] Verificar localización: cambiar locale del sistema a inglés y comprobar textos.