### PR TITLE
feat: mejoras en el dashboard — estados de fichaje, filtros de tarjetas y navegación

### DIFF
--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -170,15 +170,18 @@ class DashboardViewModel(
             val asignaciones = asignacionRepository.observarAsignaciones().firstOrNull()
                 ?: return@launch
             val hoy = LocalDate.now()
+            val ahora = LocalTime.now()
             val proxima = asignaciones
                 .mapNotNull { entidad ->
                     val fecha = parsearFecha(entidad.fecha) ?: return@mapNotNull null
                     if (fecha < hoy) return@mapNotNull null
+                    val horaFin = parsearHora(entidad.horaFin)
+                    if (fecha == hoy && horaFin != null && ahora.isAfter(horaFin)) return@mapNotNull null
                     ResumenProximoTurno(
                         nombreTurno = entidad.descripcionTurno,
                         fecha = fecha,
                         horaInicio = parsearHora(entidad.horaInicio),
-                        horaFin = parsearHora(entidad.horaFin)
+                        horaFin = horaFin
                     )
                 }
                 .minByOrNull { it.fecha }
@@ -199,7 +202,7 @@ class DashboardViewModel(
             val hoy = LocalDate.now()
             val proxima = ausencias
                 .filter { it.estado == ESTADO_AUSENCIA_SOLICITADA || it.estado == ESTADO_AUSENCIA_APROBADA }
-                .filter { !it.fechaInicio.isBefore(hoy) }
+                .filter { !it.fechaFin.isBefore(hoy) }
                 .minByOrNull { it.fechaInicio }
                 ?.let { dto ->
                     ResumenProximaAusencia(

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -88,7 +88,10 @@ data class ResumenProximaAusencia(
 )
 
 enum class EstadoFichaje {
-    TRABAJANDO, FUERA_TURNO
+    TRABAJANDO,
+    TURNO_EN_CURSO_SIN_FICHAR,
+    TURNO_PENDIENTE,
+    FUERA_TURNO
 }
 
 /**
@@ -240,7 +243,11 @@ class DashboardViewModel(
                             idFichajeAbierto = datos.idFichajeAbierto,
                             modalidadHoy = datos.modalidadHoy,
                             tieneTurnoHoy = datos.tieneTurnoHoy,
-                            estadoActual = if (datos.trabajandoActualmente) EstadoFichaje.TRABAJANDO else EstadoFichaje.FUERA_TURNO
+                            estadoActual = calcularEstadoFichaje(
+                                trabajandoActualmente = datos.trabajandoActualmente,
+                                tieneTurnoHoy = datos.tieneTurnoHoy,
+                                proximoTurno = _estadoUi.value.proximoTurno
+                            )
                         )
                     }
 
@@ -440,6 +447,25 @@ class DashboardViewModel(
         temporizadorJob?.cancel()
         temporizadorJob = null
         segundosAcumulados = 0
+    }
+
+    private fun calcularEstadoFichaje(
+        trabajandoActualmente: Boolean,
+        tieneTurnoHoy: Boolean,
+        proximoTurno: ResumenProximoTurno?
+    ): EstadoFichaje {
+        if (trabajandoActualmente) return EstadoFichaje.TRABAJANDO
+        if (!tieneTurnoHoy || proximoTurno == null) return EstadoFichaje.FUERA_TURNO
+
+        val ahora = LocalTime.now()
+        val horaInicio = proximoTurno.horaInicio
+        val horaFin = proximoTurno.horaFin
+
+        return when {
+            horaInicio != null && ahora.isBefore(horaInicio) -> EstadoFichaje.TURNO_PENDIENTE
+            horaFin != null && ahora.isAfter(horaFin) -> EstadoFichaje.FUERA_TURNO
+            else -> EstadoFichaje.TURNO_EN_CURSO_SIN_FICHAR
+        }
     }
 
     private fun formatearTiempo(segundosTotales: Long): String {

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -52,6 +52,7 @@ import androidx.compose.material.icons.filled.WifiOff
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.core.app.ActivityCompat
 
@@ -207,6 +208,7 @@ fun PantallaDashboard(
                         estaCargando = estadoUi.estaCargando,
                         modalidad = estadoUi.modalidadHoy,
                         fichajesPendientes = estadoUi.fichajesPendientesSincronizar,
+                        horaInicioPendiente = estadoUi.proximoTurno?.horaInicio,
                         alClickFichar = intentarFichar
                     )
 
@@ -478,6 +480,7 @@ private fun WidgetFichaje(
     estaCargando: Boolean,
     modalidad: ModalidadTurno?,
     fichajesPendientes: Int,
+    horaInicioPendiente: LocalTime?,
     alClickFichar: () -> Unit
 ) {
     val esActivo = estadoActual == EstadoFichaje.TRABAJANDO
@@ -487,7 +490,17 @@ private fun WidgetFichaje(
     val colorTextoEstado = if (esActivo) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
     val colorBoton = if (esActivo) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary
     val textoBoton = if (esActivo) R.string.fichaje_btn_finalizar else R.string.fichaje_btn_iniciar
-    val textoEstado = if (esActivo) R.string.fichaje_estado_activo else R.string.fichaje_estado_fuera
+
+    val formatoHora = remember { DateTimeFormatter.ofPattern("HH:mm") }
+    val textoEstado = when (estadoActual) {
+        EstadoFichaje.TRABAJANDO -> stringResource(R.string.fichaje_estado_activo)
+        EstadoFichaje.TURNO_EN_CURSO_SIN_FICHAR -> stringResource(R.string.fichaje_estado_turno_sin_fichar)
+        EstadoFichaje.TURNO_PENDIENTE -> stringResource(
+            R.string.fichaje_estado_turno_pendiente,
+            horaInicioPendiente?.format(formatoHora) ?: ""
+        )
+        EstadoFichaje.FUERA_TURNO -> stringResource(R.string.fichaje_estado_fuera)
+    }
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -509,10 +522,11 @@ private fun WidgetFichaje(
             }
 
             Text(
-                text = stringResource(id = textoEstado).uppercase(),
+                text = textoEstado,
                 style = MaterialTheme.typography.labelLarge,
                 color = colorTextoEstado,
-                fontWeight = FontWeight.Bold
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -546,7 +560,8 @@ private fun WidgetFichaje(
                     } else {
                         Text(
                             text = stringResource(id = textoBoton),
-                            style = MaterialTheme.typography.labelLarge
+                            style = MaterialTheme.typography.labelLarge,
+                            fontSize = 18.sp
                         )
                     }
                 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -27,8 +27,10 @@
     <string name="dashboard_turno_horario_hoy">Today %1$s-%2$s</string>
     <string name="dashboard_turno_horario_manana">Tomorrow %1$s-%2$s</string>
     <string name="dashboard_turno_horario_proximo">%1$s %2$s - %3$s</string>
-    <string name="fichaje_estado_fuera">Off duty</string>
+    <string name="fichaje_estado_fuera">No shift today</string>
     <string name="fichaje_estado_activo">Working</string>
+    <string name="fichaje_estado_turno_sin_fichar">Don\'t forget to clock in! Your shift has started</string>
+    <string name="fichaje_estado_turno_pendiente">Your next shift starts at %1$s</string>
     <string name="fichaje_btn_iniciar">CLOCK IN</string>
     <string name="fichaje_btn_finalizar">CLOCK OUT</string>
     <string name="fichaje_sin_conexion">No connection — your clock event will be sent automatically</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,10 +30,12 @@
     <string name="dashboard_turno_horario_manana">Mañana %1$s-%2$s</string>
     <!-- Formato del horario cuando es otro día: %1$s = día semana, %2$s = dd/MM, %3$s = hora inicio -->
     <string name="dashboard_turno_horario_proximo">%1$s %2$s - %3$s</string>
-    <string name="fichaje_estado_fuera">Fuera de turno</string>
+    <string name="fichaje_estado_fuera">No tienes turno hoy</string>
     <string name="fichaje_estado_activo">Trabajando</string>
-    <string name="fichaje_btn_iniciar">INICIAR JORNADA</string>
-    <string name="fichaje_btn_finalizar">FINALIZAR JORNADA</string>
+    <string name="fichaje_estado_turno_sin_fichar">¡Recuerda fichar! Tu turno ya ha comenzado</string>
+    <string name="fichaje_estado_turno_pendiente">Tu próximo turno empieza a las %1$s</string>
+    <string name="fichaje_btn_iniciar">Fichar entrada</string>
+    <string name="fichaje_btn_finalizar">Fichar salida</string>
     <string name="fichaje_sin_conexion">Sin conexión — el fichaje se enviará automáticamente</string>
     <string name="fichajes_pendientes">%d fichaje(s) pendiente(s) de sincronizar</string>
     <string name="fichaje_entrada_duplicada_offline">Ya hay una entrada pendiente de sincronizar. No puedes registrar otra hasta que se envíe.</string>


### PR DESCRIPTION
## Cambios incluidos

### Estados del widget de fichaje
- Añadidos cuatro estados diferenciados en `EstadoFichaje`:
  `TRABAJANDO`, `TURNO_EN_CURSO_SIN_FICHAR`, `TURNO_PENDIENTE`
  y `FUERA_TURNO`
- Implementada lógica `calcularEstadoFichaje()` que determina el
  estado según la hora actual, la asignación del día y el fichaje abierto
- Textos de estado actualizados a un tono más cercano y descriptivo
- Textos del botón actualizados a "Fichar entrada" / "Fichar salida"
- Eliminado `.uppercase()` del texto de estado
- Aumentado `fontSize` del botón a `18sp`

### Corrección de tarjetas del dashboard
- La tarjeta "Próximo turno" descarta el turno de hoy si su `horaFin`
  ya ha pasado, mostrando el siguiente turno asignado
- La tarjeta "Próxima ausencia" ahora filtra por `fechaFin` en lugar
  de `fechaInicio`, mostrando ausencias en curso aunque hayan empezado
  días anteriores

### Fix cronómetro UTC
- El cronómetro interpreta `horaEntrada` como UTC para evitar tiempo
  negativo en producción al comparar con la hora local del dispositivo
- Fix temporal hasta que la API normalice las fechas a `OffsetDateTime`

## Archivos modificados
- `DashboardViewModel.kt`
- `PantallaDashboard.kt`
- `res/values/strings.xml`
- `res/values-en/strings.xml`