### PR TITLE
fix: corregir cronómetro de fichaje con desfase UTC en producción

### DIFF
--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -245,8 +245,13 @@ class DashboardViewModel(
                     }
 
                     if (datos.trabajandoActualmente && datos.horaEntrada != null) {
-                        segundosAcumulados = ChronoUnit.SECONDS.between(datos.horaEntrada, LocalDateTime.now())
+                        val horaEntradaUtc = datos.horaEntrada.toInstant(java.time.ZoneOffset.UTC)
+                        val segundos = ChronoUnit.SECONDS.between(horaEntradaUtc, java.time.Instant.now())
+                        segundosAcumulados = segundos.coerceAtLeast(0L)
                         iniciarTemporizador()
+                    } else if (!datos.trabajandoActualmente) {
+                        detenerTemporizador()
+                        segundosAcumulados = 0
                     }
                 }
                 .onFailure { e ->


### PR DESCRIPTION
## Problema

El cronómetro del dashboard mostraba tiempo negativo o incorrecto en
producción. La causa raíz es que el servidor devuelve `horaEntrada` en
UTC sin offset explícito (ej. `"2026-05-18T17:35:00"`), pero
`LocalDateTime.now()` del dispositivo devuelve hora local española
(UTC+2), produciendo un desfase de 2 horas en el cálculo.

**Ejemplo reproducido en producción:**
- Fichaje realizado a las `19:35` hora española
- Servidor devuelve `horaEntrada: "2026-05-18T17:35:00"` (UTC)
- Cálculo anterior: `19:35 - 17:35 = -2h` → cronómetro negativo

## Solución

Se interpreta `horaEntrada` como UTC explícitamente usando
`ZoneOffset.UTC` y se compara contra `Instant.now()`, que es
independiente de la zona horaria del dispositivo. Se añade
`coerceAtLeast(0L)` como salvaguarda ante desfases residuales
de milisegundos.

Se añade además el bloque `else` para detener el temporizador
limpiamente si al volver de segundo plano el fichaje ya había
sido cerrado desde otro dispositivo.

## Archivos modificados

- `DashboardViewModel.kt` → método `sincronizarEstado()`

## Notas

Este es un **fix temporal**. La solución definitiva requiere que la API
normalice todos los timestamps a `OffsetDateTime` con offset explícito
(`Z`), de forma que los clientes no necesiten asumir la zona horaria del
servidor. Tracked en la issue de normalización UTC.