### PR TITLE
Mejorar consistencia en estados de ausencia y feedback visual del calendario

### DIFF
--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/AusenciaUtils.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/AusenciaUtils.kt
@@ -1,0 +1,27 @@
+package com.gestorrh.android.ui.ausencia
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.graphics.Color
+import com.gestorrh.android.R
+
+object AusenciaUtils {
+
+    @StringRes
+    fun obtenerStringEstado(estado: String): Int {
+        return when (estado.uppercase()) {
+            "SOLICITADA" -> R.string.ausencia_estado_solicitada
+            "APROBADA" -> R.string.ausencia_estado_aprobada
+            "RECHAZADA" -> R.string.ausencia_estado_rechazada
+            else -> R.string.ausencia_estado_desconocido
+        }
+    }
+
+    fun obtenerColorEstado(estado: String): Color {
+        return when (estado.uppercase()) {
+            "SOLICITADA" -> Color(0xFFF57C00)
+            "APROBADA" -> Color(0xFF2E7D32)
+            "RECHAZADA" -> Color(0xFFD32F2F)
+            else -> Color(0xFF8B8B8B)
+        }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
@@ -68,8 +68,6 @@ import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
 import java.time.format.DateTimeFormatter
 import androidx.lifecycle.compose.LocalLifecycleOwner
 
-private val ColorEstadoSolicitada = Color(0xFFF57C00)
-private val ColorEstadoAprobada = Color(0xFF2E7D32)
 private val ColorEstadoRechazada = Color(0xFFD32F2F)
 
 private val FormatoFecha: DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
@@ -406,35 +404,21 @@ private fun TarjetaAusencia(
 
 @Composable
 private fun ChipEstado(estado: String) {
-    val color = when (estado) {
-        "SOLICITADA" -> ColorEstadoSolicitada
-        "APROBADA" -> ColorEstadoAprobada
-        "RECHAZADA" -> ColorEstadoRechazada
-        else -> MaterialTheme.colorScheme.outline
-    }
     Box(
         modifier = Modifier
-            .background(color = color, shape = RoundedCornerShape(50))
+            .background(
+                color = AusenciaUtils.obtenerColorEstado(estado),
+                shape = RoundedCornerShape(50)
+            )
             .padding(horizontal = 12.dp, vertical = 4.dp)
     ) {
         Text(
-            text = etiquetaEstado(estado),
+            text = stringResource(id = AusenciaUtils.obtenerStringEstado(estado)),
             style = MaterialTheme.typography.labelMedium,
             color = Color.White,
             fontWeight = FontWeight.Medium
         )
     }
-}
-
-@Composable
-private fun etiquetaEstado(estado: String): String {
-    val resId = when (estado) {
-        "SOLICITADA" -> R.string.mis_ausencias_estado_solicitada
-        "APROBADA" -> R.string.mis_ausencias_estado_aprobada
-        "RECHAZADA" -> R.string.mis_ausencias_estado_rechazada
-        else -> null
-    }
-    return resId?.let { stringResource(it) } ?: estado
 }
 
 @Composable

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -35,6 +35,7 @@ import com.gestorrh.android.core.location.GestorLocalizacion
 import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.network.fichaje.ModalidadTurno
 import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
+import com.gestorrh.android.ui.ausencia.AusenciaUtils
 import com.gestorrh.android.ui.theme.SemanticSuccess
 import com.gestorrh.android.ui.theme.SemanticWarning
 import kotlinx.coroutines.launch
@@ -397,10 +398,13 @@ private fun TarjetaProximaAusencia(
         )
         return
     }
-    val (etiquetaEstado, colorEstado) = when (proximaAusencia.estado) {
-        "SOLICITADA" -> stringResource(id = R.string.dashboard_estado_ausencia_pendiente) to SemanticWarning
-        "APROBADA" -> stringResource(id = R.string.dashboard_estado_ausencia_aprobada) to SemanticSuccess
-        else -> proximaAusencia.estado to MaterialTheme.colorScheme.onSurfaceVariant
+    val etiquetaEstado = stringResource(
+        id = AusenciaUtils.obtenerStringEstado(proximaAusencia.estado)
+    )
+    val colorEstado = when (proximaAusencia.estado.uppercase()) {
+        "SOLICITADA" -> SemanticWarning
+        "APROBADA" -> SemanticSuccess
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
     }
     TarjetaInformativa(
         modifier = modifier,

--- a/app/src/main/java/com/gestorrh/android/ui/turnos/PantallaMisTurnos.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/turnos/PantallaMisTurnos.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -412,14 +413,17 @@ private fun CeldaDia(
 ) {
     val colorFondo = when {
         esHoy -> MaterialTheme.colorScheme.primaryContainer
+        tieneTurno -> MaterialTheme.colorScheme.surfaceVariant
         else -> Color.Transparent
     }
+    val opacidad = if (tieneTurno || esHoy) 1f else 0.4f
 
     Column(
         modifier = modifier
             .aspectRatio(1f)
             .clip(MaterialTheme.shapes.small)
             .background(colorFondo)
+            .alpha(opacidad)
             .clickable(enabled = tieneTurno, onClick = alClick),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
@@ -431,7 +435,7 @@ private fun CeldaDia(
                 esHoy -> MaterialTheme.colorScheme.onPrimaryContainer
                 else -> MaterialTheme.colorScheme.onSurface
             },
-            fontWeight = if (esHoy) FontWeight.Bold else FontWeight.Normal
+            fontWeight = if (esHoy || tieneTurno) FontWeight.Bold else FontWeight.Normal
         )
         if (tieneTurno) {
             Spacer(modifier = Modifier.height(2.dp))

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -29,8 +29,6 @@
     <string name="dashboard_turno_horario_hoy">Today %1$s-%2$s</string>
     <string name="dashboard_turno_horario_manana">Tomorrow %1$s-%2$s</string>
     <string name="dashboard_turno_horario_proximo">%1$s %2$s - %3$s</string>
-    <string name="dashboard_estado_ausencia_pendiente">Pending</string>
-    <string name="dashboard_estado_ausencia_aprobada">Approved</string>
     <string name="fichaje_estado_fuera">Off duty</string>
     <string name="fichaje_estado_activo">Working</string>
     <string name="fichaje_btn_iniciar">CLOCK IN</string>
@@ -140,9 +138,10 @@
     <string name="mis_ausencias_rango_fechas">%1$s → %2$s</string>
     <!-- %1$s = review notes provided by the supervisor -->
     <string name="mis_ausencias_observaciones">Notes: %1$s</string>
-    <string name="mis_ausencias_estado_solicitada">PENDING</string>
-    <string name="mis_ausencias_estado_aprobada">APPROVED</string>
-    <string name="mis_ausencias_estado_rechazada">REJECTED</string>
+    <string name="ausencia_estado_solicitada">Pending</string>
+    <string name="ausencia_estado_aprobada">Approved</string>
+    <string name="ausencia_estado_rechazada">Rejected</string>
+    <string name="ausencia_estado_desconocido">Unknown status</string>
     <string name="mis_ausencias_btn_editar">Edit</string>
     <string name="mis_ausencias_btn_cancelar">Cancel</string>
     <string name="mis_ausencias_dialog_cancelar_titulo">Cancel request</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,8 +32,6 @@
     <string name="dashboard_turno_horario_manana">Mañana %1$s-%2$s</string>
     <!-- Formato del horario cuando es otro día: %1$s = día semana, %2$s = dd/MM, %3$s = hora inicio -->
     <string name="dashboard_turno_horario_proximo">%1$s %2$s - %3$s</string>
-    <string name="dashboard_estado_ausencia_pendiente">Pendiente</string>
-    <string name="dashboard_estado_ausencia_aprobada">Aprobada</string>
     <string name="fichaje_estado_fuera">Fuera de turno</string>
     <string name="fichaje_estado_activo">Trabajando</string>
     <string name="fichaje_btn_iniciar">INICIAR JORNADA</string>
@@ -143,9 +141,10 @@
     <string name="mis_ausencias_rango_fechas">%1$s → %2$s</string>
     <!-- %1$s = observaciones de la revisión devueltas por el supervisor -->
     <string name="mis_ausencias_observaciones">Observaciones: %1$s</string>
-    <string name="mis_ausencias_estado_solicitada">SOLICITADA</string>
-    <string name="mis_ausencias_estado_aprobada">APROBADA</string>
-    <string name="mis_ausencias_estado_rechazada">RECHAZADA</string>
+    <string name="ausencia_estado_solicitada">Pendiente</string>
+    <string name="ausencia_estado_aprobada">Aprobada</string>
+    <string name="ausencia_estado_rechazada">Rechazada</string>
+    <string name="ausencia_estado_desconocido">Estado desconocido</string>
     <string name="mis_ausencias_btn_editar">Editar</string>
     <string name="mis_ausencias_btn_cancelar">Cancelar</string>
     <string name="mis_ausencias_dialog_cancelar_titulo">Cancelar solicitud</string>


### PR DESCRIPTION
## Resumen

Mejora la consistencia de la representación de estados de ausencia y el feedback visual de la vista de calendario de turnos.

### Estados de ausencia centralizados
- Nuevo `ui/ausencia/AusenciaUtils.kt` con `obtenerStringEstado()` y `obtenerColorEstado()`, que mapean el valor del backend (`SOLICITADA`, `APROBADA`, `RECHAZADA`) al string resource y color correspondiente, con fallback a `ausencia_estado_desconocido` si la API devuelve un valor no esperado.
- Unificación de strings: se reemplazan `mis_ausencias_estado_*` (que mostraban el estado en mayúsculas crudas) y `dashboard_estado_ausencia_*` por las claves `ausencia_estado_*` con etiquetas legibles ("Pendiente", "Aprobada", "Rechazada").
- `PantallaMisAusencias` y `PantallaDashboard` usan ahora el helper, eliminando los `when` hardcoded duplicados.

### Calendario de turnos
- En `PantallaMisTurnos`, los días sin turno se muestran ahora con opacidad reducida (`0.4f`), dejando claro de un vistazo que no son interactivos.
- Los días con turno destacan con fondo `surfaceVariant` y número en negrita, además del indicador circular ya existente.

## Test plan

- [ ] Compilar (`./gradlew assembleDebug`) — OK localmente.
- [ ] Verificar en "Mis ausencias" que el chip muestra "Pendiente" / "Aprobada" / "Rechazada" en español y "Pending" / "Approved" / "Rejected" en inglés.
- [ ] Forzar un estado desconocido (mocking) y comprobar que aparece "Estado desconocido" en lugar del valor crudo.
- [ ] Comprobar tarjeta "Próxima ausencia" del dashboard en ambos idiomas.
- [ ] En la vista de calendario de "Mis turnos", verificar que los días sin turno se ven atenuados y no responden al toque, mientras que los días con turno son claramente clickables.