### PR TITLE
fix: corregir eliminación de justificante en edición de ausencia

### DIFF
--- a/app/src/main/java/com/gestorrh/android/domain/usecase/ausencia/SolicitarAusenciaUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/ausencia/SolicitarAusenciaUseCase.kt
@@ -64,17 +64,12 @@ class SolicitarAusenciaUseCase(
             }
         }
 
-        val flagEliminar = if (idAusenciaEditar != null && archivoBytes == null) {
-            eliminarJustificante
-        } else {
-            null
-        }
         val peticion = PeticionAusenciaDTO(
             tipo = tipo,
             descripcion = descripcion?.takeIf { it.isNotBlank() },
             fechaInicio = fechaInicio,
             fechaFin = fechaFin,
-            eliminarJustificante = flagEliminar
+            eliminarJustificante = eliminarJustificante
         )
         return if (idAusenciaEditar != null) {
             repository.actualizarAusencia(idAusenciaEditar, peticion, archivoBytes, nombreArchivo)

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
@@ -279,12 +279,12 @@ class SolicitudAusenciaViewModel(
                 nombreNormalizadoParaSubida(estadoActual.nombreArchivo, estadoActual.esImagen)
             }
 
-            val flagEliminar = if (
-                estadoActual.idAusenciaEditar != null &&
-                archivoBytes == null &&
-                estadoActual.nombreJustificanteExistente != null
-            ) {
-                estadoActual.eliminarJustificanteExistente
+            val flagEliminar = if (estadoActual.idAusenciaEditar != null) {
+                when {
+                    estadoActual.eliminarJustificanteExistente -> true
+                    archivoBytes != null -> null
+                    else -> false
+                }
             } else {
                 null
             }


### PR DESCRIPTION
## Problema

Al editar una ausencia en estado `SOLICITADA`, no era posible eliminar
un justificante ya adjunto. El campo `eliminarJustificante` existía tanto
en el cliente como en el servidor pero no funcionaba correctamente debido
a un doble recálculo del flag que anulaba la intención del usuario.

## Causa

El `SolicitudAusenciaViewModel` calculaba `flagEliminar` correctamente,
pero `SolicitarAusenciaUseCase` lo recalculaba internamente con una lógica
diferente que sobreescribía el valor recibido, impidiendo que `true` llegase
al servidor.

## Solución

- El cálculo del flag se centraliza exclusivamente en `SolicitudAusenciaViewModel`,
  que es quien conoce el estado de la UI.
- `SolicitarAusenciaUseCase` recibe el flag y lo pasa al DTO directamente
  sin modificarlo.
- La lógica del flag respeta los tres estados posibles: `true` (eliminar),
  `false` (conservar) y `null` (creación o sustitución con archivo nuevo).

## Archivos modificados

- `SolicitudAusenciaViewModel.kt`
- `SolicitarAusenciaUseCase.kt`