### PR TITLE
chore: versionCode automatizado desde GitHub Actions y versionName actualizado a 1.0.0

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -36,7 +36,11 @@ jobs:
           echo "PROD_BASE_URL=\"https://api.gestorrh.com/api/\"" >> secrets.properties
 
       - name: Compilar APK (assembleDebug)
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
         run: ./gradlew assembleDebug
 
       - name: Ejecutar Tests Básicos
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
         run: ./gradlew testDebugUnitTest

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,9 +25,8 @@ android {
         applicationId = "com.gestorrh.android"
         minSdk = 27
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
-
+        versionCode = (System.getenv("BUILD_NUMBER")?.toIntOrNull()) ?: 1
+        versionName = "1.0.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Descripción

Configuración del sistema de versionado automático para el pipeline de CI/CD:
el `versionCode` se inyecta desde GitHub Actions en cada ejecución, eliminando
el valor hardcodeado. Actualizado `versionName` a `1.0.0` de cara al próximo
release.

## Cambios incluidos

### app/build.gradle.kts
- `versionCode` lee la variable de entorno `BUILD_NUMBER` inyectada por GitHub
  Actions (`github.run_number`). En local siempre vale `1` como fallback para
  no bloquear el desarrollo
- `versionName` actualizado de `"1.0"` a `"1.0.0"` siguiendo Semantic
  Versioning y alineado con el roadmap de release

### .github/workflows/android-ci.yml
- Añadida variable de entorno `BUILD_NUMBER: ${{ github.run_number }}` en los
  pasos `assembleDebug` y `testDebugUnitTest` para que Gradle reciba el número
  de build en cada ejecución del pipeline

## Comportamiento

- **En local**: `versionCode = 1` siempre, sin cambios en el flujo de desarrollo
- **En CI (cada push/PR)**: `versionCode` se incrementa automáticamente con
  cada ejecución de GitHub Actions, garantizando unicidad sin intervención manual
- **En release**: el AAB/APK firmado llevará el `versionCode` del run de GitHub
  Actions correspondiente al merge en `main`
