### PR TITLE
fix: fichaje sin respuesta, cronómetro reiniciado y fallo silencioso al fichar salida

### DIFF
--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -2,6 +2,7 @@ package com.gestorrh.android.ui.dashboard
 
 import android.content.Context
 import android.location.Location
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -232,12 +233,13 @@ class DashboardViewModel(
     }
 
     /**
-     * P0-11: Sincronización Inicial (BFF).
+     * Sincronización Inicial (BFF).
      * Consulta el estado de fichaje actual a través del repositorio.
      */
     fun sincronizarEstado() {
         viewModelScope.launch {
-            _estadoUi.update { it.copy(estaCargando = true, mensajeError = null) }
+            val hayEstadoActivo = _estadoUi.value.estadoActual == EstadoFichaje.TRABAJANDO
+            _estadoUi.update { it.copy(estaCargando = !hayEstadoActivo, mensajeError = null) }
 
             fichajeRepository.obtenerEstadoActual()
                 .onSuccess { datos ->
@@ -255,10 +257,14 @@ class DashboardViewModel(
                     }
 
                     if (datos.trabajandoActualmente && datos.horaEntrada != null) {
-                        val horaEntradaUtc = datos.horaEntrada.toInstant(java.time.ZoneOffset.UTC)
-                        val segundos = ChronoUnit.SECONDS.between(horaEntradaUtc, java.time.Instant.now())
-                        segundosAcumulados = segundos.coerceAtLeast(0L)
-                        iniciarTemporizador()
+                        if (!hayEstadoActivo) {
+                            // TODO: cuando se resuelva GestorRH-API#110 (normalizar fechas a UTC),
+                            //  actualizar LocalDateTimeDeserializer en ApiClient para convertir a hora local
+                            //  y revisar este cálculo si fuera necesario.
+                            val segundos = ChronoUnit.SECONDS.between(datos.horaEntrada, java.time.LocalDateTime.now())
+                            segundosAcumulados = segundos.coerceAtLeast(0L)
+                            iniciarTemporizador()
+                        }
                     } else if (!datos.trabajandoActualmente) {
                         detenerTemporizador()
                         segundosAcumulados = 0
@@ -291,16 +297,16 @@ class DashboardViewModel(
     }
 
     /**
-     * P0-10 y P0-12: Orquestador de Fichaje.
+     * Orquestador de Fichaje.
      * Decide si fichar entrada o salida según el estado actual.
      */
     fun alternarFichaje(ubicacion: Location?) {
         val estadoActual = _estadoUi.value
 
-        if (estadoActual.estadoActual == EstadoFichaje.FUERA_TURNO) {
-            ficharEntrada(ubicacion, estadoActual.modalidadHoy)
-        } else {
+        if (estadoActual.estadoActual == EstadoFichaje.TRABAJANDO) {
             ficharSalida(ubicacion, estadoActual.idFichajeAbierto)
+        } else {
+            ficharEntrada(ubicacion, estadoActual.modalidadHoy)
         }
     }
 
@@ -369,6 +375,7 @@ class DashboardViewModel(
             }
 
             if (idFichaje == null) {
+                mostrarError(MensajeUi.Recurso(R.string.error_fichaje_sin_entrada_abierta))
                 _estadoUi.update { it.copy(estaCargando = false) }
                 return@launch
             }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -36,6 +36,7 @@
     <string name="fichaje_sin_conexion">No connection — your clock event will be sent automatically</string>
     <string name="fichajes_pendientes">%d clock event(s) pending sync</string>
     <string name="fichaje_entrada_duplicada_offline">You already have a pending clock-in. You cannot register another until it is sent.</string>
+    <string name="error_fichaje_sin_entrada_abierta">No open clock-in found to register a clock-out</string>
 
     <string name="dashboard_modalidad_remota">REMOTE WORK</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="fichaje_sin_conexion">Sin conexión — el fichaje se enviará automáticamente</string>
     <string name="fichajes_pendientes">%d fichaje(s) pendiente(s) de sincronizar</string>
     <string name="fichaje_entrada_duplicada_offline">Ya hay una entrada pendiente de sincronizar. No puedes registrar otra hasta que se envíe.</string>
+    <string name="error_fichaje_sin_entrada_abierta">No hay ninguna entrada abierta para poder registrar la salida</string>
 
     <string name="dashboard_modalidad_remota">MODALIDAD REMOTA</string>
 


### PR DESCRIPTION
Closes #97

## Cambios

- Añadido Snackbar informativo cuando se intenta fichar salida sin entrada 
  abierta, eliminando el fallo silencioso anterior.
- Corregido el enrutamiento en `alternarFichaje`: los estados 
  `TURNO_EN_CURSO_SIN_FICHAR` y `TURNO_PENDIENTE` enrutaban incorrectamente 
  a `ficharSalida` en lugar de `ficharEntrada`.
- Corregido el cálculo de segundos del cronómetro comparando `LocalDateTime` 
  con `LocalDateTime` en lugar de mezclar zonas horarias, lo que causaba 
  segundos negativos y el reinicio a 00:00:00 al reabrir la app.

## Notas

El fix del cronómetro es una solución provisional hasta que se resuelva 
GestorRH-API#110 (normalizar fechas a UTC). Cuando se cierre esa issue 
revisar `LocalDateTimeDeserializer` en `ApiClient` y el cálculo en 
`DashboardViewModel`.