### PR TITLE
[P2-06] Modificación Manual de Fichajes (Supervisor)

### DIFF
--- a/app/src/main/java/com/gestorrh/android/core/network/ApiClient.kt
+++ b/app/src/main/java/com/gestorrh/android/core/network/ApiClient.kt
@@ -45,6 +45,12 @@ object ApiClient {
 
         val gson = GsonBuilder()
             .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeDeserializer())
+            .registerTypeAdapter(
+                LocalDateTime::class.java,
+                JsonSerializer<LocalDateTime> { src, _, _ ->
+                    JsonPrimitive(src.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                }
+            )
             .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
             .registerTypeAdapter(
                 LocalDate::class.java,

--- a/app/src/main/java/com/gestorrh/android/data/network/fichaje/FichajeApiService.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/fichaje/FichajeApiService.kt
@@ -5,6 +5,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.PUT
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface FichajeApiService {
@@ -21,6 +22,13 @@ interface FichajeApiService {
     @GET("api/fichajes")
     suspend fun obtenerHistorial(
         @Query("fechaInicio") fechaInicio: String,
-        @Query("fechaFin") fechaFin: String
+        @Query("fechaFin") fechaFin: String,
+        @Query("empleadoId") empleadoId: Long? = null
     ): Response<List<RespuestaFichajeDTO>>
+
+    @PUT("api/fichajes/{idFichaje}/modificar")
+    suspend fun modificarFichaje(
+        @Path("idFichaje") idFichaje: Long,
+        @Body body: PeticionModificacionFichajeDTO
+    ): Response<RespuestaFichajeDTO>
 }

--- a/app/src/main/java/com/gestorrh/android/data/network/fichaje/FichajeRequests.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/fichaje/FichajeRequests.kt
@@ -1,5 +1,7 @@
 package com.gestorrh.android.data.network.fichaje
 
+import java.time.LocalDateTime
+
 data class PeticionFichajeEntradaDTO(
     val latitud: Double?,
     val longitud: Double?
@@ -8,4 +10,10 @@ data class PeticionFichajeEntradaDTO(
 data class PeticionFichajeSalidaDTO(
     val latitud: Double?,
     val longitud: Double?
+)
+
+data class PeticionModificacionFichajeDTO(
+    val nuevaHoraEntrada: LocalDateTime?,
+    val nuevaHoraSalida: LocalDateTime?,
+    val motivoModificacion: String
 )

--- a/app/src/main/java/com/gestorrh/android/data/repository/FichajeRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/FichajeRepository.kt
@@ -113,21 +113,12 @@ class FichajeRepository(private val apiService: FichajeApiService) : IFichajeRep
                 fechaFin = fechaFin.toString(),
                 empleadoId = empleadoId
             )
-            when {
-                respuesta.isSuccessful && respuesta.body() != null -> {
-                    Result.success(respuesta.body()!!)
-                }
-                respuesta.isSuccessful -> {
-                    Result.success(emptyList())
-                }
-                respuesta.code() == 403 -> {
-                    Result.success(emptyList())
-                }
-                else -> {
-                    val mensaje = extraerMensajeError(respuesta.errorBody())
-                        ?: "Error ${respuesta.code()} al obtener los fichajes"
-                    Result.failure(Exception(mensaje))
-                }
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                val mensaje = extraerMensajeError(respuesta.errorBody())
+                    ?: "Error ${respuesta.code()} al obtener los fichajes"
+                Result.failure(Exception(mensaje))
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/gestorrh/android/data/repository/FichajeRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/FichajeRepository.kt
@@ -3,6 +3,7 @@ package com.gestorrh.android.data.repository
 import com.gestorrh.android.data.network.fichaje.FichajeApiService
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeEntradaDTO
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeSalidaDTO
+import com.gestorrh.android.data.network.fichaje.PeticionModificacionFichajeDTO
 import com.gestorrh.android.data.network.fichaje.RespuestaEstadoFichajeDTO
 import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
 import com.gestorrh.android.domain.repository.IFichajeRepository
@@ -98,6 +99,47 @@ class FichajeRepository(private val apiService: FichajeApiService) : IFichajeRep
             JSONObject(json).getString("message")
         } catch (e: JSONException) {
             null
+        }
+    }
+
+    override suspend fun obtenerHistorialFichajesSupervisor(
+        fechaInicio: LocalDate,
+        fechaFin: LocalDate,
+        empleadoId: Long?
+    ): Result<List<RespuestaFichajeDTO>> {
+        return try {
+            val respuesta = apiService.obtenerHistorial(
+                fechaInicio = fechaInicio.toString(),
+                fechaFin = fechaFin.toString(),
+                empleadoId = empleadoId
+            )
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                val mensaje = extraerMensajeError(respuesta.errorBody())
+                    ?: "Error ${respuesta.code()} al obtener los fichajes"
+                Result.failure(Exception(mensaje))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun modificarFichaje(
+        idFichaje: Long,
+        peticion: PeticionModificacionFichajeDTO
+    ): Result<RespuestaFichajeDTO> {
+        return try {
+            val respuesta = apiService.modificarFichaje(idFichaje, peticion)
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                val mensaje = extraerMensajeError(respuesta.errorBody())
+                    ?: "Error ${respuesta.code()} al modificar el fichaje"
+                Result.failure(Exception(mensaje))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 }

--- a/app/src/main/java/com/gestorrh/android/data/repository/FichajeRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/FichajeRepository.kt
@@ -113,12 +113,21 @@ class FichajeRepository(private val apiService: FichajeApiService) : IFichajeRep
                 fechaFin = fechaFin.toString(),
                 empleadoId = empleadoId
             )
-            if (respuesta.isSuccessful && respuesta.body() != null) {
-                Result.success(respuesta.body()!!)
-            } else {
-                val mensaje = extraerMensajeError(respuesta.errorBody())
-                    ?: "Error ${respuesta.code()} al obtener los fichajes"
-                Result.failure(Exception(mensaje))
+            when {
+                respuesta.isSuccessful && respuesta.body() != null -> {
+                    Result.success(respuesta.body()!!)
+                }
+                respuesta.isSuccessful -> {
+                    Result.success(emptyList())
+                }
+                respuesta.code() == 403 -> {
+                    Result.success(emptyList())
+                }
+                else -> {
+                    val mensaje = extraerMensajeError(respuesta.errorBody())
+                        ?: "Error ${respuesta.code()} al obtener los fichajes"
+                    Result.failure(Exception(mensaje))
+                }
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/gestorrh/android/domain/repository/IFichajeRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/IFichajeRepository.kt
@@ -2,6 +2,7 @@ package com.gestorrh.android.domain.repository
 
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeEntradaDTO
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeSalidaDTO
+import com.gestorrh.android.data.network.fichaje.PeticionModificacionFichajeDTO
 import com.gestorrh.android.data.network.fichaje.RespuestaEstadoFichajeDTO
 import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
 import java.time.LocalDate
@@ -52,4 +53,33 @@ interface IFichajeRepository {
         fechaInicio: LocalDate,
         fechaFin: LocalDate
     ): Result<List<RespuestaFichajeDTO>>
+
+    /**
+     * Obtiene el historial de fichajes de un empleado concreto del equipo del supervisor.
+     * Si [empleadoId] es null, devuelve los fichajes de todos los empleados del departamento.
+     *
+     * @param fechaInicio Primer día del rango (inclusive).
+     * @param fechaFin Último día del rango (inclusive).
+     * @param empleadoId Identificador del empleado a filtrar, o null para todos.
+     */
+    suspend fun obtenerHistorialFichajesSupervisor(
+        fechaInicio: LocalDate,
+        fechaFin: LocalDate,
+        empleadoId: Long?
+    ): Result<List<RespuestaFichajeDTO>>
+
+    /**
+     * Modifica manualmente la hora de entrada o salida de un fichaje existente.
+     * Solo accesible para SUPERVISOR o EMPRESA. La modificación queda registrada
+     * en auditoría mediante el campo [motivoModificacion].
+     *
+     * @param idFichaje Identificador del fichaje a corregir.
+     * @param peticion DTO con las nuevas horas y el motivo obligatorio de auditoría.
+     * @return [Result.success] con el fichaje actualizado, o [Result.failure] con el
+     *         mensaje de error del servidor.
+     */
+    suspend fun modificarFichaje(
+        idFichaje: Long,
+        peticion: PeticionModificacionFichajeDTO
+    ): Result<RespuestaFichajeDTO>
 }

--- a/app/src/main/java/com/gestorrh/android/domain/usecase/fichaje/ModificarFichajeUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/fichaje/ModificarFichajeUseCase.kt
@@ -1,0 +1,78 @@
+package com.gestorrh.android.domain.usecase.fichaje
+
+import com.gestorrh.android.data.network.fichaje.PeticionModificacionFichajeDTO
+import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
+import com.gestorrh.android.domain.repository.IFichajeRepository
+import java.time.LocalTime
+
+/**
+ * Caso de uso que valida y ejecuta la modificación manual de un fichaje existente.
+ *
+ * Aplica las mismas reglas de negocio horarias que el servidor para dar feedback
+ * inmediato al supervisor sin necesidad de un viaje de red innecesario:
+ *
+ * - **Turno diurno válido:** [nuevaHoraSalida] es estrictamente posterior a [nuevaHoraEntrada].
+ * - **Turno nocturno válido:** [nuevaHoraEntrada] >= 16:00 y [nuevaHoraSalida] <= 08:00.
+ *
+ * La validación solo se aplica cuando se proporcionan **ambas** horas. Si solo se
+ * proporciona una de las dos, la validación se delega íntegramente al servidor.
+ *
+ * El campo [motivoModificacion] es obligatorio por motivos legales y de auditoría;
+ * si viene vacío o en blanco se devuelve [ErrorValidacion.MotivoVacio] sin llamada de red.
+ *
+ * @property fichajeRepository Contrato de dominio para las operaciones de fichaje.
+ */
+class ModificarFichajeUseCase(
+    private val fichajeRepository: IFichajeRepository
+) {
+
+    sealed class ErrorValidacion(mensaje: String) : Exception(mensaje) {
+        data object MotivoVacio : ErrorValidacion("motivo_vacio")
+        data object HorasInvalidas : ErrorValidacion("horas_invalidas")
+    }
+
+    /**
+     * Valida la petición y, si es correcta, delega la modificación en el repositorio.
+     *
+     * @param idFichaje Identificador del fichaje a corregir.
+     * @param nuevaHoraEntrada Nueva hora de entrada, o null para no modificarla.
+     * @param nuevaHoraSalida Nueva hora de salida, o null para no modificarla.
+     * @param motivoModificacion Motivo obligatorio de la modificación para auditoría.
+     * @return [Result.success] con el [RespuestaFichajeDTO] actualizado, o
+     *         [Result.failure] con [ErrorValidacion] o el error del servidor.
+     */
+    suspend operator fun invoke(
+        idFichaje: Long,
+        nuevaHoraEntrada: java.time.LocalDateTime?,
+        nuevaHoraSalida: java.time.LocalDateTime?,
+        motivoModificacion: String
+    ): Result<RespuestaFichajeDTO> {
+
+        if (motivoModificacion.isBlank()) {
+            return Result.failure(ErrorValidacion.MotivoVacio)
+        }
+
+        if (nuevaHoraEntrada != null && nuevaHoraSalida != null) {
+            val horaInicio = nuevaHoraEntrada.toLocalTime()
+            val horaFin = nuevaHoraSalida.toLocalTime()
+
+            val esDiurnoValido = horaFin.isAfter(horaInicio)
+
+            val esNocturnoValido = !horaInicio.isBefore(LocalTime.of(16, 0))
+                    && !horaFin.isAfter(LocalTime.of(8, 0))
+
+            if (!esDiurnoValido && !esNocturnoValido) {
+                return Result.failure(ErrorValidacion.HorasInvalidas)
+            }
+        }
+
+        return fichajeRepository.modificarFichaje(
+            idFichaje = idFichaje,
+            peticion = PeticionModificacionFichajeDTO(
+                nuevaHoraEntrada = nuevaHoraEntrada,
+                nuevaHoraSalida = nuevaHoraSalida,
+                motivoModificacion = motivoModificacion
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/PantallaGestionEquipo.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/PantallaGestionEquipo.kt
@@ -24,15 +24,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.gestorrh.android.R
 import com.gestorrh.android.ui.equipo.cuadrante.PantallaCuadranteDepartamento
+import com.gestorrh.android.ui.equipo.fichajes.PantallaModificacionFichajes
 
-/**
- * Pantalla contenedora de las funcionalidades del rol SUPERVISOR.
- *
- * Gestiona la navegación entre pestañas mediante estado local. Cada subsección
- * se implementa como un composable independiente que se muestra en el área de
- * contenido según la pestaña activa. Las pestañas de Ausencias y Fichajes
- * permanecen como placeholder hasta que se implementen sus issues correspondientes.
- */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PantallaGestionEquipo() {
@@ -81,6 +74,7 @@ fun PantallaGestionEquipo() {
 
             when (tabSeleccionada) {
                 1 -> PantallaCuadranteDepartamento()
+                2 -> PantallaModificacionFichajes()
                 else -> PlaceholderProximamente()
             }
         }

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/EstadoUiModificacionFichajes.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/EstadoUiModificacionFichajes.kt
@@ -1,0 +1,49 @@
+package com.gestorrh.android.ui.equipo.fichajes
+
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+/**
+ * Estado inmutable que consume [PantallaModificacionFichajes].
+ *
+ * @property empleados Catálogo de empleados del departamento cargado al inicializar.
+ * @property cargandoEmpleados true mientras se obtiene el catálogo de empleados.
+ * @property empleadoSeleccionado Empleado actualmente filtrado, null significa "Todos".
+ * @property fechaInicio Inicio del rango de fechas del filtro, por defecto hoy.
+ * @property fechaFin Fin del rango de fechas del filtro, por defecto hoy.
+ * @property fichajes Lista de fichajes del rango y empleado seleccionados.
+ * @property cargandoFichajes true mientras hay una petición de fichajes en curso.
+ * @property fichajeEditando Fichaje sobre el que se ha pulsado "Editar", null si el dialog está cerrado.
+ * @property dialogEntrada Nueva hora de entrada introducida en el dialog (pre-rellena con la original).
+ * @property dialogSalida Nueva hora de salida introducida en el dialog (pre-rellena con la original).
+ * @property dialogMotivo Texto del motivo de modificación introducido en el dialog.
+ * @property dialogErrorHoras Mensaje de error de validación de horas, null si no hay error.
+ * @property guardando true mientras se ejecuta el PUT de modificación.
+ * @property mensajeError Mensaje a mostrar en Snackbar ante cualquier error.
+ * @property mensajeExito Mensaje a mostrar en Snackbar tras modificación exitosa.
+ */
+data class EstadoUiModificacionFichajes(
+    val empleados: List<RespuestaEmpleadoDTO> = emptyList(),
+    val cargandoEmpleados: Boolean = false,
+    val empleadoSeleccionado: RespuestaEmpleadoDTO? = null,
+    val fechaInicio: LocalDate = LocalDate.now(),
+    val fechaFin: LocalDate = LocalDate.now(),
+    val fichajes: List<RespuestaFichajeDTO> = emptyList(),
+    val cargandoFichajes: Boolean = false,
+    val fichajeEditando: RespuestaFichajeDTO? = null,
+    val dialogEntrada: LocalDateTime? = null,
+    val dialogSalida: LocalDateTime? = null,
+    val dialogMotivo: String = "",
+    val dialogErrorHoras: Int? = null,
+    val guardando: Boolean = false,
+    val mensajeError: MensajeUi? = null,
+    val mensajeExito: MensajeUi? = null
+) {
+    val dialogAbierto: Boolean get() = fichajeEditando != null
+
+    val dialogGuardarHabilitado: Boolean
+        get() = dialogMotivo.isNotBlank() && !guardando && dialogErrorHoras == null
+}

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/ModificacionFichajesViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/ModificacionFichajesViewModel.kt
@@ -98,7 +98,10 @@ class ModificacionFichajesViewModel(
                 empleadoId = estado.empleadoSeleccionado?.idEmpleado
             )
                 .onSuccess { lista ->
-                    val ordenada = lista.sortedByDescending { it.horaEntrada }
+                    val idSupervisor = sessionManager.getId()
+                    val ordenada = lista
+                        .filter { it.idEmpleado != idSupervisor }
+                        .sortedByDescending { it.horaEntrada }
                     _estadoUi.update { it.copy(cargandoFichajes = false, fichajes = ordenada) }
                 }
                 .onFailure { error ->

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/ModificacionFichajesViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/ModificacionFichajesViewModel.kt
@@ -1,0 +1,267 @@
+package com.gestorrh.android.ui.equipo.fichajes
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.gestorrh.android.R
+import com.gestorrh.android.core.network.ApiClient
+import com.gestorrh.android.core.security.SessionManager
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+import com.gestorrh.android.data.network.fichaje.FichajeApiService
+import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
+import com.gestorrh.android.data.network.supervisor.SupervisorEmpleadoApi
+import com.gestorrh.android.data.repository.FichajeRepository
+import com.gestorrh.android.domain.repository.IFichajeRepository
+import com.gestorrh.android.domain.usecase.fichaje.ModificarFichajeUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.io.IOException
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+/**
+ * ViewModel de la pantalla de modificación manual de fichajes para el rol SUPERVISOR.
+ *
+ * Gestiona tres responsabilidades diferenciadas:
+ * - Carga del catálogo de empleados del departamento al inicializar (reutilizando
+ *   [SupervisorEmpleadoApi], excluyendo al propio supervisor igual que en el cuadrante).
+ * - Carga y filtrado de fichajes por empleado y rango de fechas, con carga automática
+ *   al entrar al tab (todos los empleados, hoy) y recarga al cambiar filtros.
+ * - Gestión completa del estado del dialog de edición: pre-relleno con datos reales
+ *   del fichaje original, validación local de horas con las mismas reglas que el servidor,
+ *   y envío de la modificación al repositorio con manejo diferenciado de códigos de error.
+ *
+ * @property fichajeRepository Contrato de dominio para las operaciones de fichaje.
+ * @property modificarFichajeUseCase Caso de uso que valida y delega la modificación.
+ * @property supervisorEmpleadoApi Servicio para obtener los empleados del departamento.
+ * @property sessionManager Fuente de verdad de la sesión activa, usado para excluir
+ *   al propio supervisor de la lista de empleados filtrables.
+ */
+class ModificacionFichajesViewModel(
+    private val fichajeRepository: IFichajeRepository,
+    private val modificarFichajeUseCase: ModificarFichajeUseCase,
+    private val supervisorEmpleadoApi: SupervisorEmpleadoApi,
+    private val sessionManager: SessionManager
+) : ViewModel() {
+
+    private val _estadoUi = MutableStateFlow(EstadoUiModificacionFichajes())
+    val estadoUi: StateFlow<EstadoUiModificacionFichajes> = _estadoUi.asStateFlow()
+
+    init {
+        cargarEmpleados()
+    }
+
+    private fun cargarEmpleados() {
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(cargandoEmpleados = true) }
+            try {
+                val respuesta = supervisorEmpleadoApi.getEmpleadosEquipo()
+                if (respuesta.isSuccessful && respuesta.body() != null) {
+                    val idSupervisor = sessionManager.getId()
+                    val empleados = respuesta.body()!!
+                        .filter { it.idEmpleado != idSupervisor }
+                    _estadoUi.update {
+                        it.copy(cargandoEmpleados = false, empleados = empleados)
+                    }
+                    cargarFichajes()
+                } else {
+                    _estadoUi.update {
+                        it.copy(
+                            cargandoEmpleados = false,
+                            mensajeError = MensajeUi.Recurso(R.string.error_conexion)
+                        )
+                    }
+                }
+            } catch (e: IOException) {
+                _estadoUi.update {
+                    it.copy(
+                        cargandoEmpleados = false,
+                        mensajeError = MensajeUi.Recurso(R.string.error_conexion)
+                    )
+                }
+            }
+        }
+    }
+
+    fun cargarFichajes() {
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(cargandoFichajes = true, mensajeError = null) }
+            val estado = _estadoUi.value
+            fichajeRepository.obtenerHistorialFichajesSupervisor(
+                fechaInicio = estado.fechaInicio,
+                fechaFin = estado.fechaFin,
+                empleadoId = estado.empleadoSeleccionado?.idEmpleado
+            )
+                .onSuccess { lista ->
+                    val ordenada = lista.sortedByDescending { it.horaEntrada }
+                    _estadoUi.update { it.copy(cargandoFichajes = false, fichajes = ordenada) }
+                }
+                .onFailure { error ->
+                    _estadoUi.update {
+                        it.copy(
+                            cargandoFichajes = false,
+                            mensajeError = if (error is IOException) {
+                                MensajeUi.Recurso(R.string.error_conexion)
+                            } else {
+                                MensajeUi.Dinamico(error.message ?: "")
+                            }
+                        )
+                    }
+                }
+        }
+    }
+
+    fun seleccionarEmpleado(empleado: RespuestaEmpleadoDTO?) {
+        _estadoUi.update { it.copy(empleadoSeleccionado = empleado) }
+        cargarFichajes()
+    }
+
+    fun actualizarFechaInicio(fecha: LocalDate) {
+        _estadoUi.update { it.copy(fechaInicio = fecha) }
+    }
+
+    fun actualizarFechaFin(fecha: LocalDate) {
+        _estadoUi.update { it.copy(fechaFin = fecha) }
+    }
+
+    fun abrirDialogEdicion(fichaje: RespuestaFichajeDTO) {
+        _estadoUi.update {
+            it.copy(
+                fichajeEditando = fichaje,
+                dialogEntrada = fichaje.horaEntrada,
+                dialogSalida = fichaje.horaSalida,
+                dialogMotivo = "",
+                dialogErrorHoras = null
+            )
+        }
+    }
+
+    fun cerrarDialog() {
+        _estadoUi.update {
+            it.copy(
+                fichajeEditando = null,
+                dialogEntrada = null,
+                dialogSalida = null,
+                dialogMotivo = "",
+                dialogErrorHoras = null
+            )
+        }
+    }
+
+    fun actualizarDialogEntrada(hora: LocalDateTime) {
+        _estadoUi.update { it.copy(dialogEntrada = hora, dialogErrorHoras = null) }
+    }
+
+    fun actualizarDialogSalida(hora: LocalDateTime?) {
+        _estadoUi.update { it.copy(dialogSalida = hora, dialogErrorHoras = null) }
+    }
+
+    fun actualizarDialogMotivo(motivo: String) {
+        _estadoUi.update { it.copy(dialogMotivo = motivo) }
+    }
+
+    fun guardarModificacion() {
+        val estado = _estadoUi.value
+        val fichaje = estado.fichajeEditando ?: return
+        if (estado.guardando) return
+
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(guardando = true, mensajeError = null) }
+
+            modificarFichajeUseCase(
+                idFichaje = fichaje.idFichaje,
+                nuevaHoraEntrada = estado.dialogEntrada,
+                nuevaHoraSalida = estado.dialogSalida,
+                motivoModificacion = estado.dialogMotivo
+            )
+                .onSuccess { fichajeActualizado ->
+                    val fichajesActualizados = _estadoUi.value.fichajes.map {
+                        if (it.idFichaje == fichajeActualizado.idFichaje) fichajeActualizado else it
+                    }
+                    _estadoUi.update {
+                        it.copy(
+                            guardando = false,
+                            fichajeEditando = null,
+                            dialogEntrada = null,
+                            dialogSalida = null,
+                            dialogMotivo = "",
+                            dialogErrorHoras = null,
+                            fichajes = fichajesActualizados,
+                            mensajeExito = MensajeUi.Recurso(R.string.modificacion_fichaje_exito)
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    when {
+                        error is ModificarFichajeUseCase.ErrorValidacion.MotivoVacio -> {
+                            _estadoUi.update { it.copy(guardando = false) }
+                        }
+                        error is ModificarFichajeUseCase.ErrorValidacion.HorasInvalidas -> {
+                            _estadoUi.update {
+                                it.copy(
+                                    guardando = false,
+                                    dialogErrorHoras = R.string.modificacion_fichaje_error_horas
+                                )
+                            }
+                        }
+                        error.message?.contains("409") == true -> {
+                            _estadoUi.update {
+                                it.copy(
+                                    guardando = false,
+                                    fichajeEditando = null,
+                                    mensajeError = MensajeUi.Recurso(R.string.modificacion_fichaje_error_conflicto)
+                                )
+                            }
+                        }
+                        else -> {
+                            _estadoUi.update {
+                                it.copy(
+                                    guardando = false,
+                                    mensajeError = if (error is IOException) {
+                                        MensajeUi.Recurso(R.string.error_conexion)
+                                    } else {
+                                        MensajeUi.Dinamico(error.message ?: "")
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+        }
+    }
+
+    fun errorMostrado() {
+        _estadoUi.update { it.copy(mensajeError = null) }
+    }
+
+    fun exitoMostrado() {
+        _estadoUi.update { it.copy(mensajeExito = null) }
+    }
+
+    companion object {
+        fun factory(contexto: Context): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val sessionManager = SessionManager(contexto)
+                    val retrofit = ApiClient.crearRetrofit(sessionManager)
+                    val fichajeRepository = FichajeRepository(
+                        retrofit.create(FichajeApiService::class.java)
+                    )
+                    val supervisorEmpleadoApi = retrofit.create(SupervisorEmpleadoApi::class.java)
+                    val useCase = ModificarFichajeUseCase(fichajeRepository)
+                    return ModificacionFichajesViewModel(
+                        fichajeRepository = fichajeRepository,
+                        modificarFichajeUseCase = useCase,
+                        supervisorEmpleadoApi = supervisorEmpleadoApi,
+                        sessionManager = sessionManager
+                    ) as T
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
@@ -1,0 +1,735 @@
+package com.gestorrh.android.ui.equipo.fichajes
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimePicker
+import androidx.compose.material3.TimePickerDefaults
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.gestorrh.android.R
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.empleado.RespuestaEmpleadoDTO
+import com.gestorrh.android.data.network.fichaje.RespuestaFichajeDTO
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+private val ColorAmbar = Color(0xFFF57C00)
+private val ColorAmbarFondo = Color(0xFFFFF3E0)
+private val FormatoFecha = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+private val FormatoHora = DateTimeFormatter.ofPattern("HH:mm")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PantallaModificacionFichajes(
+    contexto: Context = LocalContext.current,
+    viewModel: ModificacionFichajesViewModel = viewModel(
+        factory = ModificacionFichajesViewModel.factory(contexto.applicationContext)
+    )
+) {
+    val estadoUi by viewModel.estadoUi.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val recursos = LocalResources.current
+
+    LaunchedEffect(estadoUi.mensajeError) {
+        estadoUi.mensajeError?.let { mensaje ->
+            val texto = when (mensaje) {
+                is MensajeUi.Recurso -> recursos.getString(mensaje.idRecurso)
+                is MensajeUi.Dinamico -> mensaje.texto
+            }
+            snackbarHostState.showSnackbar(texto, duration = SnackbarDuration.Long)
+            viewModel.errorMostrado()
+        }
+    }
+
+    LaunchedEffect(estadoUi.mensajeExito) {
+        estadoUi.mensajeExito?.let { mensaje ->
+            val texto = when (mensaje) {
+                is MensajeUi.Recurso -> recursos.getString(mensaje.idRecurso)
+                is MensajeUi.Dinamico -> mensaje.texto
+            }
+            snackbarHostState.showSnackbar(texto, duration = SnackbarDuration.Short)
+            viewModel.exitoMostrado()
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()) {
+
+            SeccionFiltros(
+                estadoUi = estadoUi,
+                onEmpleadoSeleccionado = viewModel::seleccionarEmpleado,
+                onFechaInicioActualizada = viewModel::actualizarFechaInicio,
+                onFechaFinActualizada = viewModel::actualizarFechaFin,
+                onAplicarFiltro = viewModel::cargarFichajes
+            )
+
+            HorizontalDivider()
+
+            when {
+                estadoUi.cargandoFichajes -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                estadoUi.fichajes.isEmpty() && !estadoUi.cargandoEmpleados -> {
+                    EstadoVacio(modifier = Modifier.fillMaxSize())
+                }
+
+                else -> {
+                    ListaFichajes(
+                        fichajes = estadoUi.fichajes,
+                        onEditar = viewModel::abrirDialogEdicion,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
+            }
+        }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
+    }
+
+    if (estadoUi.dialogAbierto) {
+        DialogEdicionFichaje(
+            estadoUi = estadoUi,
+            onDismiss = viewModel::cerrarDialog,
+            onEntradaCambiada = viewModel::actualizarDialogEntrada,
+            onSalidaCambiada = viewModel::actualizarDialogSalida,
+            onMotivoCambiado = viewModel::actualizarDialogMotivo,
+            onGuardar = viewModel::guardarModificacion
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SeccionFiltros(
+    estadoUi: EstadoUiModificacionFichajes,
+    onEmpleadoSeleccionado: (RespuestaEmpleadoDTO?) -> Unit,
+    onFechaInicioActualizada: (LocalDate) -> Unit,
+    onFechaFinActualizada: (LocalDate) -> Unit,
+    onAplicarFiltro: () -> Unit
+) {
+    var mostrarSelectorInicio by remember { mutableStateOf(false) }
+    var mostrarSelectorFin by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        DropdownEmpleado(
+            empleados = estadoUi.empleados,
+            seleccionado = estadoUi.empleadoSeleccionado,
+            cargando = estadoUi.cargandoEmpleados,
+            onSeleccionar = onEmpleadoSeleccionado
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            BotonSelectorFecha(
+                etiqueta = stringResource(R.string.historial_fichajes_fecha_inicio),
+                fecha = estadoUi.fechaInicio,
+                modifier = Modifier.weight(1f),
+                alSeleccionar = { mostrarSelectorInicio = true }
+            )
+            BotonSelectorFecha(
+                etiqueta = stringResource(R.string.historial_fichajes_fecha_fin),
+                fecha = estadoUi.fechaFin,
+                modifier = Modifier.weight(1f),
+                alSeleccionar = { mostrarSelectorFin = true }
+            )
+        }
+
+        Button(
+            onClick = onAplicarFiltro,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !estadoUi.cargandoFichajes
+        ) {
+            Text(stringResource(R.string.historial_fichajes_aplicar_filtro))
+        }
+    }
+
+    if (mostrarSelectorInicio) {
+        SelectorFecha(
+            fechaInicial = estadoUi.fechaInicio,
+            alSeleccionar = onFechaInicioActualizada,
+            alDescartar = { mostrarSelectorInicio = false }
+        )
+    }
+
+    if (mostrarSelectorFin) {
+        SelectorFecha(
+            fechaInicial = estadoUi.fechaFin,
+            alSeleccionar = onFechaFinActualizada,
+            alDescartar = { mostrarSelectorFin = false }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DropdownEmpleado(
+    empleados: List<RespuestaEmpleadoDTO>,
+    seleccionado: RespuestaEmpleadoDTO?,
+    cargando: Boolean,
+    onSeleccionar: (RespuestaEmpleadoDTO?) -> Unit
+) {
+    var expandido by remember { mutableStateOf(false) }
+
+    val textoSeleccionado = when {
+        cargando -> stringResource(R.string.modificacion_fichaje_cargando_empleados)
+        seleccionado != null -> "${seleccionado.nombre} ${seleccionado.apellidos}"
+        else -> stringResource(R.string.modificacion_fichaje_todos_empleados)
+    }
+
+    ExposedDropdownMenuBox(
+        expanded = expandido,
+        onExpandedChange = { if (!cargando) expandido = it }
+    ) {
+        OutlinedTextField(
+            value = textoSeleccionado,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text(stringResource(R.string.modificacion_fichaje_label_empleado)) },
+            trailingIcon = {
+                if (cargando) {
+                    CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                } else {
+                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandido)
+                }
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor()
+        )
+        ExposedDropdownMenu(
+            expanded = expandido,
+            onDismissRequest = { expandido = false }
+        ) {
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        text = stringResource(R.string.modificacion_fichaje_todos_empleados),
+                        fontWeight = FontWeight.Medium
+                    )
+                },
+                onClick = {
+                    onSeleccionar(null)
+                    expandido = false
+                }
+            )
+            HorizontalDivider()
+            empleados.forEach { empleado ->
+                DropdownMenuItem(
+                    text = {
+                        Column {
+                            Text(
+                                text = "${empleado.nombre} ${empleado.apellidos}",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            empleado.puesto?.let {
+                                Text(
+                                    text = it,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                        }
+                    },
+                    onClick = {
+                        onSeleccionar(empleado)
+                        expandido = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BotonSelectorFecha(
+    etiqueta: String,
+    fecha: LocalDate,
+    modifier: Modifier = Modifier,
+    alSeleccionar: () -> Unit
+) {
+    OutlinedButton(
+        onClick = alSeleccionar,
+        modifier = modifier
+    ) {
+        Icon(
+            imageVector = Icons.Filled.DateRange,
+            contentDescription = null,
+            modifier = Modifier.size(16.dp)
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Column(horizontalAlignment = Alignment.Start) {
+            Text(
+                text = etiqueta,
+                style = MaterialTheme.typography.labelSmall
+            )
+            Text(
+                text = fecha.format(FormatoFecha),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SelectorFecha(
+    fechaInicial: LocalDate,
+    alSeleccionar: (LocalDate) -> Unit,
+    alDescartar: () -> Unit
+) {
+    val zonaHoraria = ZoneId.systemDefault()
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = fechaInicial
+            .atStartOfDay(zonaHoraria)
+            .toInstant()
+            .toEpochMilli()
+    )
+    DatePickerDialog(
+        onDismissRequest = alDescartar,
+        confirmButton = {
+            TextButton(onClick = {
+                datePickerState.selectedDateMillis?.let { millis ->
+                    alSeleccionar(
+                        Instant.ofEpochMilli(millis).atZone(zonaHoraria).toLocalDate()
+                    )
+                }
+                alDescartar()
+            }) { Text(stringResource(R.string.ausencia_dialog_aceptar)) }
+        },
+        dismissButton = {
+            TextButton(onClick = alDescartar) {
+                Text(stringResource(R.string.ausencia_dialog_cancelar))
+            }
+        }
+    ) {
+        DatePicker(state = datePickerState)
+    }
+}
+
+@Composable
+private fun ListaFichajes(
+    fichajes: List<RespuestaFichajeDTO>,
+    onEditar: (RespuestaFichajeDTO) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        items(fichajes, key = { it.idFichaje }) { fichaje ->
+            TarjetaFichajeSupervisor(
+                fichaje = fichaje,
+                onEditar = { onEditar(fichaje) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun TarjetaFichajeSupervisor(
+    fichaje: RespuestaFichajeDTO,
+    onEditar: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = fichaje.nombreEmpleado,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = fichaje.fecha.format(FormatoFecha),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    fichaje.descripcionTurno?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+                IconButton(onClick = onEditar) {
+                    Icon(
+                        imageVector = Icons.Filled.Edit,
+                        contentDescription = stringResource(R.string.modificacion_fichaje_cd_editar),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Column {
+                    Text(
+                        text = stringResource(R.string.historial_fichajes_hora_entrada),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = fichaje.horaEntrada.format(FormatoHora),
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        text = stringResource(R.string.historial_fichajes_hora_salida),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    if (fichaje.horaSalida != null) {
+                        Text(
+                            text = fichaje.horaSalida.format(FormatoHora),
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    } else {
+                        Text(
+                            text = stringResource(R.string.modificacion_fichaje_sin_salida),
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            color = ColorAmbar
+                        )
+                    }
+                }
+            }
+
+            fichaje.incidencias?.let { incidencia ->
+                Spacer(modifier = Modifier.height(8.dp))
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            color = ColorAmbarFondo,
+                            shape = RoundedCornerShape(4.dp)
+                        )
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Text(
+                        text = incidencia,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = ColorAmbar
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DialogEdicionFichaje(
+    estadoUi: EstadoUiModificacionFichajes,
+    onDismiss: () -> Unit,
+    onEntradaCambiada: (LocalDateTime) -> Unit,
+    onSalidaCambiada: (LocalDateTime?) -> Unit,
+    onMotivoCambiado: (String) -> Unit,
+    onGuardar: () -> Unit
+) {
+    val fichaje = estadoUi.fichajeEditando ?: return
+
+    val horaEntradaInicial = estadoUi.dialogEntrada ?: fichaje.horaEntrada
+    val horaSalidaInicial = estadoUi.dialogSalida ?: fichaje.horaSalida
+
+    val timePickerEntradaState = rememberTimePickerState(
+        initialHour = horaEntradaInicial.hour,
+        initialMinute = horaEntradaInicial.minute,
+        is24Hour = true
+    )
+    val timePickerSalidaState = horaSalidaInicial?.let {
+        rememberTimePickerState(
+            initialHour = it.hour,
+            initialMinute = it.minute,
+            is24Hour = true
+        )
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = stringResource(R.string.modificacion_fichaje_dialog_titulo),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                BannerAdvertencia()
+
+                Text(
+                    text = stringResource(R.string.modificacion_fichaje_dialog_subtitulo,
+                        fichaje.nombreEmpleado,
+                        fichaje.fecha.format(FormatoFecha)
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+
+                Text(
+                    text = stringResource(R.string.modificacion_fichaje_label_entrada),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+                TimePicker(
+                    state = timePickerEntradaState,
+                    colors = TimePickerDefaults.colors(
+                        clockDialColor = MaterialTheme.colorScheme.surfaceVariant,
+                        selectorColor = MaterialTheme.colorScheme.primary
+                    )
+                )
+
+                LaunchedEffect(
+                    timePickerEntradaState.hour,
+                    timePickerEntradaState.minute
+                ) {
+                    val nuevaEntrada = fichaje.horaEntrada
+                        .withHour(timePickerEntradaState.hour)
+                        .withMinute(timePickerEntradaState.minute)
+                        .withSecond(0)
+                    onEntradaCambiada(nuevaEntrada)
+                }
+
+                HorizontalDivider()
+
+                Text(
+                    text = stringResource(R.string.modificacion_fichaje_label_salida),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+
+                if (timePickerSalidaState != null) {
+                    TimePicker(
+                        state = timePickerSalidaState,
+                        colors = TimePickerDefaults.colors(
+                            clockDialColor = MaterialTheme.colorScheme.surfaceVariant,
+                            selectorColor = MaterialTheme.colorScheme.primary
+                        )
+                    )
+                    LaunchedEffect(
+                        timePickerSalidaState.hour,
+                        timePickerSalidaState.minute
+                    ) {
+                        val nuevaSalida = fichaje.horaSalida
+                            ?.withHour(timePickerSalidaState.hour)
+                            ?.withMinute(timePickerSalidaState.minute)
+                            ?.withSecond(0)
+                        onSalidaCambiada(nuevaSalida)
+                    }
+                } else {
+                    Text(
+                        text = stringResource(R.string.modificacion_fichaje_sin_salida),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = ColorAmbar,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+
+                estadoUi.dialogErrorHoras?.let { idError ->
+                    Text(
+                        text = stringResource(idError),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+
+                HorizontalDivider()
+
+                OutlinedTextField(
+                    value = estadoUi.dialogMotivo,
+                    onValueChange = onMotivoCambiado,
+                    label = { Text(stringResource(R.string.modificacion_fichaje_label_motivo)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 2,
+                    maxLines = 4,
+                    isError = estadoUi.dialogMotivo.isEmpty() && estadoUi.guardando
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = onGuardar,
+                enabled = estadoUi.dialogGuardarHabilitado
+            ) {
+                if (estadoUi.guardando) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                } else {
+                    Text(stringResource(R.string.modificacion_fichaje_btn_guardar))
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                enabled = !estadoUi.guardando
+            ) {
+                Text(stringResource(R.string.ausencia_dialog_cancelar))
+            }
+        }
+    )
+}
+
+@Composable
+private fun BannerAdvertencia() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = ColorAmbarFondo,
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Warning,
+            contentDescription = null,
+            tint = ColorAmbar,
+            modifier = Modifier.size(20.dp)
+        )
+        Text(
+            text = stringResource(R.string.modificacion_fichaje_aviso_auditoria),
+            style = MaterialTheme.typography.bodySmall,
+            color = ColorAmbar,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+private fun EstadoVacio(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.History,
+            contentDescription = null,
+            modifier = Modifier.size(72.dp),
+            tint = MaterialTheme.colorScheme.outlineVariant
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.modificacion_fichaje_vacio_titulo),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.modificacion_fichaje_vacio_descripcion),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TimeInput
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TimePickerDefaults
 import androidx.compose.material3.rememberDatePickerState
@@ -578,7 +579,7 @@ private fun DialogEdicionFichaje(
                     style = MaterialTheme.typography.labelMedium,
                     fontWeight = FontWeight.SemiBold
                 )
-                TimePicker(
+                TimeInput(
                     state = timePickerEntradaState,
                     colors = TimePickerDefaults.colors(
                         clockDialColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -638,7 +639,7 @@ private fun DialogEdicionFichaje(
                 }
 
                 if (salidaActivada) {
-                    TimePicker(
+                    TimeInput(
                         state = timePickerSalidaState,
                         colors = TimePickerDefaults.colors(
                             clockDialColor = MaterialTheme.colorScheme.surfaceVariant,

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
@@ -484,11 +484,12 @@ private fun TarjetaFichajeSupervisor(
                             fontWeight = FontWeight.SemiBold
                         )
                     } else {
+                        val textoSinSalida = calcularTextoSinSalida(fichaje.horaEntrada, fichaje.fecha)
                         Text(
-                            text = stringResource(R.string.modificacion_fichaje_sin_salida),
+                            text = stringResource(textoSinSalida.first),
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold,
-                            color = ColorAmbar
+                            color = textoSinSalida.second
                         )
                     }
                 }
@@ -774,6 +775,24 @@ private fun EstadoVacio(modifier: Modifier = Modifier) {
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center
         )
+    }
+}
+
+private fun calcularTextoSinSalida(
+    horaEntrada: java.time.LocalDateTime,
+    fecha: java.time.LocalDate
+): Pair<Int, Color> {
+    val ahora = java.time.LocalDateTime.now()
+    val hoy = java.time.LocalDate.now()
+    val horasTranscurridas = java.time.Duration.between(horaEntrada, ahora).toHours()
+
+    return when {
+        fecha.isBefore(hoy) ->
+            Pair(R.string.modificacion_fichaje_sin_salida, ColorAmbar)
+        fecha == hoy && horasTranscurridas < 9 ->
+            Pair(R.string.historial_fichajes_en_curso, Color(0xFF2E7D32))
+        else ->
+            Pair(R.string.modificacion_fichaje_sin_salida, ColorAmbar)
     }
 }
 

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
@@ -531,9 +531,7 @@ private fun DialogEdicionFichaje(
     val horaEntradaInicial = estadoUi.dialogEntrada ?: fichaje.horaEntrada
     val horaSalidaInicial = estadoUi.dialogSalida ?: fichaje.horaSalida
 
-    var salidaActivada by remember {
-        mutableStateOf(horaSalidaInicial != null)
-    }
+    var anadirSalida by remember { mutableStateOf(false) }
 
     val timePickerEntradaState = rememberTimePickerState(
         initialHour = horaEntradaInicial.hour,
@@ -599,71 +597,77 @@ private fun DialogEdicionFichaje(
 
                 HorizontalDivider()
 
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Text(
-                        text = stringResource(R.string.modificacion_fichaje_label_salida),
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.SemiBold
-                    )
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        Text(
-                            text = stringResource(R.string.modificacion_fichaje_incluir_salida),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Switch(
-                            checked = salidaActivada,
-                            onCheckedChange = { activada ->
-                                salidaActivada = activada
-                                if (activada) {
-                                    // Al activar, propagamos la hora actual del picker
-                                    val baseFecha = fichaje.horaSalida ?: fichaje.horaEntrada
-                                    val nuevaSalida = baseFecha
-                                        .withHour(timePickerSalidaState.hour)
-                                        .withMinute(timePickerSalidaState.minute)
-                                        .withSecond(0)
-                                    onSalidaCambiada(nuevaSalida)
-                                } else {
-                                    onSalidaCambiada(null)
-                                }
-                            }
-                        )
-                    }
-                }
+                Text(
+                    text = stringResource(R.string.modificacion_fichaje_label_salida),
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
 
-                if (salidaActivada) {
-                    TimeInput(
-                        state = timePickerSalidaState,
-                        colors = TimePickerDefaults.colors(
-                            clockDialColor = MaterialTheme.colorScheme.surfaceVariant,
-                            selectorColor = MaterialTheme.colorScheme.primary
+                when {
+                    horaSalidaInicial != null -> {
+                        TimeInput(
+                            state = timePickerSalidaState,
+                            colors = TimePickerDefaults.colors(
+                                clockDialColor = MaterialTheme.colorScheme.surfaceVariant,
+                                selectorColor = MaterialTheme.colorScheme.primary
+                            )
                         )
-                    )
-                    LaunchedEffect(
-                        timePickerSalidaState.hour,
-                        timePickerSalidaState.minute
-                    ) {
-                        val baseFecha = fichaje.horaSalida ?: fichaje.horaEntrada
-                        val nuevaSalida = baseFecha
-                            .withHour(timePickerSalidaState.hour)
-                            .withMinute(timePickerSalidaState.minute)
-                            .withSecond(0)
-                        onSalidaCambiada(nuevaSalida)
+                        LaunchedEffect(
+                            timePickerSalidaState.hour,
+                            timePickerSalidaState.minute
+                        ) {
+                            val nuevaSalida = fichaje.horaSalida
+                                ?.withHour(timePickerSalidaState.hour)
+                                ?.withMinute(timePickerSalidaState.minute)
+                                ?.withSecond(0)
+                            onSalidaCambiada(nuevaSalida)
+                        }
                     }
-                } else {
-                    Text(
-                        text = stringResource(R.string.modificacion_fichaje_sin_salida),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = ColorAmbar,
-                        fontWeight = FontWeight.SemiBold
-                    )
+
+                    anadirSalida -> {
+                        TimeInput(
+                            state = timePickerSalidaState,
+                            colors = TimePickerDefaults.colors(
+                                clockDialColor = MaterialTheme.colorScheme.surfaceVariant,
+                                selectorColor = MaterialTheme.colorScheme.primary
+                            )
+                        )
+                        LaunchedEffect(
+                            timePickerSalidaState.hour,
+                            timePickerSalidaState.minute
+                        ) {
+                            val nuevaSalida = fichaje.horaEntrada
+                                .withHour(timePickerSalidaState.hour)
+                                .withMinute(timePickerSalidaState.minute)
+                                .withSecond(0)
+                            onSalidaCambiada(nuevaSalida)
+                        }
+                    }
+
+                    else -> {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = stringResource(R.string.modificacion_fichaje_sin_salida),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = ColorAmbar,
+                                fontWeight = FontWeight.SemiBold
+                            )
+                            TextButton(onClick = {
+                                anadirSalida = true
+                                val nuevaSalida = fichaje.horaEntrada
+                                    .withHour(timePickerSalidaState.hour)
+                                    .withMinute(timePickerSalidaState.minute)
+                                    .withSecond(0)
+                                onSalidaCambiada(nuevaSalida)
+                            }) {
+                                Text(stringResource(R.string.modificacion_fichaje_anadir_salida))
+                            }
+                        }
+                    }
                 }
 
                 estadoUi.dialogErrorHoras?.let { idError ->

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimePicker
@@ -529,18 +530,22 @@ private fun DialogEdicionFichaje(
     val horaEntradaInicial = estadoUi.dialogEntrada ?: fichaje.horaEntrada
     val horaSalidaInicial = estadoUi.dialogSalida ?: fichaje.horaSalida
 
+    var salidaActivada by remember {
+        mutableStateOf(horaSalidaInicial != null)
+    }
+
     val timePickerEntradaState = rememberTimePickerState(
         initialHour = horaEntradaInicial.hour,
         initialMinute = horaEntradaInicial.minute,
         is24Hour = true
     )
-    val timePickerSalidaState = horaSalidaInicial?.let {
-        rememberTimePickerState(
-            initialHour = it.hour,
-            initialMinute = it.minute,
-            is24Hour = true
-        )
-    }
+
+    val horaSalidaParaPicker = horaSalidaInicial ?: LocalDateTime.now()
+    val timePickerSalidaState = rememberTimePickerState(
+        initialHour = horaSalidaParaPicker.hour,
+        initialMinute = horaSalidaParaPicker.minute,
+        is24Hour = true
+    )
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -559,7 +564,8 @@ private fun DialogEdicionFichaje(
                 BannerAdvertencia()
 
                 Text(
-                    text = stringResource(R.string.modificacion_fichaje_dialog_subtitulo,
+                    text = stringResource(
+                        R.string.modificacion_fichaje_dialog_subtitulo,
                         fichaje.nombreEmpleado,
                         fichaje.fecha.format(FormatoFecha)
                     ),
@@ -579,7 +585,6 @@ private fun DialogEdicionFichaje(
                         selectorColor = MaterialTheme.colorScheme.primary
                     )
                 )
-
                 LaunchedEffect(
                     timePickerEntradaState.hour,
                     timePickerEntradaState.minute
@@ -593,13 +598,46 @@ private fun DialogEdicionFichaje(
 
                 HorizontalDivider()
 
-                Text(
-                    text = stringResource(R.string.modificacion_fichaje_label_salida),
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.SemiBold
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = stringResource(R.string.modificacion_fichaje_label_salida),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.modificacion_fichaje_incluir_salida),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Switch(
+                            checked = salidaActivada,
+                            onCheckedChange = { activada ->
+                                salidaActivada = activada
+                                if (activada) {
+                                    // Al activar, propagamos la hora actual del picker
+                                    val baseFecha = fichaje.horaSalida ?: fichaje.horaEntrada
+                                    val nuevaSalida = baseFecha
+                                        .withHour(timePickerSalidaState.hour)
+                                        .withMinute(timePickerSalidaState.minute)
+                                        .withSecond(0)
+                                    onSalidaCambiada(nuevaSalida)
+                                } else {
+                                    onSalidaCambiada(null)
+                                }
+                            }
+                        )
+                    }
+                }
 
-                if (timePickerSalidaState != null) {
+                if (salidaActivada) {
                     TimePicker(
                         state = timePickerSalidaState,
                         colors = TimePickerDefaults.colors(
@@ -611,10 +649,11 @@ private fun DialogEdicionFichaje(
                         timePickerSalidaState.hour,
                         timePickerSalidaState.minute
                     ) {
-                        val nuevaSalida = fichaje.horaSalida
-                            ?.withHour(timePickerSalidaState.hour)
-                            ?.withMinute(timePickerSalidaState.minute)
-                            ?.withSecond(0)
+                        val baseFecha = fichaje.horaSalida ?: fichaje.horaEntrada
+                        val nuevaSalida = baseFecha
+                            .withHour(timePickerSalidaState.hour)
+                            .withMinute(timePickerSalidaState.minute)
+                            .withSecond(0)
                         onSalidaCambiada(nuevaSalida)
                     }
                 } else {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -248,4 +248,23 @@
     <string name="cuadrante_modalidad_presencial">ON-SITE</string>
     <string name="cuadrante_modalidad_teletrabajo">REMOTE</string>
     <string name="cuadrante_horario">%1$s - %2$s</string>
+
+    <!-- Clock-in Modification Screen (Supervisor) -->
+    <string name="modificacion_fichaje_label_empleado">Employee</string>
+    <string name="modificacion_fichaje_todos_empleados">All employees</string>
+    <string name="modificacion_fichaje_cargando_empleados">Loading employees…</string>
+    <string name="modificacion_fichaje_sin_salida">No clock-out recorded</string>
+    <string name="modificacion_fichaje_cd_editar">Edit record</string>
+    <string name="modificacion_fichaje_vacio_titulo">No records in this period</string>
+    <string name="modificacion_fichaje_vacio_descripcion">Select a different employee or date range to view records.</string>
+    <string name="modificacion_fichaje_dialog_titulo">Edit record</string>
+    <string name="modificacion_fichaje_dialog_subtitulo">%1$s · %2$s</string>
+    <string name="modificacion_fichaje_label_entrada">Clock-in time</string>
+    <string name="modificacion_fichaje_label_salida">Clock-out time</string>
+    <string name="modificacion_fichaje_label_motivo">Reason for modification (required)</string>
+    <string name="modificacion_fichaje_aviso_auditoria">⚠ This is a manual modification. It will be recorded for audit purposes.</string>
+    <string name="modificacion_fichaje_btn_guardar">Save</string>
+    <string name="modificacion_fichaje_exito">Record updated successfully</string>
+    <string name="modificacion_fichaje_error_horas">Invalid schedule. For day shifts, clock-out must be after clock-in. For night shifts, clock-in must be from 16:00 and clock-out by 08:00.</string>
+    <string name="modificacion_fichaje_error_conflicto">Concurrency conflict — reload and try again</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -267,5 +267,5 @@
     <string name="modificacion_fichaje_exito">Record updated successfully</string>
     <string name="modificacion_fichaje_error_horas">Invalid schedule. For day shifts, clock-out must be after clock-in. For night shifts, clock-in must be from 16:00 and clock-out by 08:00.</string>
     <string name="modificacion_fichaje_error_conflicto">Concurrency conflict — reload and try again</string>
-    <string name="modificacion_fichaje_incluir_salida">Include clock-out</string>
+    <string name="modificacion_fichaje_anadir_salida">+ Add clock-out</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -267,4 +267,5 @@
     <string name="modificacion_fichaje_exito">Record updated successfully</string>
     <string name="modificacion_fichaje_error_horas">Invalid schedule. For day shifts, clock-out must be after clock-in. For night shifts, clock-in must be from 16:00 and clock-out by 08:00.</string>
     <string name="modificacion_fichaje_error_conflicto">Concurrency conflict — reload and try again</string>
+    <string name="modificacion_fichaje_incluir_salida">Include clock-out</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -268,4 +268,5 @@
     <string name="modificacion_fichaje_exito">Fichaje modificado correctamente</string>
     <string name="modificacion_fichaje_error_horas">Horario inválido. Para turnos diurnos la salida debe ser posterior a la entrada. Para turnos nocturnos la entrada debe ser desde las 16:00 y la salida hasta las 08:00.</string>
     <string name="modificacion_fichaje_error_conflicto">Conflicto de concurrencia — recarga e inténtalo de nuevo</string>
+    <string name="modificacion_fichaje_incluir_salida">Incluir salida</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -249,4 +249,23 @@
     <string name="cuadrante_modalidad_presencial">Presencial</string>
     <string name="cuadrante_modalidad_teletrabajo">Teletrabajo</string>
     <string name="cuadrante_horario">%1$s - %2$s</string>
+
+    <!-- Pantalla Modificación de Fichajes (Supervisor) -->
+    <string name="modificacion_fichaje_label_empleado">Empleado</string>
+    <string name="modificacion_fichaje_todos_empleados">Todos los empleados</string>
+    <string name="modificacion_fichaje_cargando_empleados">Cargando empleados…</string>
+    <string name="modificacion_fichaje_sin_salida">Sin salida registrada</string>
+    <string name="modificacion_fichaje_cd_editar">Editar fichaje</string>
+    <string name="modificacion_fichaje_vacio_titulo">Sin fichajes en este periodo</string>
+    <string name="modificacion_fichaje_vacio_descripcion">Selecciona un empleado o rango de fechas diferente para ver sus fichajes.</string>
+    <string name="modificacion_fichaje_dialog_titulo">Modificar fichaje</string>
+    <string name="modificacion_fichaje_dialog_subtitulo">%1$s · %2$s</string>
+    <string name="modificacion_fichaje_label_entrada">Hora de entrada</string>
+    <string name="modificacion_fichaje_label_salida">Hora de salida</string>
+    <string name="modificacion_fichaje_label_motivo">Motivo de la modificación (obligatorio)</string>
+    <string name="modificacion_fichaje_aviso_auditoria">⚠ Esta es una modificación manual. Quedará registrada en auditoría.</string>
+    <string name="modificacion_fichaje_btn_guardar">Guardar</string>
+    <string name="modificacion_fichaje_exito">Fichaje modificado correctamente</string>
+    <string name="modificacion_fichaje_error_horas">Horario inválido. Para turnos diurnos la salida debe ser posterior a la entrada. Para turnos nocturnos la entrada debe ser desde las 16:00 y la salida hasta las 08:00.</string>
+    <string name="modificacion_fichaje_error_conflicto">Conflicto de concurrencia — recarga e inténtalo de nuevo</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -268,5 +268,5 @@
     <string name="modificacion_fichaje_exito">Fichaje modificado correctamente</string>
     <string name="modificacion_fichaje_error_horas">Horario inválido. Para turnos diurnos la salida debe ser posterior a la entrada. Para turnos nocturnos la entrada debe ser desde las 16:00 y la salida hasta las 08:00.</string>
     <string name="modificacion_fichaje_error_conflicto">Conflicto de concurrencia — recarga e inténtalo de nuevo</string>
-    <string name="modificacion_fichaje_incluir_salida">Incluir salida</string>
+    <string name="modificacion_fichaje_anadir_salida">+ Añadir salida</string>
 </resources>


### PR DESCRIPTION
## Descripción

Implementa la subsección de auditoría de fichajes dentro del tab "Fichajes" 
de la pantalla de Gestión Equipo. El supervisor puede consultar los fichajes 
de su departamento y corregir manualmente horas de entrada o salida incorrectas 
o faltantes.

## Cambios implementados

### Data Layer
- Añadido `PeticionModificacionFichajeDTO` en `FichajeRequests.kt`
- Añadido parámetro opcional `empleadoId` a `obtenerHistorial` en `FichajeApiService`
- Añadido endpoint `PUT /api/fichajes/{idFichaje}/modificar` en `FichajeApiService`
- Añadidos contratos `obtenerHistorialFichajesSupervisor` y `modificarFichaje` en `IFichajeRepository`
- Implementados ambos métodos en `FichajeRepository`
- Registrado serializador `LocalDateTime` en `ApiClient` (fix latente que afectaría a cualquier DTO con `LocalDateTime` en el body)

### Domain Layer
- Creado `ModificarFichajeUseCase` con validación de turnos diurnos y nocturnos replicando las reglas del servidor

### Presentation Layer
- Creados `EstadoUiModificacionFichajes`, `ModificacionFichajesViewModel` y `PantallaModificacionFichajes`
- Integrada la pantalla en el tab "Fichajes" de `PantallaGestionEquipo` sustituyendo el placeholder
- Strings añadidos en ES y EN

## Comportamiento

- Carga automática al entrar al tab con todos los empleados del departamento para hoy
- Dropdown de empleado con opción "Todos los empleados", excluyendo al propio supervisor
- Selector de rango de fechas con botón "Aplicar filtro"
- Fichajes sin salida muestran "En curso" (verde) si llevan menos de 9h desde la entrada, o "Sin salida registrada" (ámbar) si llevan más de 9h o son de días pasados
- Dialog de edición con `TimeInput` pre-relleno con los datos reales del fichaje, banner de advertencia de auditoría y campo de motivo obligatorio
- Fichajes sin salida permiten añadir una hora de salida mediante botón "+ Añadir salida"
- Tras modificación exitosa: dialog cierra, snackbar de éxito y el ítem se actualiza en la lista sin recargar
- Manejo diferenciado de errores 400 (dialog permanece abierto) y 409 (conflicto de concurrencia)

Closes #20