### PR TITLE
[P2-03] Cuadrante del Departamento (Supervisor)

### DIFF
--- a/app/src/main/java/com/gestorrh/android/core/network/ApiClient.kt
+++ b/app/src/main/java/com/gestorrh/android/core/network/ApiClient.kt
@@ -12,6 +12,8 @@ import retrofit2.converter.gson.GsonConverterFactory
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import com.gestorrh.android.core.network.LocalTimeDeserializer
+import java.time.LocalTime
 
 /**
  * Motor central de comunicaciones HTTP de la aplicación.
@@ -48,6 +50,13 @@ object ApiClient {
                 LocalDate::class.java,
                 JsonSerializer<LocalDate> { src, _, _ ->
                     JsonPrimitive(src.format(DateTimeFormatter.ISO_LOCAL_DATE))
+                }
+            )
+            .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
+            .registerTypeAdapter(
+                LocalTime::class.java,
+                JsonSerializer<LocalTime> { src, _, _ ->
+                    JsonPrimitive(src.format(DateTimeFormatter.ofPattern("HH:mm")))
                 }
             )
             .create()

--- a/app/src/main/java/com/gestorrh/android/core/network/LocalTimeDeserializer.kt
+++ b/app/src/main/java/com/gestorrh/android/core/network/LocalTimeDeserializer.kt
@@ -6,17 +6,29 @@ import com.google.gson.JsonElement
 import java.lang.reflect.Type
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatterBuilder
 
 /**
- * Enseña a Retrofit (Gson) cómo transformar el String "HH:mm" de Spring Boot
- * en un objeto LocalTime de Kotlin.
+ * Enseña a Retrofit (Gson) cómo transformar Strings de hora de Spring Boot
+ * en un objeto LocalTime de Kotlin. Acepta tanto "HH:mm" como "HH:mm:ss"
+ * para ser tolerante con distintas configuraciones del servidor.
  */
 class LocalTimeDeserializer : JsonDeserializer<LocalTime> {
+
     override fun deserialize(
         json: JsonElement,
         typeOfT: Type,
         context: JsonDeserializationContext
     ): LocalTime {
-        return LocalTime.parse(json.asString, DateTimeFormatter.ofPattern("HH:mm"))
+        return LocalTime.parse(json.asString, FORMATTER)
+    }
+
+    companion object {
+        private val FORMATTER: DateTimeFormatter = DateTimeFormatterBuilder()
+            .appendPattern("HH:mm")
+            .optionalStart()
+            .appendPattern(":ss")
+            .optionalEnd()
+            .toFormatter()
     }
 }

--- a/app/src/main/java/com/gestorrh/android/core/network/LocalTimeDeserializer.kt
+++ b/app/src/main/java/com/gestorrh/android/core/network/LocalTimeDeserializer.kt
@@ -1,0 +1,22 @@
+package com.gestorrh.android.core.network
+
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import java.lang.reflect.Type
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * Enseña a Retrofit (Gson) cómo transformar el String "HH:mm" de Spring Boot
+ * en un objeto LocalTime de Kotlin.
+ */
+class LocalTimeDeserializer : JsonDeserializer<LocalTime> {
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext
+    ): LocalTime {
+        return LocalTime.parse(json.asString, DateTimeFormatter.ofPattern("HH:mm"))
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/data/local/mapper/AsignacionMapper.kt
+++ b/app/src/main/java/com/gestorrh/android/data/local/mapper/AsignacionMapper.kt
@@ -10,8 +10,8 @@ fun RespuestaAsignacionTurnoDTO.toEntity(fechaSincronizacion: Long): AsignacionE
         descripcionTurno = descripcionTurno,
         fecha = fecha.toString(),
         modalidad = modalidad.name,
-        horaInicio = horaInicio,
-        horaFin = horaFin,
+        horaInicio = horaInicio?.toString(),
+        horaFin = horaFin?.toString(),
         motivoCambio = motivoCambio,
         responsableCambio = responsableCambio,
         fechaSincronizacion = fechaSincronizacion

--- a/app/src/main/java/com/gestorrh/android/data/network/asignacion/AsignacionApiService.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/asignacion/AsignacionApiService.kt
@@ -1,10 +1,20 @@
 package com.gestorrh.android.data.network.asignacion
 
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 
 interface AsignacionApiService {
 
     @GET("api/asignaciones/me")
     suspend fun getMisAsignaciones(): Response<List<RespuestaAsignacionTurnoDTO>>
+
+    @GET("api/asignaciones")
+    suspend fun getAsignacionesEquipo(): Response<List<RespuestaAsignacionTurnoDTO>>
+
+    @POST("api/asignaciones")
+    suspend fun crearAsignacion(
+        @Body body: PeticionAsignacionTurnoDTO
+    ): Response<RespuestaAsignacionTurnoDTO>
 }

--- a/app/src/main/java/com/gestorrh/android/data/network/asignacion/AsignacionApiService.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/asignacion/AsignacionApiService.kt
@@ -2,8 +2,11 @@ package com.gestorrh.android.data.network.asignacion
 
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.PUT
+import retrofit2.http.Path
 
 interface AsignacionApiService {
 
@@ -17,4 +20,15 @@ interface AsignacionApiService {
     suspend fun crearAsignacion(
         @Body body: PeticionAsignacionTurnoDTO
     ): Response<RespuestaAsignacionTurnoDTO>
+
+    @PUT("api/asignaciones/{id}")
+    suspend fun actualizarAsignacion(
+        @Path("id") id: Long,
+        @Body body: PeticionAsignacionTurnoDTO
+    ): Response<RespuestaAsignacionTurnoDTO>
+
+    @DELETE("api/asignaciones/{id}")
+    suspend fun eliminarAsignacion(
+        @Path("id") id: Long
+    ): Response<Unit>
 }

--- a/app/src/main/java/com/gestorrh/android/data/network/asignacion/AsignacionResponse.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/asignacion/AsignacionResponse.kt
@@ -2,6 +2,7 @@ package com.gestorrh.android.data.network.asignacion
 
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 data class RespuestaAsignacionTurnoDTO(
     val idAsignacion: Long,
@@ -11,8 +12,8 @@ data class RespuestaAsignacionTurnoDTO(
     val descripcionTurno: String,
     val fecha: LocalDate,
     val modalidad: ModalidadAsignacion,
-    val horaInicio: String?,
-    val horaFin: String?,
+    val horaInicio: LocalTime?,
+    val horaFin: LocalTime?,
     val motivoCambio: String?,
     val fechaCambio: LocalDateTime?,
     val responsableCambio: String?

--- a/app/src/main/java/com/gestorrh/android/data/network/asignacion/PeticionAsignacionTurnoDTO.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/asignacion/PeticionAsignacionTurnoDTO.kt
@@ -1,0 +1,11 @@
+package com.gestorrh.android.data.network.asignacion
+
+import java.time.LocalDate
+
+data class PeticionAsignacionTurnoDTO(
+    val idEmpleado: Long,
+    val idTurno: Long,
+    val fecha: LocalDate,
+    val modalidad: ModalidadAsignacion,
+    val motivoCambio: String? = null
+)

--- a/app/src/main/java/com/gestorrh/android/data/network/supervisor/SupervisorEmpleadoApi.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/supervisor/SupervisorEmpleadoApi.kt
@@ -1,0 +1,11 @@
+package com.gestorrh.android.data.network.supervisor
+
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface SupervisorEmpleadoApi {
+
+    @GET("api/empleados")
+    suspend fun getEmpleadosEquipo(): Response<List<RespuestaEmpleadoDTO>>
+}

--- a/app/src/main/java/com/gestorrh/android/data/network/turno/RespuestaTurnoDTO.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/turno/RespuestaTurnoDTO.kt
@@ -1,0 +1,10 @@
+package com.gestorrh.android.data.network.turno
+
+import java.time.LocalTime
+
+data class RespuestaTurnoDTO(
+    val idTurno: Long,
+    val descripcion: String,
+    val horaInicio: LocalTime?,
+    val horaFin: LocalTime?
+)

--- a/app/src/main/java/com/gestorrh/android/data/network/turno/TurnoApiService.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/turno/TurnoApiService.kt
@@ -1,0 +1,10 @@
+package com.gestorrh.android.data.network.turno
+
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface TurnoApiService {
+
+    @GET("api/turnos")
+    suspend fun getTurnos(): Response<List<RespuestaTurnoDTO>>
+}

--- a/app/src/main/java/com/gestorrh/android/data/repository/cuadrante/CuadranteRepositoryImpl.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/cuadrante/CuadranteRepositoryImpl.kt
@@ -73,6 +73,50 @@ class CuadranteRepositoryImpl(
         }
     }
 
+    override suspend fun actualizarAsignacion(
+        id: Long,
+        peticion: PeticionAsignacionTurnoDTO
+    ): Result<RespuestaAsignacionTurnoDTO> = withContext(Dispatchers.IO) {
+        try {
+            val respuesta = asignacionApiService.actualizarAsignacion(id, peticion)
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                val codigo = respuesta.code()
+                val mensaje = when (codigo) {
+                    409 -> null
+                    else -> extraerMensajeError(respuesta.errorBody())
+                } ?: "Error $codigo al actualizar la asignación"
+                Result.failure(Exception(mensaje))
+            }
+        } catch (e: IOException) {
+            Result.failure(e)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun eliminarAsignacion(id: Long): Result<Unit> =
+        withContext(Dispatchers.IO) {
+            try {
+                val respuesta = asignacionApiService.eliminarAsignacion(id)
+                if (respuesta.isSuccessful) {
+                    Result.success(Unit)
+                } else {
+                    Result.failure(
+                        Exception(
+                            extraerMensajeError(respuesta.errorBody())
+                                ?: "Error ${respuesta.code()} al eliminar la asignación"
+                        )
+                    )
+                }
+            } catch (e: IOException) {
+                Result.failure(e)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
     override suspend fun getTurnos(): Result<List<RespuestaTurnoDTO>> =
         withContext(Dispatchers.IO) {
             try {

--- a/app/src/main/java/com/gestorrh/android/data/repository/cuadrante/CuadranteRepositoryImpl.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/cuadrante/CuadranteRepositoryImpl.kt
@@ -1,0 +1,126 @@
+package com.gestorrh.android.data.repository.cuadrante
+
+import com.gestorrh.android.data.network.asignacion.AsignacionApiService
+import com.gestorrh.android.data.network.asignacion.PeticionAsignacionTurnoDTO
+import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+import com.gestorrh.android.data.network.supervisor.SupervisorEmpleadoApi
+import com.gestorrh.android.data.network.turno.RespuestaTurnoDTO
+import com.gestorrh.android.data.network.turno.TurnoApiService
+import com.gestorrh.android.domain.repository.ICuadranteRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.ResponseBody
+import org.json.JSONException
+import org.json.JSONObject
+import java.io.IOException
+
+/**
+ * Implementación de [ICuadranteRepository] que delega en los servicios Retrofit
+ * correspondientes. No usa caché local: todos los datos se obtienen siempre
+ * frescos desde el servidor para garantizar la consistencia del cuadrante.
+ *
+ * @param asignacionApiService Servicio Retrofit para los endpoints de asignaciones.
+ * @param turnoApiService Servicio Retrofit para el catálogo de turnos.
+ * @param supervisorEmpleadoApi Servicio Retrofit para los empleados del departamento.
+ */
+class CuadranteRepositoryImpl(
+    private val asignacionApiService: AsignacionApiService,
+    private val turnoApiService: TurnoApiService,
+    private val supervisorEmpleadoApi: SupervisorEmpleadoApi
+) : ICuadranteRepository {
+
+    override suspend fun getAsignacionesEquipo(): Result<List<RespuestaAsignacionTurnoDTO>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val respuesta = asignacionApiService.getAsignacionesEquipo()
+                if (respuesta.isSuccessful && respuesta.body() != null) {
+                    Result.success(respuesta.body()!!)
+                } else {
+                    Result.failure(
+                        Exception(
+                            extraerMensajeError(respuesta.errorBody())
+                                ?: "Error ${respuesta.code()} al obtener el cuadrante"
+                        )
+                    )
+                }
+            } catch (e: IOException) {
+                Result.failure(e)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    override suspend fun crearAsignacion(
+        peticion: PeticionAsignacionTurnoDTO
+    ): Result<RespuestaAsignacionTurnoDTO> = withContext(Dispatchers.IO) {
+        try {
+            val respuesta = asignacionApiService.crearAsignacion(peticion)
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                Result.failure(
+                    Exception(
+                        extraerMensajeError(respuesta.errorBody())
+                            ?: "Error ${respuesta.code()} al crear la asignación"
+                    )
+                )
+            }
+        } catch (e: IOException) {
+            Result.failure(e)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun getTurnos(): Result<List<RespuestaTurnoDTO>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val respuesta = turnoApiService.getTurnos()
+                if (respuesta.isSuccessful && respuesta.body() != null) {
+                    Result.success(respuesta.body()!!)
+                } else {
+                    Result.failure(
+                        Exception(
+                            extraerMensajeError(respuesta.errorBody())
+                                ?: "Error ${respuesta.code()} al obtener los turnos"
+                        )
+                    )
+                }
+            } catch (e: IOException) {
+                Result.failure(e)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    override suspend fun getEmpleadosEquipo(): Result<List<RespuestaEmpleadoDTO>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val respuesta = supervisorEmpleadoApi.getEmpleadosEquipo()
+                if (respuesta.isSuccessful && respuesta.body() != null) {
+                    Result.success(respuesta.body()!!)
+                } else {
+                    Result.failure(
+                        Exception(
+                            extraerMensajeError(respuesta.errorBody())
+                                ?: "Error ${respuesta.code()} al obtener los empleados"
+                        )
+                    )
+                }
+            } catch (e: IOException) {
+                Result.failure(e)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    private fun extraerMensajeError(errorBody: ResponseBody?): String? {
+        return try {
+            val json = errorBody?.string() ?: return null
+            JSONObject(json).getString("message")
+        } catch (e: JSONException) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/domain/repository/ICuadranteRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/ICuadranteRepository.kt
@@ -15,22 +15,37 @@ interface ICuadranteRepository {
 
     /**
      * Recupera todas las asignaciones del departamento del supervisor
-     * autenticado desde `GET /api/asignaciones`. El servidor filtra
-     * automáticamente por el JWT.
+     * autenticado desde `GET /api/asignaciones`.
      */
     suspend fun getAsignacionesEquipo(): Result<List<RespuestaAsignacionTurnoDTO>>
 
     /**
      * Crea una nueva asignación de turno para un empleado del equipo
      * mediante `POST /api/asignaciones`.
-     *
-     * @param peticion DTO con los datos validados de la asignación.
-     * @return [Result.success] con la asignación creada, o [Result.failure]
-     *         con el mensaje de error del servidor.
      */
     suspend fun crearAsignacion(
         peticion: PeticionAsignacionTurnoDTO
     ): Result<RespuestaAsignacionTurnoDTO>
+
+    /**
+     * Modifica una asignación existente mediante `PUT /api/asignaciones/{id}`.
+     * El motivo de cambio es obligatorio para la auditoría.
+     *
+     * @param id Identificador de la asignación a modificar.
+     * @param peticion DTO con los nuevos datos y el motivo del cambio.
+     */
+    suspend fun actualizarAsignacion(
+        id: Long,
+        peticion: PeticionAsignacionTurnoDTO
+    ): Result<RespuestaAsignacionTurnoDTO>
+
+    /**
+     * Elimina de forma permanente una asignación mediante
+     * `DELETE /api/asignaciones/{id}`.
+     *
+     * @param id Identificador de la asignación a eliminar.
+     */
+    suspend fun eliminarAsignacion(id: Long): Result<Unit>
 
     /**
      * Recupera el catálogo de plantillas de turno disponibles

--- a/app/src/main/java/com/gestorrh/android/domain/repository/ICuadranteRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/ICuadranteRepository.kt
@@ -1,0 +1,46 @@
+package com.gestorrh.android.domain.repository
+
+import com.gestorrh.android.data.network.asignacion.PeticionAsignacionTurnoDTO
+import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+import com.gestorrh.android.data.network.turno.RespuestaTurnoDTO
+
+/**
+ * Contrato de dominio para las operaciones del cuadrante del departamento.
+ * Usado exclusivamente por el rol SUPERVISOR. No implementa caché local:
+ * los datos deben ser siempre frescos para evitar asignaciones sobre
+ * información desactualizada.
+ */
+interface ICuadranteRepository {
+
+    /**
+     * Recupera todas las asignaciones del departamento del supervisor
+     * autenticado desde `GET /api/asignaciones`. El servidor filtra
+     * automáticamente por el JWT.
+     */
+    suspend fun getAsignacionesEquipo(): Result<List<RespuestaAsignacionTurnoDTO>>
+
+    /**
+     * Crea una nueva asignación de turno para un empleado del equipo
+     * mediante `POST /api/asignaciones`.
+     *
+     * @param peticion DTO con los datos validados de la asignación.
+     * @return [Result.success] con la asignación creada, o [Result.failure]
+     *         con el mensaje de error del servidor.
+     */
+    suspend fun crearAsignacion(
+        peticion: PeticionAsignacionTurnoDTO
+    ): Result<RespuestaAsignacionTurnoDTO>
+
+    /**
+     * Recupera el catálogo de plantillas de turno disponibles
+     * desde `GET /api/turnos`.
+     */
+    suspend fun getTurnos(): Result<List<RespuestaTurnoDTO>>
+
+    /**
+     * Recupera la lista de empleados del departamento del supervisor
+     * autenticado desde `GET /api/empleados`.
+     */
+    suspend fun getEmpleadosEquipo(): Result<List<RespuestaEmpleadoDTO>>
+}

--- a/app/src/main/java/com/gestorrh/android/domain/usecase/supervisor/AsignarTurnoUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/supervisor/AsignarTurnoUseCase.kt
@@ -7,16 +7,15 @@ import com.gestorrh.android.domain.repository.ICuadranteRepository
 import java.time.LocalDate
 
 /**
- * Caso de uso que valida una asignación de turno antes de delegarla al repositorio.
+ * Caso de uso que valida y ejecuta la creación o edición de una asignación de turno.
  *
- * Validaciones aplicadas en cliente para evitar viajes de red innecesarios:
- * - El empleado debe estar seleccionado.
- * - El turno debe estar seleccionado.
- * - La fecha debe ser hoy o futura.
- * - La modalidad debe estar seleccionada.
+ * En modo creación (`idAsignacion == null`):
+ * - Valida que empleado, turno, fecha (hoy o futura) y modalidad no sean nulos.
  *
- * El servidor aplica validaciones adicionales de solapamiento (400) y
- * concurrencia (409) que se propagan tal cual al ViewModel.
+ * En modo edición (`idAsignacion != null`):
+ * - Aplica las mismas validaciones anteriores.
+ * - Además valida que el motivo de cambio no esté vacío, requerido por el
+ *   servidor para auditoría.
  *
  * @param repository Contrato de dominio para las operaciones del cuadrante.
  */
@@ -29,6 +28,7 @@ class AsignarTurnoUseCase(
         data object TurnoNoSeleccionado : ErrorValidacion("turno_no_seleccionado")
         data object FechaPasada : ErrorValidacion("fecha_pasada")
         data object ModalidadNoSeleccionada : ErrorValidacion("modalidad_no_seleccionada")
+        data object MotivoVacio : ErrorValidacion("motivo_vacio")
     }
 
     suspend operator fun invoke(
@@ -37,6 +37,7 @@ class AsignarTurnoUseCase(
         fecha: LocalDate?,
         modalidad: ModalidadAsignacion?,
         motivoCambio: String? = null,
+        idAsignacion: Long? = null,
         hoy: LocalDate = LocalDate.now()
     ): Result<RespuestaAsignacionTurnoDTO> {
 
@@ -52,6 +53,9 @@ class AsignarTurnoUseCase(
         if (modalidad == null) {
             return Result.failure(ErrorValidacion.ModalidadNoSeleccionada)
         }
+        if (idAsignacion != null && motivoCambio.isNullOrBlank()) {
+            return Result.failure(ErrorValidacion.MotivoVacio)
+        }
 
         val peticion = PeticionAsignacionTurnoDTO(
             idEmpleado = idEmpleado,
@@ -61,6 +65,10 @@ class AsignarTurnoUseCase(
             motivoCambio = motivoCambio?.takeIf { it.isNotBlank() }
         )
 
-        return repository.crearAsignacion(peticion)
+        return if (idAsignacion != null) {
+            repository.actualizarAsignacion(idAsignacion, peticion)
+        } else {
+            repository.crearAsignacion(peticion)
+        }
     }
 }

--- a/app/src/main/java/com/gestorrh/android/domain/usecase/supervisor/AsignarTurnoUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/supervisor/AsignarTurnoUseCase.kt
@@ -1,0 +1,66 @@
+package com.gestorrh.android.domain.usecase.supervisor
+
+import com.gestorrh.android.data.network.asignacion.ModalidadAsignacion
+import com.gestorrh.android.data.network.asignacion.PeticionAsignacionTurnoDTO
+import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
+import com.gestorrh.android.domain.repository.ICuadranteRepository
+import java.time.LocalDate
+
+/**
+ * Caso de uso que valida una asignación de turno antes de delegarla al repositorio.
+ *
+ * Validaciones aplicadas en cliente para evitar viajes de red innecesarios:
+ * - El empleado debe estar seleccionado.
+ * - El turno debe estar seleccionado.
+ * - La fecha debe ser hoy o futura.
+ * - La modalidad debe estar seleccionada.
+ *
+ * El servidor aplica validaciones adicionales de solapamiento (400) y
+ * concurrencia (409) que se propagan tal cual al ViewModel.
+ *
+ * @param repository Contrato de dominio para las operaciones del cuadrante.
+ */
+class AsignarTurnoUseCase(
+    private val repository: ICuadranteRepository
+) {
+
+    sealed class ErrorValidacion(mensaje: String) : Exception(mensaje) {
+        data object EmpleadoNoSeleccionado : ErrorValidacion("empleado_no_seleccionado")
+        data object TurnoNoSeleccionado : ErrorValidacion("turno_no_seleccionado")
+        data object FechaPasada : ErrorValidacion("fecha_pasada")
+        data object ModalidadNoSeleccionada : ErrorValidacion("modalidad_no_seleccionada")
+    }
+
+    suspend operator fun invoke(
+        idEmpleado: Long?,
+        idTurno: Long?,
+        fecha: LocalDate?,
+        modalidad: ModalidadAsignacion?,
+        motivoCambio: String? = null,
+        hoy: LocalDate = LocalDate.now()
+    ): Result<RespuestaAsignacionTurnoDTO> {
+
+        if (idEmpleado == null) {
+            return Result.failure(ErrorValidacion.EmpleadoNoSeleccionado)
+        }
+        if (idTurno == null) {
+            return Result.failure(ErrorValidacion.TurnoNoSeleccionado)
+        }
+        if (fecha == null || fecha.isBefore(hoy)) {
+            return Result.failure(ErrorValidacion.FechaPasada)
+        }
+        if (modalidad == null) {
+            return Result.failure(ErrorValidacion.ModalidadNoSeleccionada)
+        }
+
+        val peticion = PeticionAsignacionTurnoDTO(
+            idEmpleado = idEmpleado,
+            idTurno = idTurno,
+            fecha = fecha,
+            modalidad = modalidad,
+            motivoCambio = motivoCambio?.takeIf { it.isNotBlank() }
+        )
+
+        return repository.crearAsignacion(peticion)
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/PantallaGestionEquipo.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/PantallaGestionEquipo.kt
@@ -23,18 +23,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.gestorrh.android.R
+import com.gestorrh.android.ui.equipo.cuadrante.PantallaCuadranteDepartamento
 
 /**
  * Pantalla contenedora de las funcionalidades del rol SUPERVISOR.
  *
- * Actúa como shell vacío listo para recibir el contenido.
- * Cada subsección se implementará como una pantalla
- * independiente que se mostrará en el área de contenido de esta pantalla
- * según la pestaña activa.
- *
- * La pestaña seleccionada se gestiona como estado local del composable
- * ya que no hay lógica de negocio asociada hasta que se implementen
- * las subsecciones.
+ * Gestiona la navegación entre pestañas mediante estado local. Cada subsección
+ * se implementa como un composable independiente que se muestra en el área de
+ * contenido según la pestaña activa. Las pestañas de Ausencias y Fichajes
+ * permanecen como placeholder hasta que se implementen sus issues correspondientes.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -82,17 +79,16 @@ fun PantallaGestionEquipo() {
                 }
             }
 
-            ContenidoTab(tabSeleccionada = tabSeleccionada)
+            when (tabSeleccionada) {
+                1 -> PantallaCuadranteDepartamento()
+                else -> PlaceholderProximamente()
+            }
         }
     }
 }
 
-/**
- * Área de contenido de cada pestaña del supervisor.
- * Muestra un placeholder hasta que cada subsección sea implementada.
- */
 @Composable
-private fun ContenidoTab(tabSeleccionada: Int) {
+private fun PlaceholderProximamente() {
     Box(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/CuadranteDepartamentoViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/CuadranteDepartamentoViewModel.kt
@@ -106,8 +106,31 @@ class CuadranteDepartamentoViewModel(
         }
         cargarCatalogosIfNeeded()
     }
-
     fun abrirBottomSheetEdicion(asignacion: RespuestaAsignacionTurnoDTO) {
+        _estadoUi.update {
+            it.copy(
+                mostrarBottomSheet = true,
+                idAsignacionEditando = asignacion.idAsignacion,
+                empleadoSeleccionado = null,
+                turnoSeleccionado = null,
+                fechaAsignacion = asignacion.fecha,
+                modalidadSeleccionada = asignacion.modalidad,
+                motivoCambio = ""
+            )
+        }
+        val catalogosCargados = _estadoUi.value.empleados.isNotEmpty() &&
+                _estadoUi.value.turnos.isNotEmpty()
+        if (catalogosCargados) {
+            prerrellenarCatalogos(asignacion)
+        } else {
+            viewModelScope.launch {
+                cargarCatalogosIfNeeded()
+                prerrellenarCatalogos(asignacion)
+            }
+        }
+    }
+
+    private fun prerrellenarCatalogos(asignacion: RespuestaAsignacionTurnoDTO) {
         val empleado = _estadoUi.value.empleados.find {
             it.idEmpleado == asignacion.idEmpleado
         }
@@ -116,16 +139,10 @@ class CuadranteDepartamentoViewModel(
         }
         _estadoUi.update {
             it.copy(
-                mostrarBottomSheet = true,
-                idAsignacionEditando = asignacion.idAsignacion,
                 empleadoSeleccionado = empleado,
-                turnoSeleccionado = turno,
-                fechaAsignacion = asignacion.fecha,
-                modalidadSeleccionada = asignacion.modalidad,
-                motivoCambio = ""
+                turnoSeleccionado = turno
             )
         }
-        cargarCatalogosIfNeeded()
     }
 
     fun cerrarBottomSheet() {
@@ -245,31 +262,31 @@ class CuadranteDepartamentoViewModel(
         val catalogosCargados = _estadoUi.value.empleados.isNotEmpty() &&
                 _estadoUi.value.turnos.isNotEmpty()
         if (!catalogosCargados) {
-            cargarCatalogos()
+            viewModelScope.launch {
+                cargarCatalogos()
+            }
         }
     }
 
-    private fun cargarCatalogos() {
-        viewModelScope.launch {
-            _estadoUi.update { it.copy(cargandoCatalogos = true) }
-            val empleadosDeferred = async { cuadranteRepository.getEmpleadosEquipo() }
-            val turnosDeferred = async { cuadranteRepository.getTurnos() }
-            val resultadoEmpleados = empleadosDeferred.await()
-            val resultadoTurnos = turnosDeferred.await()
-            val idSupervisor = sessionManager.getId()
-            val empleados = resultadoEmpleados.getOrElse { emptyList() }
-                .filter { it.idEmpleado != idSupervisor }
-            val turnos = resultadoTurnos.getOrElse { emptyList() }
-            val error = resultadoEmpleados.exceptionOrNull()
-                ?: resultadoTurnos.exceptionOrNull()
-            _estadoUi.update {
-                it.copy(
-                    cargandoCatalogos = false,
-                    empleados = empleados,
-                    turnos = turnos,
-                    mensajeError = error?.let { e -> mensajeDesdeError(e) }
-                )
-            }
+    private suspend fun cargarCatalogos() {
+        _estadoUi.update { it.copy(cargandoCatalogos = true) }
+        val empleadosDeferred = viewModelScope.async { cuadranteRepository.getEmpleadosEquipo() }
+        val turnosDeferred = viewModelScope.async { cuadranteRepository.getTurnos() }
+        val resultadoEmpleados = empleadosDeferred.await()
+        val resultadoTurnos = turnosDeferred.await()
+        val idSupervisor = sessionManager.getId()
+        val empleados = resultadoEmpleados.getOrElse { emptyList() }
+            .filter { it.idEmpleado != idSupervisor }
+        val turnos = resultadoTurnos.getOrElse { emptyList() }
+        val error = resultadoEmpleados.exceptionOrNull()
+            ?: resultadoTurnos.exceptionOrNull()
+        _estadoUi.update {
+            it.copy(
+                cargandoCatalogos = false,
+                empleados = empleados,
+                turnos = turnos,
+                mensajeError = error?.let { e -> mensajeDesdeError(e) }
+            )
         }
     }
 

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/CuadranteDepartamentoViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/CuadranteDepartamentoViewModel.kt
@@ -10,6 +10,7 @@ import com.gestorrh.android.core.security.SessionManager
 import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.network.asignacion.AsignacionApiService
 import com.gestorrh.android.data.network.asignacion.ModalidadAsignacion
+import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
 import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
 import com.gestorrh.android.data.network.supervisor.SupervisorEmpleadoApi
 import com.gestorrh.android.data.network.turno.RespuestaTurnoDTO
@@ -31,14 +32,17 @@ import java.time.LocalDate
  *
  * Responsabilidades:
  * - Carga las asignaciones del equipo al inicializar y expone el filtro reactivo
- *   por fecha sin nueva llamada de red al cambiar [fechaSeleccionada].
- * - Gestiona el estado del BottomSheet de asignación, cargando los catálogos
- *   (empleados y turnos) en la primera apertura y reutilizándolos en las siguientes.
- * - Bloquea reenvíos con el flag [EstadoUiCuadranteDepartamento.estaAsignando].
- * - Refresca el cuadrante tras una asignación exitosa para reflejar el nuevo turno.
+ *   por fecha sin nueva llamada de red al cambiar [EstadoUiCuadranteDepartamento.fechaSeleccionada].
+ * - Gestiona el BottomSheet en modo creación y edición, cargando los catálogos
+ *   en la primera apertura y reutilizándolos en las siguientes.
+ * - Gestiona el diálogo de confirmación de eliminación.
+ * - Bloquea reenvíos con los flags [EstadoUiCuadranteDepartamento.estaAsignando]
+ *   y [EstadoUiCuadranteDepartamento.eliminando].
  *
  * @param cuadranteRepository Contrato de dominio para las operaciones del cuadrante.
- * @param asignarTurnoUseCase Caso de uso que valida y delega la creación de asignaciones.
+ * @param asignarTurnoUseCase Caso de uso que valida y delega la creación y edición.
+ * @param sessionManager Fuente de verdad de la sesión activa, usado para excluir
+ *        al propio supervisor de la lista de empleados asignables.
  */
 class CuadranteDepartamentoViewModel(
     private val cuadranteRepository: ICuadranteRepository,
@@ -50,6 +54,7 @@ class CuadranteDepartamentoViewModel(
     val estadoUi: StateFlow<EstadoUiCuadranteDepartamento> = _estadoUi.asStateFlow()
 
     init {
+        _estadoUi.update { it.copy(idSupervisor = sessionManager.getId()) }
         cargarAsignaciones()
     }
 
@@ -91,6 +96,7 @@ class CuadranteDepartamentoViewModel(
         _estadoUi.update {
             it.copy(
                 mostrarBottomSheet = true,
+                idAsignacionEditando = null,
                 empleadoSeleccionado = null,
                 turnoSeleccionado = null,
                 fechaAsignacion = _estadoUi.value.fechaSeleccionada,
@@ -98,11 +104,28 @@ class CuadranteDepartamentoViewModel(
                 motivoCambio = ""
             )
         }
-        val catalogosCargados = _estadoUi.value.empleados.isNotEmpty() &&
-                _estadoUi.value.turnos.isNotEmpty()
-        if (!catalogosCargados) {
-            cargarCatalogos()
+        cargarCatalogosIfNeeded()
+    }
+
+    fun abrirBottomSheetEdicion(asignacion: RespuestaAsignacionTurnoDTO) {
+        val empleado = _estadoUi.value.empleados.find {
+            it.idEmpleado == asignacion.idEmpleado
         }
+        val turno = _estadoUi.value.turnos.find {
+            it.idTurno == asignacion.idTurno
+        }
+        _estadoUi.update {
+            it.copy(
+                mostrarBottomSheet = true,
+                idAsignacionEditando = asignacion.idAsignacion,
+                empleadoSeleccionado = empleado,
+                turnoSeleccionado = turno,
+                fechaAsignacion = asignacion.fecha,
+                modalidadSeleccionada = asignacion.modalidad,
+                motivoCambio = ""
+            )
+        }
+        cargarCatalogosIfNeeded()
     }
 
     fun cerrarBottomSheet() {
@@ -129,6 +152,40 @@ class CuadranteDepartamentoViewModel(
         _estadoUi.update { it.copy(motivoCambio = motivo) }
     }
 
+    fun confirmarEliminar(asignacion: RespuestaAsignacionTurnoDTO) {
+        _estadoUi.update { it.copy(asignacionAEliminar = asignacion) }
+    }
+
+    fun cancelarEliminar() {
+        _estadoUi.update { it.copy(asignacionAEliminar = null) }
+    }
+
+    fun eliminarAsignacion() {
+        val id = _estadoUi.value.asignacionAEliminar?.idAsignacion ?: return
+        if (_estadoUi.value.eliminando) return
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(eliminando = true, asignacionAEliminar = null) }
+            cuadranteRepository.eliminarAsignacion(id)
+                .onSuccess {
+                    _estadoUi.update {
+                        it.copy(
+                            eliminando = false,
+                            mensajeExito = MensajeUi.Recurso(R.string.cuadrante_eliminacion_exitosa)
+                        )
+                    }
+                    cargarAsignaciones()
+                }
+                .onFailure { error ->
+                    _estadoUi.update {
+                        it.copy(
+                            eliminando = false,
+                            mensajeError = mensajeDesdeError(error)
+                        )
+                    }
+                }
+        }
+    }
+
     fun asignarTurno() {
         if (_estadoUi.value.estaAsignando) return
         val estado = _estadoUi.value
@@ -139,14 +196,20 @@ class CuadranteDepartamentoViewModel(
                 idTurno = estado.turnoSeleccionado?.idTurno,
                 fecha = estado.fechaAsignacion,
                 modalidad = estado.modalidadSeleccionada,
-                motivoCambio = estado.motivoCambio
+                motivoCambio = estado.motivoCambio,
+                idAsignacion = estado.idAsignacionEditando
             )
                 .onSuccess {
+                    val mensajeRes = if (estado.modoEdicion) {
+                        R.string.cuadrante_actualizacion_exitosa
+                    } else {
+                        R.string.cuadrante_asignacion_exitosa
+                    }
                     _estadoUi.update {
                         it.copy(
                             estaAsignando = false,
                             mostrarBottomSheet = false,
-                            mensajeExito = MensajeUi.Recurso(R.string.cuadrante_asignacion_exitosa)
+                            mensajeExito = MensajeUi.Recurso(mensajeRes)
                         )
                     }
                     cargarAsignaciones()
@@ -161,6 +224,8 @@ class CuadranteDepartamentoViewModel(
                             MensajeUi.Recurso(R.string.cuadrante_error_fecha_pasada)
                         AsignarTurnoUseCase.ErrorValidacion.ModalidadNoSeleccionada ->
                             MensajeUi.Recurso(R.string.cuadrante_error_modalidad_requerida)
+                        AsignarTurnoUseCase.ErrorValidacion.MotivoVacio ->
+                            MensajeUi.Recurso(R.string.cuadrante_error_motivo_requerido)
                         else -> mensajeDesdeError(error)
                     }
                     _estadoUi.update { it.copy(estaAsignando = false, mensajeError = mensaje) }
@@ -176,6 +241,14 @@ class CuadranteDepartamentoViewModel(
         _estadoUi.update { it.copy(mensajeExito = null) }
     }
 
+    private fun cargarCatalogosIfNeeded() {
+        val catalogosCargados = _estadoUi.value.empleados.isNotEmpty() &&
+                _estadoUi.value.turnos.isNotEmpty()
+        if (!catalogosCargados) {
+            cargarCatalogos()
+        }
+    }
+
     private fun cargarCatalogos() {
         viewModelScope.launch {
             _estadoUi.update { it.copy(cargandoCatalogos = true) }
@@ -187,9 +260,8 @@ class CuadranteDepartamentoViewModel(
             val empleados = resultadoEmpleados.getOrElse { emptyList() }
                 .filter { it.idEmpleado != idSupervisor }
             val turnos = resultadoTurnos.getOrElse { emptyList() }
-            val errorEmpleados = resultadoEmpleados.exceptionOrNull()
-            val errorTurnos = resultadoTurnos.exceptionOrNull()
-            val error = errorEmpleados ?: errorTurnos
+            val error = resultadoEmpleados.exceptionOrNull()
+                ?: resultadoTurnos.exceptionOrNull()
             _estadoUi.update {
                 it.copy(
                     cargandoCatalogos = false,
@@ -202,7 +274,7 @@ class CuadranteDepartamentoViewModel(
     }
 
     private fun filtrarPorFecha(
-        asignaciones: List<com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO>,
+        asignaciones: List<RespuestaAsignacionTurnoDTO>,
         fecha: LocalDate
     ) = asignaciones.filter { it.fecha == fecha }
 

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/CuadranteDepartamentoViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/CuadranteDepartamentoViewModel.kt
@@ -1,0 +1,237 @@
+package com.gestorrh.android.ui.equipo.cuadrante
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.gestorrh.android.R
+import com.gestorrh.android.core.network.ApiClient
+import com.gestorrh.android.core.security.SessionManager
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.asignacion.AsignacionApiService
+import com.gestorrh.android.data.network.asignacion.ModalidadAsignacion
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+import com.gestorrh.android.data.network.supervisor.SupervisorEmpleadoApi
+import com.gestorrh.android.data.network.turno.RespuestaTurnoDTO
+import com.gestorrh.android.data.network.turno.TurnoApiService
+import com.gestorrh.android.data.repository.cuadrante.CuadranteRepositoryImpl
+import com.gestorrh.android.domain.repository.ICuadranteRepository
+import com.gestorrh.android.domain.usecase.supervisor.AsignarTurnoUseCase
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.io.IOException
+import java.time.LocalDate
+
+/**
+ * ViewModel de la pantalla de cuadrante del departamento para el rol SUPERVISOR.
+ *
+ * Responsabilidades:
+ * - Carga las asignaciones del equipo al inicializar y expone el filtro reactivo
+ *   por fecha sin nueva llamada de red al cambiar [fechaSeleccionada].
+ * - Gestiona el estado del BottomSheet de asignación, cargando los catálogos
+ *   (empleados y turnos) en la primera apertura y reutilizándolos en las siguientes.
+ * - Bloquea reenvíos con el flag [EstadoUiCuadranteDepartamento.estaAsignando].
+ * - Refresca el cuadrante tras una asignación exitosa para reflejar el nuevo turno.
+ *
+ * @param cuadranteRepository Contrato de dominio para las operaciones del cuadrante.
+ * @param asignarTurnoUseCase Caso de uso que valida y delega la creación de asignaciones.
+ */
+class CuadranteDepartamentoViewModel(
+    private val cuadranteRepository: ICuadranteRepository,
+    private val asignarTurnoUseCase: AsignarTurnoUseCase,
+    private val sessionManager: SessionManager
+) : ViewModel() {
+
+    private val _estadoUi = MutableStateFlow(EstadoUiCuadranteDepartamento())
+    val estadoUi: StateFlow<EstadoUiCuadranteDepartamento> = _estadoUi.asStateFlow()
+
+    init {
+        cargarAsignaciones()
+    }
+
+    fun cargarAsignaciones() {
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(cargando = true, mensajeError = null) }
+            cuadranteRepository.getAsignacionesEquipo()
+                .onSuccess { lista ->
+                    val fechaActual = _estadoUi.value.fechaSeleccionada
+                    _estadoUi.update {
+                        it.copy(
+                            cargando = false,
+                            asignaciones = lista,
+                            asignacionesFiltradas = filtrarPorFecha(lista, fechaActual)
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _estadoUi.update {
+                        it.copy(
+                            cargando = false,
+                            mensajeError = mensajeDesdeError(error)
+                        )
+                    }
+                }
+        }
+    }
+
+    fun seleccionarFecha(fecha: LocalDate) {
+        _estadoUi.update {
+            it.copy(
+                fechaSeleccionada = fecha,
+                asignacionesFiltradas = filtrarPorFecha(it.asignaciones, fecha)
+            )
+        }
+    }
+
+    fun abrirBottomSheet() {
+        _estadoUi.update {
+            it.copy(
+                mostrarBottomSheet = true,
+                empleadoSeleccionado = null,
+                turnoSeleccionado = null,
+                fechaAsignacion = _estadoUi.value.fechaSeleccionada,
+                modalidadSeleccionada = null,
+                motivoCambio = ""
+            )
+        }
+        val catalogosCargados = _estadoUi.value.empleados.isNotEmpty() &&
+                _estadoUi.value.turnos.isNotEmpty()
+        if (!catalogosCargados) {
+            cargarCatalogos()
+        }
+    }
+
+    fun cerrarBottomSheet() {
+        _estadoUi.update { it.copy(mostrarBottomSheet = false) }
+    }
+
+    fun seleccionarEmpleado(empleado: RespuestaEmpleadoDTO) {
+        _estadoUi.update { it.copy(empleadoSeleccionado = empleado) }
+    }
+
+    fun seleccionarTurno(turno: RespuestaTurnoDTO) {
+        _estadoUi.update { it.copy(turnoSeleccionado = turno) }
+    }
+
+    fun seleccionarFechaAsignacion(fecha: LocalDate) {
+        _estadoUi.update { it.copy(fechaAsignacion = fecha) }
+    }
+
+    fun seleccionarModalidad(modalidad: ModalidadAsignacion) {
+        _estadoUi.update { it.copy(modalidadSeleccionada = modalidad) }
+    }
+
+    fun actualizarMotivoCambio(motivo: String) {
+        _estadoUi.update { it.copy(motivoCambio = motivo) }
+    }
+
+    fun asignarTurno() {
+        if (_estadoUi.value.estaAsignando) return
+        val estado = _estadoUi.value
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(estaAsignando = true, mensajeError = null) }
+            asignarTurnoUseCase(
+                idEmpleado = estado.empleadoSeleccionado?.idEmpleado,
+                idTurno = estado.turnoSeleccionado?.idTurno,
+                fecha = estado.fechaAsignacion,
+                modalidad = estado.modalidadSeleccionada,
+                motivoCambio = estado.motivoCambio
+            )
+                .onSuccess {
+                    _estadoUi.update {
+                        it.copy(
+                            estaAsignando = false,
+                            mostrarBottomSheet = false,
+                            mensajeExito = MensajeUi.Recurso(R.string.cuadrante_asignacion_exitosa)
+                        )
+                    }
+                    cargarAsignaciones()
+                }
+                .onFailure { error ->
+                    val mensaje = when (error) {
+                        AsignarTurnoUseCase.ErrorValidacion.EmpleadoNoSeleccionado ->
+                            MensajeUi.Recurso(R.string.cuadrante_error_empleado_requerido)
+                        AsignarTurnoUseCase.ErrorValidacion.TurnoNoSeleccionado ->
+                            MensajeUi.Recurso(R.string.cuadrante_error_turno_requerido)
+                        AsignarTurnoUseCase.ErrorValidacion.FechaPasada ->
+                            MensajeUi.Recurso(R.string.cuadrante_error_fecha_pasada)
+                        AsignarTurnoUseCase.ErrorValidacion.ModalidadNoSeleccionada ->
+                            MensajeUi.Recurso(R.string.cuadrante_error_modalidad_requerida)
+                        else -> mensajeDesdeError(error)
+                    }
+                    _estadoUi.update { it.copy(estaAsignando = false, mensajeError = mensaje) }
+                }
+        }
+    }
+
+    fun errorMostrado() {
+        _estadoUi.update { it.copy(mensajeError = null) }
+    }
+
+    fun exitoMostrado() {
+        _estadoUi.update { it.copy(mensajeExito = null) }
+    }
+
+    private fun cargarCatalogos() {
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(cargandoCatalogos = true) }
+            val empleadosDeferred = async { cuadranteRepository.getEmpleadosEquipo() }
+            val turnosDeferred = async { cuadranteRepository.getTurnos() }
+            val resultadoEmpleados = empleadosDeferred.await()
+            val resultadoTurnos = turnosDeferred.await()
+            val idSupervisor = sessionManager.getId()
+            val empleados = resultadoEmpleados.getOrElse { emptyList() }
+                .filter { it.idEmpleado != idSupervisor }
+            val turnos = resultadoTurnos.getOrElse { emptyList() }
+            val errorEmpleados = resultadoEmpleados.exceptionOrNull()
+            val errorTurnos = resultadoTurnos.exceptionOrNull()
+            val error = errorEmpleados ?: errorTurnos
+            _estadoUi.update {
+                it.copy(
+                    cargandoCatalogos = false,
+                    empleados = empleados,
+                    turnos = turnos,
+                    mensajeError = error?.let { e -> mensajeDesdeError(e) }
+                )
+            }
+        }
+    }
+
+    private fun filtrarPorFecha(
+        asignaciones: List<com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO>,
+        fecha: LocalDate
+    ) = asignaciones.filter { it.fecha == fecha }
+
+    private fun mensajeDesdeError(error: Throwable): MensajeUi =
+        if (error is IOException) MensajeUi.Recurso(R.string.error_conexion)
+        else MensajeUi.Dinamico(error.message ?: "")
+
+    companion object {
+        fun factory(contexto: Context): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val sessionManager = SessionManager(contexto)
+                    val retrofit = ApiClient.crearRetrofit(sessionManager)
+                    val asignacionApiService = retrofit.create(AsignacionApiService::class.java)
+                    val turnoApiService = retrofit.create(TurnoApiService::class.java)
+                    val supervisorEmpleadoApi = retrofit.create(SupervisorEmpleadoApi::class.java)
+                    val repository = CuadranteRepositoryImpl(
+                        asignacionApiService,
+                        turnoApiService,
+                        supervisorEmpleadoApi
+                    )
+                    val useCase = AsignarTurnoUseCase(repository)
+                    return CuadranteDepartamentoViewModel(
+                        repository,
+                        useCase,
+                        sessionManager
+                    ) as T
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/EstadoUiCuadranteDepartamento.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/EstadoUiCuadranteDepartamento.kt
@@ -1,0 +1,57 @@
+package com.gestorrh.android.ui.equipo.cuadrante
+
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.asignacion.ModalidadAsignacion
+import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+import com.gestorrh.android.data.network.turno.RespuestaTurnoDTO
+import java.time.LocalDate
+
+/**
+ * Estado inmutable que consume [PantallaCuadranteDepartamento].
+ *
+ * @property cargando true mientras se obtienen las asignaciones del equipo al inicializar.
+ * @property asignaciones Lista completa de asignaciones del departamento sin filtrar.
+ * @property asignacionesFiltradas Subconjunto de [asignaciones] para [fechaSeleccionada],
+ *           calculado reactivamente en el ViewModel sin nueva llamada de red.
+ * @property fechaSeleccionada Fecha actualmente visible en el cuadrante. Por defecto hoy.
+ * @property empleados Catálogo de empleados del departamento, cargado al abrir el BottomSheet.
+ * @property turnos Catálogo de plantillas de turno, cargado al abrir el BottomSheet.
+ * @property modalidades Valores disponibles del enum de modalidad.
+ * @property mostrarBottomSheet Controla la visibilidad del BottomSheet de asignación.
+ * @property cargandoCatalogos true mientras se cargan empleados y turnos. Muestra spinner
+ *           en el botón "Asignar" del BottomSheet.
+ * @property estaAsignando true mientras hay una petición POST en curso. Bloquea reenvíos.
+ * @property empleadoSeleccionado Empleado elegido en el dropdown del BottomSheet.
+ * @property turnoSeleccionado Turno elegido en el dropdown del BottomSheet.
+ * @property fechaAsignacion Fecha elegida en el DatePicker del BottomSheet.
+ * @property modalidadSeleccionada Modalidad elegida en el dropdown del BottomSheet.
+ * @property motivoCambio Texto opcional del campo motivo del BottomSheet.
+ * @property mensajeError Mensaje a mostrar en Snackbar. Null si no hay error pendiente.
+ * @property mensajeExito Mensaje a mostrar en Snackbar tras asignación exitosa.
+ */
+data class EstadoUiCuadranteDepartamento(
+    val cargando: Boolean = true,
+    val asignaciones: List<RespuestaAsignacionTurnoDTO> = emptyList(),
+    val asignacionesFiltradas: List<RespuestaAsignacionTurnoDTO> = emptyList(),
+    val fechaSeleccionada: LocalDate = LocalDate.now(),
+    val empleados: List<RespuestaEmpleadoDTO> = emptyList(),
+    val turnos: List<RespuestaTurnoDTO> = emptyList(),
+    val modalidades: List<ModalidadAsignacion> = ModalidadAsignacion.entries,
+    val mostrarBottomSheet: Boolean = false,
+    val cargandoCatalogos: Boolean = false,
+    val estaAsignando: Boolean = false,
+    val empleadoSeleccionado: RespuestaEmpleadoDTO? = null,
+    val turnoSeleccionado: RespuestaTurnoDTO? = null,
+    val fechaAsignacion: LocalDate = LocalDate.now(),
+    val modalidadSeleccionada: ModalidadAsignacion? = null,
+    val motivoCambio: String = "",
+    val mensajeError: MensajeUi? = null,
+    val mensajeExito: MensajeUi? = null
+) {
+    val formularioValido: Boolean
+        get() = empleadoSeleccionado != null &&
+                turnoSeleccionado != null &&
+                !fechaAsignacion.isBefore(LocalDate.now()) &&
+                modalidadSeleccionada != null
+}

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/EstadoUiCuadranteDepartamento.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/EstadoUiCuadranteDepartamento.kt
@@ -19,16 +19,18 @@ import java.time.LocalDate
  * @property turnos Catálogo de plantillas de turno, cargado al abrir el BottomSheet.
  * @property modalidades Valores disponibles del enum de modalidad.
  * @property mostrarBottomSheet Controla la visibilidad del BottomSheet de asignación.
- * @property cargandoCatalogos true mientras se cargan empleados y turnos. Muestra spinner
- *           en el botón "Asignar" del BottomSheet.
- * @property estaAsignando true mientras hay una petición POST en curso. Bloquea reenvíos.
+ * @property cargandoCatalogos true mientras se cargan empleados y turnos.
+ * @property estaAsignando true mientras hay una petición POST o PUT en curso.
+ * @property idAsignacionEditando Id de la asignación en edición, null en modo creación.
  * @property empleadoSeleccionado Empleado elegido en el dropdown del BottomSheet.
  * @property turnoSeleccionado Turno elegido en el dropdown del BottomSheet.
  * @property fechaAsignacion Fecha elegida en el DatePicker del BottomSheet.
  * @property modalidadSeleccionada Modalidad elegida en el dropdown del BottomSheet.
- * @property motivoCambio Texto opcional del campo motivo del BottomSheet.
+ * @property motivoCambio Texto del campo motivo, obligatorio en modo edición.
+ * @property asignacionAEliminar Asignación pendiente de confirmar eliminación, null si no hay.
+ * @property eliminando true mientras hay una petición DELETE en curso.
  * @property mensajeError Mensaje a mostrar en Snackbar. Null si no hay error pendiente.
- * @property mensajeExito Mensaje a mostrar en Snackbar tras asignación exitosa.
+ * @property mensajeExito Mensaje a mostrar en Snackbar tras operación exitosa.
  */
 data class EstadoUiCuadranteDepartamento(
     val cargando: Boolean = true,
@@ -41,17 +43,25 @@ data class EstadoUiCuadranteDepartamento(
     val mostrarBottomSheet: Boolean = false,
     val cargandoCatalogos: Boolean = false,
     val estaAsignando: Boolean = false,
+    val idAsignacionEditando: Long? = null,
     val empleadoSeleccionado: RespuestaEmpleadoDTO? = null,
     val turnoSeleccionado: RespuestaTurnoDTO? = null,
     val fechaAsignacion: LocalDate = LocalDate.now(),
     val modalidadSeleccionada: ModalidadAsignacion? = null,
     val motivoCambio: String = "",
+    val asignacionAEliminar: RespuestaAsignacionTurnoDTO? = null,
+    val eliminando: Boolean = false,
     val mensajeError: MensajeUi? = null,
-    val mensajeExito: MensajeUi? = null
+    val mensajeExito: MensajeUi? = null,
+    val idSupervisor: Long = -1L,
 ) {
+    val modoEdicion: Boolean
+        get() = idAsignacionEditando != null
+
     val formularioValido: Boolean
         get() = empleadoSeleccionado != null &&
                 turnoSeleccionado != null &&
                 !fechaAsignacion.isBefore(LocalDate.now()) &&
-                modalidadSeleccionada != null
+                modalidadSeleccionada != null &&
+                (!modoEdicion || motivoCambio.isNotBlank())
 }

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/PantallaCuadranteDepartamento.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/PantallaCuadranteDepartamento.kt
@@ -23,8 +23,11 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -38,6 +41,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -83,7 +87,9 @@ import java.time.format.DateTimeFormatter
 
 private val ColorPresencial = Color(0xFF1A365D)
 private val ColorTeletrabajo = Color(0xFF00A8E8)
+private val ColorEliminar = Color(0xFFD32F2F)
 private val FormatoHora = DateTimeFormatter.ofPattern("HH:mm")
+private val FormatoFechaModificacion = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm")
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -176,6 +182,10 @@ fun PantallaCuadranteDepartamento(
                 else -> {
                     ListaEmpleados(
                         asignaciones = estadoUi.asignacionesFiltradas,
+                        idSupervisor = estadoUi.idSupervisor,
+                        eliminando = estadoUi.eliminando,
+                        onEditar = viewModel::abrirBottomSheetEdicion,
+                        onEliminar = viewModel::confirmarEliminar,
                         modifier = Modifier.fillMaxSize()
                     )
                 }
@@ -191,7 +201,31 @@ fun PantallaCuadranteDepartamento(
             onTurnoSeleccionado = viewModel::seleccionarTurno,
             onFechaSeleccionada = viewModel::seleccionarFechaAsignacion,
             onModalidadSeleccionada = viewModel::seleccionarModalidad,
+            onMotivoCambio = viewModel::actualizarMotivoCambio,
             onAsignar = viewModel::asignarTurno
+        )
+    }
+
+    estadoUi.asignacionAEliminar?.let { asignacion ->
+        AlertDialog(
+            onDismissRequest = viewModel::cancelarEliminar,
+            title = { Text(stringResource(R.string.cuadrante_dialog_eliminar_titulo)) },
+            text = { Text(stringResource(R.string.cuadrante_dialog_eliminar_mensaje)) },
+            confirmButton = {
+                TextButton(
+                    onClick = viewModel::eliminarAsignacion,
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = ColorEliminar
+                    )
+                ) {
+                    Text(stringResource(R.string.cuadrante_dialog_eliminar_confirmar))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = viewModel::cancelarEliminar) {
+                    Text(stringResource(R.string.cuadrante_dialog_eliminar_cancelar))
+                }
+            }
         )
     }
 }
@@ -214,12 +248,8 @@ private fun SelectorFecha(
         verticalAlignment = Alignment.CenterVertically
     ) {
         IconButton(onClick = alRetroceder) {
-            Icon(
-                imageVector = Icons.Filled.ChevronLeft,
-                contentDescription = null
-            )
+            Icon(imageVector = Icons.Filled.ChevronLeft, contentDescription = null)
         }
-
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
                 text = fechaSeleccionada.format(formatter),
@@ -234,12 +264,8 @@ private fun SelectorFecha(
                 )
             }
         }
-
         IconButton(onClick = alAvanzar) {
-            Icon(
-                imageVector = Icons.Filled.ChevronRight,
-                contentDescription = null
-            )
+            Icon(imageVector = Icons.Filled.ChevronRight, contentDescription = null)
         }
     }
 }
@@ -260,6 +286,10 @@ private fun CabeceraCuadrante(
 @Composable
 private fun ListaEmpleados(
     asignaciones: List<RespuestaAsignacionTurnoDTO>,
+    idSupervisor: Long,
+    eliminando: Boolean,
+    onEditar: (RespuestaAsignacionTurnoDTO) -> Unit,
+    onEliminar: (RespuestaAsignacionTurnoDTO) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -271,13 +301,25 @@ private fun ListaEmpleados(
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         items(asignaciones, key = { it.idAsignacion }) { asignacion ->
-            TarjetaEmpleado(asignacion = asignacion)
+            TarjetaEmpleado(
+                asignacion = asignacion,
+                idSupervisor = idSupervisor,
+                eliminando = eliminando,
+                onEditar = { onEditar(asignacion) },
+                onEliminar = { onEliminar(asignacion) }
+            )
         }
     }
 }
 
 @Composable
-private fun TarjetaEmpleado(asignacion: RespuestaAsignacionTurnoDTO) {
+private fun TarjetaEmpleado(
+    asignacion: RespuestaAsignacionTurnoDTO,
+    idSupervisor: Long,
+    eliminando: Boolean,
+    onEditar: () -> Unit,
+    onEliminar: () -> Unit
+) {
     val iniciales = remember(asignacion.nombreCompletoEmpleado) {
         asignacion.nombreCompletoEmpleado
             .split(" ")
@@ -293,68 +335,92 @@ private fun TarjetaEmpleado(asignacion: RespuestaAsignacionTurnoDTO) {
         ),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            AvatarIniciales(
-                iniciales = iniciales,
-                nombreCompleto = asignacion.nombreCompletoEmpleado
-            )
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                AvatarIniciales(iniciales = iniciales)
 
-            Spacer(modifier = Modifier.width(12.dp))
+                Spacer(modifier = Modifier.width(12.dp))
 
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = asignacion.nombreCompletoEmpleado,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold
-                )
-
-                Spacer(modifier = Modifier.height(4.dp))
-
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    BadgeModalidad(modalidad = asignacion.modalidad)
-
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            imageVector = Icons.Filled.Schedule,
-                            contentDescription = null,
-                            modifier = Modifier.size(14.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                        val horario = when {
-                            asignacion.horaInicio != null && asignacion.horaFin != null ->
-                                stringResource(
-                                    R.string.cuadrante_horario,
-                                    asignacion.horaInicio.format(FormatoHora),
-                                    asignacion.horaFin.format(FormatoHora)
-                                )
-                            else -> asignacion.descripcionTurno
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = asignacion.nombreCompletoEmpleado,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        BadgeModalidad(modalidad = asignacion.modalidad)
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                imageVector = Icons.Filled.Schedule,
+                                contentDescription = null,
+                                modifier = Modifier.size(14.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            val horario = when {
+                                asignacion.horaInicio != null && asignacion.horaFin != null ->
+                                    stringResource(
+                                        R.string.cuadrante_horario,
+                                        asignacion.horaInicio.format(FormatoHora),
+                                        asignacion.horaFin.format(FormatoHora)
+                                    )
+                                else -> asignacion.descripcionTurno
+                            }
+                            Text(
+                                text = horario,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                         }
-                        Text(
-                            text = horario,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                    }
+                }
+
+                if (asignacion.idEmpleado != idSupervisor) {
+                    IconButton(onClick = onEditar, enabled = !eliminando) {
+                        Icon(
+                            imageVector = Icons.Filled.Edit,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                    IconButton(onClick = onEliminar, enabled = !eliminando) {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = null,
+                            tint = ColorEliminar
                         )
                     }
                 }
+            }
+
+            if (asignacion.fechaCambio != null && asignacion.responsableCambio != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = stringResource(
+                        R.string.cuadrante_modificado_por,
+                        asignacion.responsableCambio,
+                        asignacion.fechaCambio.format(FormatoFechaModificacion),
+                        asignacion.motivoCambio ?: ""
+                    ),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
     }
 }
 
 @Composable
-private fun AvatarIniciales(
-    iniciales: String,
-    nombreCompleto: String
-) {
+private fun AvatarIniciales(iniciales: String) {
     Box(
         modifier = Modifier
             .size(44.dp)
@@ -380,7 +446,6 @@ private fun BadgeModalidad(modalidad: ModalidadAsignacion) {
         ModalidadAsignacion.TELETRABAJO ->
             ColorTeletrabajo to R.string.cuadrante_modalidad_teletrabajo
     }
-
     Box(
         modifier = Modifier
             .background(color = color, shape = RoundedCornerShape(4.dp))
@@ -427,6 +492,7 @@ private fun BottomSheetAsignacionTurno(
     onTurnoSeleccionado: (RespuestaTurnoDTO) -> Unit,
     onFechaSeleccionada: (LocalDate) -> Unit,
     onModalidadSeleccionada: (ModalidadAsignacion) -> Unit,
+    onMotivoCambio: (String) -> Unit,
     onAsignar: () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -446,7 +512,10 @@ private fun BottomSheetAsignacionTurno(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = stringResource(R.string.cuadrante_sheet_titulo),
+                text = stringResource(
+                    if (estadoUi.modoEdicion) R.string.cuadrante_sheet_titulo_edicion
+                    else R.string.cuadrante_sheet_titulo
+                ),
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold
             )
@@ -495,6 +564,17 @@ private fun BottomSheetAsignacionTurno(
                     onSeleccionar = onModalidadSeleccionada
                 )
 
+                if (estadoUi.modoEdicion) {
+                    OutlinedTextField(
+                        value = estadoUi.motivoCambio,
+                        onValueChange = onMotivoCambio,
+                        label = { Text(stringResource(R.string.cuadrante_label_motivo_edicion)) },
+                        modifier = Modifier.fillMaxWidth(),
+                        minLines = 2,
+                        maxLines = 4
+                    )
+                }
+
                 Button(
                     onClick = onAsignar,
                     enabled = estadoUi.formularioValido && !estadoUi.estaAsignando,
@@ -509,7 +589,12 @@ private fun BottomSheetAsignacionTurno(
                             color = MaterialTheme.colorScheme.onPrimary
                         )
                     } else {
-                        Text(stringResource(R.string.cuadrante_btn_asignar))
+                        Text(
+                            stringResource(
+                                if (estadoUi.modoEdicion) R.string.cuadrante_btn_actualizar
+                                else R.string.cuadrante_btn_asignar
+                            )
+                        )
                     }
                 }
             }
@@ -569,10 +654,7 @@ private fun DropdownEmpleado(
             readOnly = true,
             label = { Text(stringResource(R.string.cuadrante_label_empleado)) },
             trailingIcon = {
-                Icon(
-                    imageVector = Icons.Filled.ArrowDropDown,
-                    contentDescription = null
-                )
+                Icon(imageVector = Icons.Filled.ArrowDropDown, contentDescription = null)
             },
             modifier = Modifier
                 .fillMaxWidth()
@@ -635,10 +717,7 @@ private fun DropdownTurno(
             readOnly = true,
             label = { Text(stringResource(R.string.cuadrante_label_turno)) },
             trailingIcon = {
-                Icon(
-                    imageVector = Icons.Filled.ArrowDropDown,
-                    contentDescription = null
-                )
+                Icon(imageVector = Icons.Filled.ArrowDropDown, contentDescription = null)
             },
             modifier = Modifier
                 .fillMaxWidth()
@@ -674,7 +753,6 @@ private fun DropdownModalidad(
     onSeleccionar: (ModalidadAsignacion) -> Unit
 ) {
     var expandido by remember { mutableStateOf(false) }
-
     val textoPresencial = stringResource(R.string.cuadrante_modalidad_presencial)
     val textoTeletrabajo = stringResource(R.string.cuadrante_modalidad_teletrabajo)
 

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/PantallaCuadranteDepartamento.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/PantallaCuadranteDepartamento.kt
@@ -1,0 +1,717 @@
+package com.gestorrh.android.ui.equipo.cuadrante
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.gestorrh.android.R
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.asignacion.ModalidadAsignacion
+import com.gestorrh.android.data.network.asignacion.RespuestaAsignacionTurnoDTO
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+import com.gestorrh.android.data.network.turno.RespuestaTurnoDTO
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val ColorPresencial = Color(0xFF1A365D)
+private val ColorTeletrabajo = Color(0xFF00A8E8)
+private val FormatoHora = DateTimeFormatter.ofPattern("HH:mm")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PantallaCuadranteDepartamento(
+    contexto: Context = LocalContext.current,
+    viewModel: CuadranteDepartamentoViewModel = viewModel(
+        factory = CuadranteDepartamentoViewModel.factory(contexto.applicationContext)
+    )
+) {
+    val estadoUi by viewModel.estadoUi.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val recursos = LocalResources.current
+    val textoReintentar = stringResource(R.string.cuadrante_reintentar)
+
+    LaunchedEffect(estadoUi.mensajeError) {
+        estadoUi.mensajeError?.let { mensaje ->
+            val texto = when (mensaje) {
+                is MensajeUi.Recurso -> recursos.getString(mensaje.idRecurso)
+                is MensajeUi.Dinamico -> mensaje.texto
+            }
+            val resultado = snackbarHostState.showSnackbar(
+                message = texto,
+                actionLabel = textoReintentar,
+                duration = SnackbarDuration.Long
+            )
+            viewModel.errorMostrado()
+            if (resultado == SnackbarResult.ActionPerformed) {
+                viewModel.cargarAsignaciones()
+            }
+        }
+    }
+
+    LaunchedEffect(estadoUi.mensajeExito) {
+        estadoUi.mensajeExito?.let { mensaje ->
+            val texto = when (mensaje) {
+                is MensajeUi.Recurso -> recursos.getString(mensaje.idRecurso)
+                is MensajeUi.Dinamico -> mensaje.texto
+            }
+            snackbarHostState.showSnackbar(
+                message = texto,
+                duration = SnackbarDuration.Short
+            )
+            viewModel.exitoMostrado()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            FloatingActionButton(onClick = viewModel::abrirBottomSheet) {
+                Icon(
+                    imageVector = Icons.Filled.Add,
+                    contentDescription = stringResource(R.string.cuadrante_fab_cd)
+                )
+            }
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            SelectorFecha(
+                fechaSeleccionada = estadoUi.fechaSeleccionada,
+                alRetroceder = {
+                    viewModel.seleccionarFecha(estadoUi.fechaSeleccionada.minusDays(1))
+                },
+                alAvanzar = {
+                    viewModel.seleccionarFecha(estadoUi.fechaSeleccionada.plusDays(1))
+                }
+            )
+
+            CabeceraCuadrante(
+                totalEmpleados = estadoUi.asignacionesFiltradas.size,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            )
+
+            when {
+                estadoUi.cargando -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                estadoUi.asignacionesFiltradas.isEmpty() -> {
+                    EstadoVacio(modifier = Modifier.fillMaxSize())
+                }
+                else -> {
+                    ListaEmpleados(
+                        asignaciones = estadoUi.asignacionesFiltradas,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+            }
+        }
+    }
+
+    if (estadoUi.mostrarBottomSheet) {
+        BottomSheetAsignacionTurno(
+            estadoUi = estadoUi,
+            onDismiss = viewModel::cerrarBottomSheet,
+            onEmpleadoSeleccionado = viewModel::seleccionarEmpleado,
+            onTurnoSeleccionado = viewModel::seleccionarTurno,
+            onFechaSeleccionada = viewModel::seleccionarFechaAsignacion,
+            onModalidadSeleccionada = viewModel::seleccionarModalidad,
+            onAsignar = viewModel::asignarTurno
+        )
+    }
+}
+
+@Composable
+private fun SelectorFecha(
+    fechaSeleccionada: LocalDate,
+    alRetroceder: () -> Unit,
+    alAvanzar: () -> Unit
+) {
+    val hoy = remember { LocalDate.now() }
+    val esHoy = fechaSeleccionada == hoy
+    val formatter = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = alRetroceder) {
+            Icon(
+                imageVector = Icons.Filled.ChevronLeft,
+                contentDescription = null
+            )
+        }
+
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = fechaSeleccionada.format(formatter),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            if (esHoy) {
+                Text(
+                    text = stringResource(R.string.cuadrante_subtitulo_hoy),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+
+        IconButton(onClick = alAvanzar) {
+            Icon(
+                imageVector = Icons.Filled.ChevronRight,
+                contentDescription = null
+            )
+        }
+    }
+}
+
+@Composable
+private fun CabeceraCuadrante(
+    totalEmpleados: Int,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = stringResource(R.string.cuadrante_contador_empleados, totalEmpleados),
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun ListaEmpleados(
+    asignaciones: List<RespuestaAsignacionTurnoDTO>,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(
+            horizontal = 16.dp,
+            vertical = 8.dp
+        ),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        items(asignaciones, key = { it.idAsignacion }) { asignacion ->
+            TarjetaEmpleado(asignacion = asignacion)
+        }
+    }
+}
+
+@Composable
+private fun TarjetaEmpleado(asignacion: RespuestaAsignacionTurnoDTO) {
+    val iniciales = remember(asignacion.nombreCompletoEmpleado) {
+        asignacion.nombreCompletoEmpleado
+            .split(" ")
+            .take(2)
+            .mapNotNull { it.firstOrNull()?.uppercaseChar() }
+            .joinToString("")
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AvatarIniciales(
+                iniciales = iniciales,
+                nombreCompleto = asignacion.nombreCompletoEmpleado
+            )
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = asignacion.nombreCompletoEmpleado,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    BadgeModalidad(modalidad = asignacion.modalidad)
+
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Filled.Schedule,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        val horario = when {
+                            asignacion.horaInicio != null && asignacion.horaFin != null ->
+                                stringResource(
+                                    R.string.cuadrante_horario,
+                                    asignacion.horaInicio.format(FormatoHora),
+                                    asignacion.horaFin.format(FormatoHora)
+                                )
+                            else -> asignacion.descripcionTurno
+                        }
+                        Text(
+                            text = horario,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AvatarIniciales(
+    iniciales: String,
+    nombreCompleto: String
+) {
+    Box(
+        modifier = Modifier
+            .size(44.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = iniciales,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun BadgeModalidad(modalidad: ModalidadAsignacion) {
+    val (color, textoRes) = when (modalidad) {
+        ModalidadAsignacion.PRESENCIAL ->
+            ColorPresencial to R.string.cuadrante_modalidad_presencial
+        ModalidadAsignacion.TELETRABAJO ->
+            ColorTeletrabajo to R.string.cuadrante_modalidad_teletrabajo
+    }
+
+    Box(
+        modifier = Modifier
+            .background(color = color, shape = RoundedCornerShape(4.dp))
+            .padding(horizontal = 6.dp, vertical = 2.dp)
+    ) {
+        Text(
+            text = stringResource(textoRes),
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@Composable
+private fun EstadoVacio(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Groups,
+            contentDescription = null,
+            modifier = Modifier.size(72.dp),
+            tint = MaterialTheme.colorScheme.outlineVariant
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.cuadrante_vacio),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BottomSheetAsignacionTurno(
+    estadoUi: EstadoUiCuadranteDepartamento,
+    onDismiss: () -> Unit,
+    onEmpleadoSeleccionado: (RespuestaEmpleadoDTO) -> Unit,
+    onTurnoSeleccionado: (RespuestaTurnoDTO) -> Unit,
+    onFechaSeleccionada: (LocalDate) -> Unit,
+    onModalidadSeleccionada: (ModalidadAsignacion) -> Unit,
+    onAsignar: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var mostrarSelectorFecha by remember { mutableStateOf(false) }
+    val formatter = remember { DateTimeFormatter.ofPattern("dd/MM/yyyy") }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        dragHandle = { BottomSheetDefaults.DragHandle() }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.cuadrante_sheet_titulo),
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+
+            if (estadoUi.cargandoCatalogos) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            } else {
+                DropdownEmpleado(
+                    empleados = estadoUi.empleados,
+                    seleccionado = estadoUi.empleadoSeleccionado,
+                    onSeleccionar = onEmpleadoSeleccionado
+                )
+
+                DropdownTurno(
+                    turnos = estadoUi.turnos,
+                    seleccionado = estadoUi.turnoSeleccionado,
+                    onSeleccionar = onTurnoSeleccionado
+                )
+
+                OutlinedTextField(
+                    value = estadoUi.fechaAsignacion.format(formatter),
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text(stringResource(R.string.cuadrante_label_fecha)) },
+                    trailingIcon = {
+                        IconButton(onClick = { mostrarSelectorFecha = true }) {
+                            Icon(
+                                imageVector = Icons.Filled.DateRange,
+                                contentDescription = stringResource(R.string.cuadrante_label_fecha)
+                            )
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                DropdownModalidad(
+                    modalidades = estadoUi.modalidades,
+                    seleccionada = estadoUi.modalidadSeleccionada,
+                    onSeleccionar = onModalidadSeleccionada
+                )
+
+                Button(
+                    onClick = onAsignar,
+                    enabled = estadoUi.formularioValido && !estadoUi.estaAsignando,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(52.dp)
+                ) {
+                    if (estadoUi.estaAsignando) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp,
+                            color = MaterialTheme.colorScheme.onPrimary
+                        )
+                    } else {
+                        Text(stringResource(R.string.cuadrante_btn_asignar))
+                    }
+                }
+            }
+        }
+    }
+
+    if (mostrarSelectorFecha) {
+        val zonaHoraria = ZoneId.systemDefault()
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = estadoUi.fechaAsignacion
+                .atStartOfDay(zonaHoraria)
+                .toInstant()
+                .toEpochMilli()
+        )
+        DatePickerDialog(
+            onDismissRequest = { mostrarSelectorFecha = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    datePickerState.selectedDateMillis?.let { millis ->
+                        val fecha = Instant.ofEpochMilli(millis)
+                            .atZone(zonaHoraria)
+                            .toLocalDate()
+                        onFechaSeleccionada(fecha)
+                    }
+                    mostrarSelectorFecha = false
+                }) {
+                    Text(stringResource(R.string.ausencia_dialog_aceptar))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { mostrarSelectorFecha = false }) {
+                    Text(stringResource(R.string.ausencia_dialog_cancelar))
+                }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DropdownEmpleado(
+    empleados: List<RespuestaEmpleadoDTO>,
+    seleccionado: RespuestaEmpleadoDTO?,
+    onSeleccionar: (RespuestaEmpleadoDTO) -> Unit
+) {
+    var expandido by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expandido,
+        onExpandedChange = { expandido = it }
+    ) {
+        OutlinedTextField(
+            value = seleccionado?.let { "${it.nombre} ${it.apellidos}" } ?: "",
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(stringResource(R.string.cuadrante_label_empleado)) },
+            trailingIcon = {
+                Icon(
+                    imageVector = Icons.Filled.ArrowDropDown,
+                    contentDescription = null
+                )
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor()
+        )
+        ExposedDropdownMenu(
+            expanded = expandido,
+            onDismissRequest = { expandido = false }
+        ) {
+            empleados.forEach { empleado ->
+                DropdownMenuItem(
+                    text = {
+                        Column {
+                            Text(
+                                text = "${empleado.nombre} ${empleado.apellidos}",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            empleado.puesto?.let {
+                                Text(
+                                    text = it,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    },
+                    onClick = {
+                        onSeleccionar(empleado)
+                        expandido = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DropdownTurno(
+    turnos: List<RespuestaTurnoDTO>,
+    seleccionado: RespuestaTurnoDTO?,
+    onSeleccionar: (RespuestaTurnoDTO) -> Unit
+) {
+    var expandido by remember { mutableStateOf(false) }
+    val textoSeleccionado = seleccionado?.let { turno ->
+        if (turno.horaInicio != null && turno.horaFin != null) {
+            "${turno.descripcion} · ${turno.horaInicio.format(FormatoHora)} - ${turno.horaFin.format(FormatoHora)}"
+        } else {
+            turno.descripcion
+        }
+    } ?: ""
+
+    ExposedDropdownMenuBox(
+        expanded = expandido,
+        onExpandedChange = { expandido = it }
+    ) {
+        OutlinedTextField(
+            value = textoSeleccionado,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(stringResource(R.string.cuadrante_label_turno)) },
+            trailingIcon = {
+                Icon(
+                    imageVector = Icons.Filled.ArrowDropDown,
+                    contentDescription = null
+                )
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor()
+        )
+        ExposedDropdownMenu(
+            expanded = expandido,
+            onDismissRequest = { expandido = false }
+        ) {
+            turnos.forEach { turno ->
+                val etiqueta = if (turno.horaInicio != null && turno.horaFin != null) {
+                    "${turno.descripcion} · ${turno.horaInicio.format(FormatoHora)} - ${turno.horaFin.format(FormatoHora)}"
+                } else {
+                    turno.descripcion
+                }
+                DropdownMenuItem(
+                    text = { Text(etiqueta) },
+                    onClick = {
+                        onSeleccionar(turno)
+                        expandido = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DropdownModalidad(
+    modalidades: List<ModalidadAsignacion>,
+    seleccionada: ModalidadAsignacion?,
+    onSeleccionar: (ModalidadAsignacion) -> Unit
+) {
+    var expandido by remember { mutableStateOf(false) }
+
+    val textoPresencial = stringResource(R.string.cuadrante_modalidad_presencial)
+    val textoTeletrabajo = stringResource(R.string.cuadrante_modalidad_teletrabajo)
+
+    fun etiqueta(modalidad: ModalidadAsignacion) = when (modalidad) {
+        ModalidadAsignacion.PRESENCIAL -> textoPresencial
+        ModalidadAsignacion.TELETRABAJO -> textoTeletrabajo
+    }
+
+    ExposedDropdownMenuBox(
+        expanded = expandido,
+        onExpandedChange = { expandido = it }
+    ) {
+        OutlinedTextField(
+            value = seleccionada?.let { etiqueta(it) } ?: "",
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(stringResource(R.string.cuadrante_label_modalidad)) },
+            trailingIcon = {
+                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandido)
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor()
+        )
+        ExposedDropdownMenu(
+            expanded = expandido,
+            onDismissRequest = { expandido = false }
+        ) {
+            modalidades.forEach { modalidad ->
+                DropdownMenuItem(
+                    text = { Text(etiqueta(modalidad)) },
+                    onClick = {
+                        onSeleccionar(modalidad)
+                        expandido = false
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -223,7 +223,7 @@
     <string name="cuadrante_dialog_eliminar_confirmar">Delete</string>
     <string name="cuadrante_dialog_eliminar_cancelar">Cancel</string>
     <string name="cuadrante_label_motivo_edicion">Reason for change</string>
-    <string name="cuadrante_modificado_por">Modified by %1$s on %2$s · %3$s</string>
+    <string name="cuadrante_modificado_por">Modified by %1$s on %2$s\n%3$s</string>
 
     <!-- Assignment BottomSheet -->
     <string name="cuadrante_sheet_titulo">New assignment</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -203,4 +203,38 @@
     <string name="equipo_tab_cuadrante">Schedule</string>
     <string name="equipo_tab_fichajes">Records</string>
     <string name="equipo_proximamente">Coming soon</string>
+
+    <!-- Cuadrante Department Screen (Supervisor) -->
+    <string name="cuadrante_titulo">Schedule</string>
+    <string name="cuadrante_subtitulo_hoy">Today</string>
+    <string name="cuadrante_contador_empleados">%d employees scheduled</string>
+    <string name="cuadrante_vacio">No employees scheduled for this day</string>
+    <string name="cuadrante_fab_cd">Assign shift</string>
+    <string name="cuadrante_btn_asignar">Assign</string>
+    <string name="cuadrante_asignacion_exitosa">Shift assigned successfully</string>
+    <string name="cuadrante_reintentar">Retry</string>
+
+    <!-- Assignment BottomSheet -->
+    <string name="cuadrante_sheet_titulo">New assignment</string>
+    <string name="cuadrante_label_empleado">Employee</string>
+    <string name="cuadrante_label_turno">Shift</string>
+    <string name="cuadrante_label_fecha">Date</string>
+    <string name="cuadrante_label_modalidad">Mode</string>
+    <string name="cuadrante_label_motivo">Reason (optional)</string>
+    <string name="cuadrante_cargando_catalogos">Loading…</string>
+
+    <!-- Validation errors -->
+    <string name="cuadrante_error_empleado_requerido">Select an employee</string>
+    <string name="cuadrante_error_turno_requerido">Select a shift</string>
+    <string name="cuadrante_error_fecha_pasada">Date cannot be in the past</string>
+    <string name="cuadrante_error_modalidad_requerida">Select a mode</string>
+
+    <!-- Error 409 -->
+    <string name="cuadrante_error_conflicto">Data has changed, please reload and try again</string>
+
+    <!-- Employee card -->
+    <string name="cuadrante_cd_avatar">Avatar of %s</string>
+    <string name="cuadrante_modalidad_presencial">ON-SITE</string>
+    <string name="cuadrante_modalidad_teletrabajo">REMOTE</string>
+    <string name="cuadrante_horario">%1$s - %2$s</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -213,6 +213,17 @@
     <string name="cuadrante_btn_asignar">Assign</string>
     <string name="cuadrante_asignacion_exitosa">Shift assigned successfully</string>
     <string name="cuadrante_reintentar">Retry</string>
+    <string name="cuadrante_actualizacion_exitosa">Assignment updated successfully</string>
+    <string name="cuadrante_eliminacion_exitosa">Assignment deleted successfully</string>
+    <string name="cuadrante_error_motivo_requerido">Reason is required when editing an assignment</string>
+    <string name="cuadrante_sheet_titulo_edicion">Edit assignment</string>
+    <string name="cuadrante_btn_actualizar">Update</string>
+    <string name="cuadrante_dialog_eliminar_titulo">Delete assignment</string>
+    <string name="cuadrante_dialog_eliminar_mensaje">Are you sure you want to delete this assignment? This action cannot be undone.</string>
+    <string name="cuadrante_dialog_eliminar_confirmar">Delete</string>
+    <string name="cuadrante_dialog_eliminar_cancelar">Cancel</string>
+    <string name="cuadrante_label_motivo_edicion">Reason for change</string>
+    <string name="cuadrante_modificado_por">Modified by %1$s on %2$s · %3$s</string>
 
     <!-- Assignment BottomSheet -->
     <string name="cuadrante_sheet_titulo">New assignment</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,4 +204,38 @@
     <string name="equipo_tab_cuadrante">Cuadrante</string>
     <string name="equipo_tab_fichajes">Fichajes</string>
     <string name="equipo_proximamente">Próximamente</string>
+
+    <!-- Pantalla Cuadrante Departamento (Supervisor) -->
+    <string name="cuadrante_titulo">Cuadrante</string>
+    <string name="cuadrante_subtitulo_hoy">Hoy</string>
+    <string name="cuadrante_contador_empleados">%d empleados planificados</string>
+    <string name="cuadrante_vacio">No hay empleados con turno asignado este día</string>
+    <string name="cuadrante_fab_cd">Asignar turno</string>
+    <string name="cuadrante_btn_asignar">Asignar</string>
+    <string name="cuadrante_asignacion_exitosa">Turno asignado correctamente</string>
+    <string name="cuadrante_reintentar">Reintentar</string>
+
+    <!-- BottomSheet asignación -->
+    <string name="cuadrante_sheet_titulo">Nueva asignación</string>
+    <string name="cuadrante_label_empleado">Empleado</string>
+    <string name="cuadrante_label_turno">Turno</string>
+    <string name="cuadrante_label_fecha">Fecha</string>
+    <string name="cuadrante_label_modalidad">Modalidad</string>
+    <string name="cuadrante_label_motivo">Motivo (opcional)</string>
+    <string name="cuadrante_cargando_catalogos">Cargando…</string>
+
+    <!-- Errores de validación -->
+    <string name="cuadrante_error_empleado_requerido">Selecciona un empleado</string>
+    <string name="cuadrante_error_turno_requerido">Selecciona un turno</string>
+    <string name="cuadrante_error_fecha_pasada">La fecha no puede ser anterior a hoy</string>
+    <string name="cuadrante_error_modalidad_requerida">Selecciona una modalidad</string>
+
+    <!-- Error 409 -->
+    <string name="cuadrante_error_conflicto">Los datos han cambiado, recarga e inténtalo de nuevo</string>
+
+    <!-- Tarjeta empleado -->
+    <string name="cuadrante_cd_avatar">Avatar de %s</string>
+    <string name="cuadrante_modalidad_presencial">Presencial</string>
+    <string name="cuadrante_modalidad_teletrabajo">Teletrabajo</string>
+    <string name="cuadrante_horario">%1$s - %2$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,7 +224,7 @@
     <string name="cuadrante_dialog_eliminar_confirmar">Eliminar</string>
     <string name="cuadrante_dialog_eliminar_cancelar">Cancelar</string>
     <string name="cuadrante_label_motivo_edicion">Motivo del cambio</string>
-    <string name="cuadrante_modificado_por">Modificado por %1$s el %2$s · %3$s</string>
+    <string name="cuadrante_modificado_por">Modificado por %1$s el %2$s\n%3$s</string>
 
     <!-- BottomSheet asignación -->
     <string name="cuadrante_sheet_titulo">Nueva asignación</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,6 +214,17 @@
     <string name="cuadrante_btn_asignar">Asignar</string>
     <string name="cuadrante_asignacion_exitosa">Turno asignado correctamente</string>
     <string name="cuadrante_reintentar">Reintentar</string>
+    <string name="cuadrante_actualizacion_exitosa">Asignación actualizada correctamente</string>
+    <string name="cuadrante_eliminacion_exitosa">Asignación eliminada correctamente</string>
+    <string name="cuadrante_error_motivo_requerido">El motivo es obligatorio al editar una asignación</string>
+    <string name="cuadrante_sheet_titulo_edicion">Editar asignación</string>
+    <string name="cuadrante_btn_actualizar">Actualizar</string>
+    <string name="cuadrante_dialog_eliminar_titulo">Eliminar asignación</string>
+    <string name="cuadrante_dialog_eliminar_mensaje">¿Estás seguro de que deseas eliminar esta asignación? Esta acción no se puede deshacer.</string>
+    <string name="cuadrante_dialog_eliminar_confirmar">Eliminar</string>
+    <string name="cuadrante_dialog_eliminar_cancelar">Cancelar</string>
+    <string name="cuadrante_label_motivo_edicion">Motivo del cambio</string>
+    <string name="cuadrante_modificado_por">Modificado por %1$s el %2$s · %3$s</string>
 
     <!-- BottomSheet asignación -->
     <string name="cuadrante_sheet_titulo">Nueva asignación</string>


### PR DESCRIPTION
Implementa la subsección "Cuadrante" dentro de la pantalla de Gestión Equipo para el rol SUPERVISOR.

## Cambios implementados

### Core
- Añadido `LocalTimeDeserializer` con soporte para formatos `HH:mm` y `HH:mm:ss`
- Registrado deserializador y serializador de `LocalTime` en `ApiClient`

### Data
- Actualizado `RespuestaAsignacionTurnoDTO`: `horaInicio` y `horaFin` de `String?` a `LocalTime?`
- Actualizado `AsignacionMapper.toEntity()` para convertir `LocalTime?` a `String?`
- Añadidos endpoints `getAsignacionesEquipo`, `crearAsignacion`, `actualizarAsignacion` y `eliminarAsignacion` en `AsignacionApiService`
- Nuevos DTOs: `PeticionAsignacionTurnoDTO`, `RespuestaTurnoDTO`
- Nuevos servicios: `TurnoApiService`, `SupervisorEmpleadoApi`
- Nueva implementación `CuadranteRepositoryImpl` sin caché local

### Domain
- Nueva interfaz `ICuadranteRepository`
- Nuevo `AsignarTurnoUseCase` con validaciones para creación y edición

### Presentation
- Nueva pantalla `PantallaCuadranteDepartamento` con selector de fecha reactivo y contador de empleados planificados
- Tarjetas de empleado con avatar de iniciales, badge de modalidad con color semántico e información de modificación
- `BottomSheetAsignacionTurno` con modo creación y edición
- Integración en `PantallaGestionEquipo` (pestaña "Cuadrante")
- El supervisor no aparece en la lista de empleados asignables ni puede editar o eliminar su propia asignación

### Correcciones
- `LocalTimeDeserializer` tolerante con formato `HH:mm:ss` devuelto por algunos endpoints del servidor

## Criterios de aceptación verificados
- [x] Solo visible para usuarios con rol `SUPERVISOR`
- [x] Al entrar se muestra el cuadrante del día actual con el subtítulo "Hoy"
- [x] Cambiar la fecha actualiza la lista reactivamente sin nueva llamada de red
- [x] Cada tarjeta muestra avatar de iniciales, nombre, badge de modalidad con color semántico y turno con horario
- [x] El contador de empleados se actualiza al cambiar de fecha
- [x] Estado vacío si no hay nadie con turno en la fecha seleccionada
- [x] FAB "+" abre el `BottomSheet` de asignación
- [x] Los selectores de empleado, turno y modalidad se cargan desde la API
- [x] El selector de turno muestra descripción y tramo horario
- [x] Tras asignación exitosa: sheet se cierra y `Snackbar` de confirmación
- [x] Error 400 del servidor: `Snackbar` con mensaje dinámico, sheet permanece abierto
- [x] Edición de asignación existente con prerrellenado de datos
- [x] Eliminación de asignación con diálogo de confirmación
- [x] El supervisor no puede editar ni eliminar su propia asignación

Closes #18