### PR TITLE
fix: mejorar UX del formulario de ausencias

### DIFF
--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -31,6 +32,7 @@ import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.PictureAsPdf
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
@@ -107,7 +109,26 @@ fun PantallaSolicitudAusencia(
     val mensajeExito = stringResource(R.string.ausencia_envio_exitoso)
 
     var mostrarSelectorFuente by remember { mutableStateOf(false) }
+    var mostrarDialogoSalir by remember { mutableStateOf(false) }
     var uriCapturaPendiente by remember { mutableStateOf<GestorArchivosJustificante.UriCaptura?>(null) }
+
+    val hayDatosEnFormulario = estadoUi.tipoSeleccionado != null ||
+        estadoUi.fechaInicio != null ||
+        estadoUi.fechaFin != null ||
+        estadoUi.descripcion.isNotBlank() ||
+        estadoUi.archivoUri != null
+
+    val intentarVolver: () -> Unit = {
+        if (hayDatosEnFormulario) {
+            mostrarDialogoSalir = true
+        } else {
+            alVolver()
+        }
+    }
+
+    BackHandler(enabled = hayDatosEnFormulario) {
+        mostrarDialogoSalir = true
+    }
 
     val selectorArchivo = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
@@ -255,13 +276,36 @@ fun PantallaSolicitudAusencia(
             }
 
             OutlinedButton(
-                onClick = alVolver,
+                onClick = intentarVolver,
                 modifier = Modifier.fillMaxWidth(),
                 enabled = !estadoUi.enviando
             ) {
                 Text(stringResource(R.string.ausencia_btn_volver))
             }
         }
+    }
+
+    if (mostrarDialogoSalir) {
+        AlertDialog(
+            onDismissRequest = { mostrarDialogoSalir = false },
+            title = { Text(stringResource(R.string.ausencia_dialogo_salir_titulo)) },
+            text = { Text(stringResource(R.string.ausencia_dialogo_salir_mensaje)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        mostrarDialogoSalir = false
+                        alVolver()
+                    }
+                ) {
+                    Text(stringResource(R.string.ausencia_dialogo_salir_confirmar))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { mostrarDialogoSalir = false }) {
+                    Text(stringResource(R.string.ausencia_dialogo_salir_cancelar))
+                }
+            }
+        )
     }
 
     if (mostrarSelectorFuente) {

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
@@ -616,7 +616,7 @@ private fun CampoFecha(
                 TextButton(onClick = {
                     estadoPicker.selectedDateMillis?.let { millis ->
                         val fechaSeleccionada = Instant.ofEpochMilli(millis)
-                            .atZone(ZoneId.of("UTC"))
+                            .atZone(ZoneId.systemDefault())
                             .toLocalDate()
                         onFechaSeleccionada(fechaSeleccionada)
                     }

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
@@ -259,7 +259,7 @@ fun PantallaSolicitudAusencia(
                 modifier = Modifier.fillMaxWidth(),
                 enabled = !estadoUi.enviando
             ) {
-                Text(stringResource(R.string.ausencia_btn_cancelar))
+                Text(stringResource(R.string.ausencia_btn_volver))
             }
         }
     }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -114,6 +114,10 @@
     <string name="ausencia_error_sin_visor">No app available to open this file type.</string>
     <string name="ausencia_btn_enviar">Submit request</string>
     <string name="ausencia_btn_volver">Go back</string>
+    <string name="ausencia_dialogo_salir_titulo">Exit without saving?</string>
+    <string name="ausencia_dialogo_salir_mensaje">Form data will be lost. Are you sure you want to exit?</string>
+    <string name="ausencia_dialogo_salir_confirmar">Exit</string>
+    <string name="ausencia_dialogo_salir_cancelar">Keep editing</string>
     <string name="ausencia_dialog_aceptar">OK</string>
     <string name="ausencia_dialog_cancelar">Cancel</string>
     <string name="ausencia_envio_exitoso">Request sent successfully</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -113,7 +113,7 @@
     <string name="ausencia_error_archivo_grande">File exceeds the maximum allowed size (10 MB).</string>
     <string name="ausencia_error_sin_visor">No app available to open this file type.</string>
     <string name="ausencia_btn_enviar">Submit request</string>
-    <string name="ausencia_btn_cancelar">Cancel</string>
+    <string name="ausencia_btn_volver">Go back</string>
     <string name="ausencia_dialog_aceptar">OK</string>
     <string name="ausencia_dialog_cancelar">Cancel</string>
     <string name="ausencia_envio_exitoso">Request sent successfully</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,7 +116,7 @@
     <string name="ausencia_error_archivo_grande">El archivo supera el tamaño máximo permitido (10 MB).</string>
     <string name="ausencia_error_sin_visor">No hay ninguna aplicación disponible para abrir este tipo de archivo.</string>
     <string name="ausencia_btn_enviar">Enviar solicitud</string>
-    <string name="ausencia_btn_cancelar">Cancelar</string>
+    <string name="ausencia_btn_volver">Volver</string>
     <string name="ausencia_dialog_aceptar">Aceptar</string>
     <string name="ausencia_dialog_cancelar">Cancelar</string>
     <string name="ausencia_envio_exitoso">Solicitud enviada correctamente</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,10 @@
     <string name="ausencia_error_sin_visor">No hay ninguna aplicación disponible para abrir este tipo de archivo.</string>
     <string name="ausencia_btn_enviar">Enviar solicitud</string>
     <string name="ausencia_btn_volver">Volver</string>
+    <string name="ausencia_dialogo_salir_titulo">¿Salir sin guardar?</string>
+    <string name="ausencia_dialogo_salir_mensaje">Los datos del formulario se perderán. ¿Estás seguro de que quieres salir?</string>
+    <string name="ausencia_dialogo_salir_confirmar">Salir</string>
+    <string name="ausencia_dialogo_salir_cancelar">Continuar editando</string>
     <string name="ausencia_dialog_aceptar">Aceptar</string>
     <string name="ausencia_dialog_cancelar">Cancelar</string>
     <string name="ausencia_envio_exitoso">Solicitud enviada correctamente</string>


### PR DESCRIPTION
## Resumen

Mejora la UX del formulario de solicitud de ausencias en tres frentes:

- **Botón "Volver" en lugar de "Cancelar"**: el formulario reutilizaba el mismo label que el botón de cancelar solicitud en `PantallaMisAusencias`, que tiene un significado irreversible muy distinto. Renombrado a "Volver" / "Go back" para diferenciar la acción reversible (descartar formulario) de la irreversible (cancelar una solicitud ya enviada).
- **Confirmación al salir con datos sin guardar**: si el formulario contiene tipo, fechas, descripción o adjunto, tanto pulsar "Volver" como el botón "Atrás" del sistema (`BackHandler`) abren un `AlertDialog` que pide confirmación antes de descartar los datos. Si el formulario está vacío se sale directamente.
- **Zona horaria local en el `DatePicker`**: el selector usaba `ZoneId.of("UTC")` para convertir milisegundos a `LocalDate`, mientras que el validador usa `LocalDate.now()` (zona del dispositivo). Esto causaba que un usuario en zona UTC+ pudiera recibir el error "fecha en el pasado" al seleccionar "hoy". Cambiado a `ZoneId.systemDefault()` para alinearlo con la conversión inversa que ya usaba la zona local.

## Plan de pruebas

- [x] `./gradlew assembleDebug -x test` — compila sin errores
- [x] `./gradlew test` — tests unitarios en verde
- [x] El formulario muestra "Volver" (`OutlinedButton`) en lugar de "Cancelar"
- [x] El botón "Cancelar" de las cards en `PantallaMisAusencias` permanece intacto
- [x] Al rellenar el formulario y pulsar "Volver" aparece el diálogo de confirmación
- [x] Al rellenar el formulario y pulsar "Atrás" del sistema aparece el diálogo
- [x] Con el formulario vacío, "Volver" sale sin diálogo
- [x] Seleccionar fecha de inicio = hoy y fecha fin = hoy y enviar no produce error de "fecha en el pasado" en distintas zonas horarias