### PR TITLE
fix: simplificar acceso al historial de fichajes

### DIFF
--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -20,6 +20,7 @@ import com.gestorrh.android.data.network.fichaje.FichajeApiService
 import com.gestorrh.android.data.network.fichaje.ModalidadTurno
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeEntradaDTO
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeSalidaDTO
+import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
 import com.gestorrh.android.data.repository.FichajeRepository
 import com.gestorrh.android.data.repository.asignacion.AsignacionRepositoryImpl
 import com.gestorrh.android.data.repository.ausencia.AusenciaRepositoryImpl
@@ -59,7 +60,9 @@ data class EstadoUiDashboard(
     /** Resumen del próximo turno asignado (hoy o futuro), o `null` si no hay ninguno. */
     val proximoTurno: ResumenProximoTurno? = null,
     /** Resumen de la próxima ausencia solicitada o aprobada, o `null` si no hay ninguna. */
-    val proximaAusencia: ResumenProximaAusencia? = null
+    val proximaAusencia: ResumenProximaAusencia? = null,
+    /** Últimos fichajes (máximo 3) de los últimos 7 días, mostrados inline en el dashboard. */
+    val ultimosFichajes: List<RespuestaFichajeDTO> = emptyList()
 )
 
 /**
@@ -112,6 +115,27 @@ class DashboardViewModel(
         cargarFichajesPendientes()
         cargarProximoTurno()
         cargarProximaAusencia()
+        cargarUltimosFichajes()
+    }
+
+    /**
+     * Recupera los últimos fichajes del empleado en los 7 días previos para mostrarlos
+     * inline en el dashboard. Limitado a 3 entradas, ordenados por hora de entrada
+     * descendente. Los errores se silencian: si la petición falla, la sección
+     * simplemente queda vacía y el dashboard sigue siendo usable.
+     */
+    fun cargarUltimosFichajes() {
+        viewModelScope.launch {
+            val hoy = LocalDate.now()
+            val hace7Dias = hoy.minusDays(7)
+            fichajeRepository.obtenerHistorialFichajes(hace7Dias, hoy)
+                .onSuccess { fichajes ->
+                    val ultimos = fichajes
+                        .sortedByDescending { it.horaEntrada }
+                        .take(3)
+                    _estadoUi.update { it.copy(ultimosFichajes = ultimos) }
+                }
+        }
     }
 
     /**

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -10,8 +10,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.EventBusy
-import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Schedule
@@ -34,6 +34,7 @@ import com.gestorrh.android.R
 import com.gestorrh.android.core.location.GestorLocalizacion
 import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.network.fichaje.ModalidadTurno
+import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
 import com.gestorrh.android.ui.theme.SemanticSuccess
 import com.gestorrh.android.ui.theme.SemanticWarning
 import kotlinx.coroutines.launch
@@ -54,7 +55,7 @@ import androidx.core.app.ActivityCompat
 
 @Composable
 fun PantallaDashboard(
-    alVerHistorial: () -> Unit,
+    alVerHistorialCompleto: () -> Unit,
     contexto: android.content.Context = LocalContext.current,
     viewModel: DashboardViewModel = viewModel(
         factory = DashboardViewModelFactory(contexto.applicationContext)
@@ -81,6 +82,7 @@ fun PantallaDashboard(
                 viewModel.cargarFichajesPendientes()
                 viewModel.cargarProximoTurno()
                 viewModel.cargarProximaAusencia()
+                viewModel.cargarUltimosFichajes()
             }
         }
         propietarioCicloVida.lifecycle.addObserver(observador)
@@ -206,22 +208,6 @@ fun PantallaDashboard(
                         alClickFichar = intentarFichar
                     )
 
-            Spacer(modifier = Modifier.height(16.dp))
-
-            OutlinedButton(
-                onClick = alVerHistorial,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.History,
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(stringResource(id = R.string.dashboard_btn_ver_historial))
-            }
-
-            Spacer(modifier = Modifier.height(32.dp))
                     Spacer(modifier = Modifier.height(32.dp))
 
                     Row(
@@ -241,6 +227,14 @@ fun PantallaDashboard(
                                 .weight(1f)
                                 .fillMaxHeight(),
                             proximaAusencia = estadoUi.proximaAusencia
+                        )
+                    }
+
+                    if (estadoUi.ultimosFichajes.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(24.dp))
+                        SeccionUltimosFichajes(
+                            ultimosFichajes = estadoUi.ultimosFichajes,
+                            alVerTodos = alVerHistorialCompleto
                         )
                     }
                 }
@@ -579,6 +573,115 @@ private fun WidgetFichaje(
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.error
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SeccionUltimosFichajes(
+    ultimosFichajes: List<RespuestaFichajeDTO>,
+    alVerTodos: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(id = R.string.dashboard_ultimos_fichajes_titulo),
+                style = MaterialTheme.typography.titleMedium
+            )
+            TextButton(onClick = alVerTodos) {
+                Text(stringResource(id = R.string.dashboard_ver_todos))
+            }
+        }
+        ultimosFichajes.forEach { fichaje ->
+            CardFichajeResumido(fichaje = fichaje)
+        }
+    }
+}
+
+@Composable
+private fun CardFichajeResumido(fichaje: RespuestaFichajeDTO) {
+    val formatoFecha = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
+    val formatoHora = remember { DateTimeFormatter.ofPattern("HH:mm") }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = fichaje.fecha.format(formatoFecha),
+                    style = MaterialTheme.typography.labelMedium
+                )
+                fichaje.descripcionTurno?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = stringResource(id = R.string.historial_fichajes_hora_entrada),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = fichaje.horaEntrada.format(formatoHora),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = stringResource(id = R.string.historial_fichajes_hora_salida),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    if (fichaje.horaSalida != null) {
+                        Text(
+                            text = fichaje.horaSalida.format(formatoHora),
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                    } else {
+                        Text(
+                            text = stringResource(id = R.string.historial_fichajes_en_curso),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = SemanticSuccess
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
@@ -82,7 +82,7 @@ fun PantallaPrincipal(
 
             composable(RutasDestino.Inicio.ruta) {
                 PantallaDashboard(
-                    alVerHistorial = {
+                    alVerHistorialCompleto = {
                         controladorNavegacionInterno.navigate(
                             RutasDestino.HistorialFichajes.ruta
                         ) {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -161,7 +161,8 @@
     <string name="historial_fichajes_en_curso">In progress</string>
     <string name="historial_fichajes_cd_volver">Back</string>
     <string name="perfil_btn_ver_mis_fichajes">View my records</string>
-    <string name="dashboard_btn_ver_historial">View history</string>
+    <string name="dashboard_ultimos_fichajes_titulo">Recent clock-ins</string>
+    <string name="dashboard_ver_todos">View all</string>
     <!-- Dashboard — dedicated error screen -->
     <string name="dashboard_error_titulo">Could not connect</string>
     <string name="dashboard_error_descripcion">We could not retrieve your clock-in status. Check your connection and try again.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,7 +164,8 @@
     <string name="historial_fichajes_en_curso">En curso</string>
     <string name="historial_fichajes_cd_volver">Volver</string>
     <string name="perfil_btn_ver_mis_fichajes">Ver mis fichajes</string>
-    <string name="dashboard_btn_ver_historial">Ver historial</string>
+    <string name="dashboard_ultimos_fichajes_titulo">Últimos fichajes</string>
+    <string name="dashboard_ver_todos">Ver todos</string>
     <!-- Dashboard — pantalla de error dedicada -->
     <string name="dashboard_error_titulo">No se pudo conectar</string>
     <string name="dashboard_error_descripcion">No hemos podido obtener tu estado de fichaje. Comprueba tu conexión e inténtalo de nuevo.</string>


### PR DESCRIPTION
## Resumen

- Elimina el botón "Ver historial" del Dashboard, que abría la pantalla completa perdiendo la `BottomNavigationBar` y duplicaba el punto de entrada al historial.
- Añade una sección inline "Últimos fichajes" en el Dashboard con los 3 fichajes más recientes (rango de los últimos 7 días) y un enlace "Ver todos" que navega al historial completo.
- Mantiene `Perfil → Ver mis fichajes` como único punto de entrada a la pantalla completa de historial; `PantallaPerfil` no se modifica.

## Cambios

- `DashboardViewModel`: nuevo campo `ultimosFichajes` en el estado y método `cargarUltimosFichajes()` que reutiliza `obtenerHistorialFichajes(hoy - 7d, hoy)`, ordena por `horaEntrada` desc y toma 3. Se invoca en `init` y en `ON_RESUME`.
- `PantallaDashboard`: eliminado el `OutlinedButton` y un `Spacer(32.dp)` duplicado que arrastraba; renombrado el callback `alVerHistorial` → `alVerHistorialCompleto`; nuevos composables privados `SeccionUltimosFichajes` y `CardFichajeResumido`.
- `PantallaPrincipal`: renombrado el parámetro al construir `PantallaDashboard`.
- `strings.xml` (es/en): añadidos `dashboard_ultimos_fichajes_titulo` y `dashboard_ver_todos`; eliminado el ya no usado `dashboard_btn_ver_historial`. Para "Entrada / Salida / En curso" se reutilizan los strings existentes `historial_fichajes_hora_entrada/salida/en_curso` en lugar de duplicarlos.

## Test plan

- [ ] Abrir el Dashboard y verificar que aparece la sección "Últimos fichajes" con hasta 3 cards.
- [ ] Pulsar "Ver todos" → navega a `PantallaHistorialFichajes`; al volver atrás se mantiene el Dashboard.
- [ ] Verificar que el botón "Ver historial" ya no existe en el Dashboard.
- [ ] Ir a Perfil → "Ver mis fichajes" → navega correctamente al historial completo.
- [ ] Cada card inline muestra fecha, turno (si existe), hora de entrada, hora de salida o "En curso".
- [ ] CI: `./gradlew assembleDebug` y `./gradlew testDebugUnitTest` en verde.