### PR TITLE
fix: estado inicial incorrecto del dashboard y mejoras en el widget de fichaje

### DIFF
--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -187,6 +187,16 @@ class DashboardViewModel(
                 }
                 .minByOrNull { it.fecha }
             _estadoUi.update { it.copy(proximoTurno = proxima) }
+
+            _estadoUi.update { current ->
+                current.copy(
+                    estadoActual = calcularEstadoFichaje(
+                        trabajandoActualmente = current.estadoActual == EstadoFichaje.TRABAJANDO,
+                        tieneTurnoHoy = current.tieneTurnoHoy,
+                        proximoTurno = proxima
+                    )
+                )
+            }
         }
     }
 
@@ -350,6 +360,7 @@ class DashboardViewModel(
                     }
                     segundosAcumulados = 0
                     iniciarTemporizador()
+                    cargarUltimosFichajes()
                 }
                 .onFailure { e ->
                     val mensaje = if (e.message != null) MensajeUi.Dinamico(e.message!!)
@@ -392,6 +403,7 @@ class DashboardViewModel(
                             tiempoTranscurrido = "00:00:00"
                         )
                     }
+                    cargarUltimosFichajes()
                 }
                 .onFailure { e ->
                     val mensaje = if (e.message != null) MensajeUi.Dinamico(e.message!!)

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -52,6 +52,7 @@ import androidx.compose.material.icons.filled.WifiOff
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.core.app.ActivityCompat
@@ -512,7 +513,7 @@ private fun WidgetFichaje(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
 
-            if (modalidad == ModalidadTurno.TELETRABAJO) {
+            if (modalidad == ModalidadTurno.TELETRABAJO && estadoActual != EstadoFichaje.FUERA_TURNO) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(imageVector = Icons.Filled.Home, contentDescription = stringResource(id = R.string.cd_teletrabajo), tint = colorTextoEstado, modifier = Modifier.size(16.dp))
                     Spacer(modifier = Modifier.width(8.dp))
@@ -526,7 +527,9 @@ private fun WidgetFichaje(
                 style = MaterialTheme.typography.labelLarge,
                 color = colorTextoEstado,
                 fontWeight = FontWeight.Bold,
-                fontSize = 18.sp
+                fontSize = 18.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
             )
 
             Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
## Cambios

- Corregida condición de carrera en el arranque: `cargarProximoTurno()` 
  ahora recalcula `estadoActual` al terminar, evitando que se muestre 
  "No tienes turno hoy" incorrectamente en el primer frame.
- Centrado el texto de estado en el widget de fichaje.
- La modalidad (TELETRABAJO/PRESENCIAL) solo se muestra en el widget 
  cuando hay turno activo, pendiente o en curso.
- La sección "Últimos fichajes" se actualiza inmediatamente tras fichar 
  entrada o salida sin necesidad de navegar entre pestañas.