### PR TITLE
fix: igualar altura de tarjetas informativas en dashboard

### DIFF
--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -225,15 +225,21 @@ fun PantallaDashboard(
                     Spacer(modifier = Modifier.height(32.dp))
 
                     Row(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(IntrinsicSize.Min),
                         horizontalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
                         TarjetaProximoTurno(
-                            modifier = Modifier.weight(1f),
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxHeight(),
                             proximoTurno = estadoUi.proximoTurno
                         )
                         TarjetaProximaAusencia(
-                            modifier = Modifier.weight(1f),
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxHeight(),
                             proximaAusencia = estadoUi.proximaAusencia
                         )
                     }


### PR DESCRIPTION
Uso IntrinsicSize.Min en el Row y fillMaxHeight en cada tarjeta para que ambas adopten la altura de la más alta y el diseño no se rompa cuando una de ellas tiene más líneas (subtítulo, detalle de estado) que la otra.