### PR TITLE
fix: elimina tab Turnos redundante en PantallaGestionEquipo

### DIFF
--- a/app/src/main/java/com/gestorrh/android/ui/equipo/PantallaGestionEquipo.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/PantallaGestionEquipo.kt
@@ -42,7 +42,6 @@ fun PantallaGestionEquipo() {
     val tabs = listOf(
         stringResource(R.string.equipo_tab_ausencias),
         stringResource(R.string.equipo_tab_cuadrante),
-        stringResource(R.string.equipo_tab_turnos),
         stringResource(R.string.equipo_tab_fichajes)
     )
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -201,8 +201,6 @@
     <string name="equipo_titulo">Team Management</string>
     <string name="equipo_tab_ausencias">Time Off</string>
     <string name="equipo_tab_cuadrante">Schedule</string>
-    <string name="equipo_tab_dashboard">Dashboard</string>
-    <string name="equipo_tab_turnos">Shifts</string>
     <string name="equipo_tab_fichajes">Records</string>
     <string name="equipo_proximamente">Coming soon</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,8 +202,6 @@
     <string name="equipo_titulo">Gestión Equipo</string>
     <string name="equipo_tab_ausencias">Ausencias</string>
     <string name="equipo_tab_cuadrante">Cuadrante</string>
-    <string name="equipo_tab_dashboard">Dashboard</string>
-    <string name="equipo_tab_turnos">Turnos</string>
     <string name="equipo_tab_fichajes">Fichajes</string>
     <string name="equipo_proximamente">Próximamente</string>
 </resources>


### PR DESCRIPTION
## Descripción

Corrige la pantalla contenedora del supervisor eliminando la tab "Turnos" por ser
redundante con "Cuadrante" e incorrecta desde el punto de vista funcional.

## Motivo

- **Turnos** (`/api/turnos`) son plantillas de turno definidas a nivel de empresa
  (ej: "Turno Mañana 8:00-16:00"). Su gestión es territorio de `EMPRESA`, no de `SUPERVISOR`.
- **Cuadrante** (`/api/asignaciones`) es la planificación concreta: qué empleado trabaja
  qué turno qué día. Esta sí es responsabilidad del supervisor sobre su equipo.

Tener ambas tabs era conceptualmente incorrecto y generaba confusión.

## Cambios incluidos

- Elimina la tab "Turnos" de `PantallaGestionEquipo`
- Elimina el string `equipo_tab_turnos` de `values/strings.xml` y `values-en/strings.xml`
- `PantallaGestionEquipo` queda con 3 tabs: **Ausencias, Cuadrante, Fichajes**

## Criterios de aceptación verificados

- [x] La pantalla "Mi equipo" muestra exactamente 3 tabs
- [x] No hay referencias huérfanas al string eliminado