### PR TITLE
feat: [P2-02] Validación de Ausencias del Equipo (Supervisor)

### DIFF
--- a/app/src/main/java/com/gestorrh/android/data/network/ausencia/AusenciaApiService.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/ausencia/AusenciaApiService.kt
@@ -3,6 +3,7 @@ package com.gestorrh.android.data.network.ausencia
 import okhttp3.MultipartBody
 import okhttp3.ResponseBody
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
@@ -46,4 +47,15 @@ interface AusenciaApiService {
     suspend fun descargarJustificante(
         @Path("nombreArchivo") nombreArchivo: String
     ): Response<ResponseBody>
+
+    @GET("api/ausencias")
+    suspend fun getAusenciasEquipo(
+        @Query("estado") estado: String? = null
+    ): Response<List<RespuestaAusenciaDTO>>
+
+    @PUT("api/ausencias/{id}/revision")
+    suspend fun revisarAusencia(
+        @Path("id") id: Long,
+        @Body body: PeticionRevisionAusenciaDTO
+    ): Response<RespuestaAusenciaDTO>
 }

--- a/app/src/main/java/com/gestorrh/android/data/network/ausencia/PeticionRevisionAusenciaDTO.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/ausencia/PeticionRevisionAusenciaDTO.kt
@@ -1,0 +1,6 @@
+package com.gestorrh.android.data.network.ausencia
+
+data class PeticionRevisionAusenciaDTO(
+    val estado: String,
+    val observacionesRevision: String? = null
+)

--- a/app/src/main/java/com/gestorrh/android/data/network/ausencia/RespuestaAusenciaDTO.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/ausencia/RespuestaAusenciaDTO.kt
@@ -7,14 +7,16 @@ data class RespuestaAusenciaDTO(
     val idAusencia: Long,
     val idEmpleado: Long?,
     val nombreCompletoEmpleado: String?,
-    val tipo: String,
+    val tipo: TipoAusencia,
     val descripcion: String?,
     val fechaInicio: LocalDate,
     val fechaFin: LocalDate,
-    val estado: String,
+    val estado: EstadoAusencia,
     val justificante: String?,
     val fechaSolicitud: LocalDateTime?,
     val fechaResolucion: LocalDateTime?,
     val responsableResolucion: String?,
-    val motivoRechazo: String?
+    val motivoRechazo: String?,
+    val responsableRevision: String?,
+    val observacionesRevision: String?
 )

--- a/app/src/main/java/com/gestorrh/android/data/network/ausencia/TipoAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/data/network/ausencia/TipoAusencia.kt
@@ -8,7 +8,7 @@ enum class TipoAusencia {
 }
 
 enum class EstadoAusencia {
-    PENDIENTE,
+    SOLICITADA,
     APROBADA,
     RECHAZADA
 }

--- a/app/src/main/java/com/gestorrh/android/data/repository/ausencia/AusenciaRepositoryImpl.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/ausencia/AusenciaRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.gestorrh.android.data.repository.ausencia
 
 import com.gestorrh.android.data.network.ausencia.AusenciaApiService
 import com.gestorrh.android.data.network.ausencia.PeticionAusenciaDTO
+import com.gestorrh.android.data.network.ausencia.PeticionRevisionAusenciaDTO
 import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
 import com.gestorrh.android.domain.repository.IAusenciaRepository
 import com.google.gson.Gson
@@ -206,6 +207,50 @@ class AusenciaRepositoryImpl(
             JSONObject(json).getString("message")
         } catch (e: JSONException) {
             null
+        }
+    }
+
+    override suspend fun obtenerAusenciasEquipo(estado: String?): Result<List<RespuestaAusenciaDTO>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val respuesta = apiService.getAusenciasEquipo(estado)
+                if (respuesta.isSuccessful && respuesta.body() != null) {
+                    Result.success(respuesta.body()!!)
+                } else {
+                    Result.failure(
+                        Exception(
+                            extraerMensajeError(respuesta.errorBody())
+                                ?: "Error ${respuesta.code()} al obtener las ausencias del equipo"
+                        )
+                    )
+                }
+            } catch (e: IOException) {
+                Result.failure(e)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+
+    override suspend fun revisarAusencia(
+        id: Long,
+        peticion: PeticionRevisionAusenciaDTO
+    ): Result<RespuestaAusenciaDTO> = withContext(Dispatchers.IO) {
+        try {
+            val respuesta = apiService.revisarAusencia(id, peticion)
+            if (respuesta.isSuccessful && respuesta.body() != null) {
+                Result.success(respuesta.body()!!)
+            } else {
+                Result.failure(
+                    Exception(
+                        extraerMensajeError(respuesta.errorBody())
+                            ?: "Error ${respuesta.code()} al revisar la ausencia"
+                    )
+                )
+            }
+        } catch (e: IOException) {
+            Result.failure(e)
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 }

--- a/app/src/main/java/com/gestorrh/android/domain/repository/IAusenciaRepository.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/repository/IAusenciaRepository.kt
@@ -1,6 +1,7 @@
 package com.gestorrh.android.domain.repository
 
 import com.gestorrh.android.data.network.ausencia.PeticionAusenciaDTO
+import com.gestorrh.android.data.network.ausencia.PeticionRevisionAusenciaDTO
 import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
 
 /**
@@ -74,4 +75,11 @@ interface IAusenciaRepository {
      * `GET /api/ausencias/justificantes/{nombreArchivo}`.
      */
     suspend fun descargarJustificante(nombreArchivo: String): Result<ByteArray>
+
+    suspend fun obtenerAusenciasEquipo(estado: String? = null): Result<List<RespuestaAusenciaDTO>>
+
+    suspend fun revisarAusencia(
+        id: Long,
+        peticion: PeticionRevisionAusenciaDTO
+    ): Result<RespuestaAusenciaDTO>
 }

--- a/app/src/main/java/com/gestorrh/android/domain/usecase/ausencia/SolicitarAusenciaUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/ausencia/SolicitarAusenciaUseCase.kt
@@ -28,7 +28,6 @@ class SolicitarAusenciaUseCase(
 ) {
 
     sealed class ErrorValidacion(mensaje: String) : Exception(mensaje) {
-        data object FechaInicioPasada : ErrorValidacion("fechaInicio_pasada")
         data object FechaFinAnterior : ErrorValidacion("fechaFin_anterior")
         data object TipoVacio : ErrorValidacion("tipo_vacio")
         data object ArchivoTipoNoSoportado : ErrorValidacion("archivo_tipo_no_soportado")
@@ -43,14 +42,13 @@ class SolicitarAusenciaUseCase(
         archivoBytes: ByteArray?,
         nombreArchivo: String?,
         idAusenciaEditar: Long? = null,
-        eliminarJustificante: Boolean? = null,
-        hoy: LocalDate = LocalDate.now()
+        eliminarJustificante: Boolean? = null
     ): Result<RespuestaAusenciaDTO> {
         if (tipo.isNullOrBlank()) {
             return Result.failure(ErrorValidacion.TipoVacio)
         }
-        if (fechaInicio == null || fechaInicio.isBefore(hoy)) {
-            return Result.failure(ErrorValidacion.FechaInicioPasada)
+        if (fechaInicio == null) {
+            return Result.failure(ErrorValidacion.FechaFinAnterior)
         }
         if (fechaFin == null || fechaFin.isBefore(fechaInicio)) {
             return Result.failure(ErrorValidacion.FechaFinAnterior)

--- a/app/src/main/java/com/gestorrh/android/domain/usecase/supervisor/ObtenerAusenciasEquipoUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/supervisor/ObtenerAusenciasEquipoUseCase.kt
@@ -1,0 +1,14 @@
+package com.gestorrh.android.domain.usecase.supervisor
+
+import com.gestorrh.android.data.network.ausencia.EstadoAusencia
+import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
+import com.gestorrh.android.domain.repository.IAusenciaRepository
+
+class ObtenerAusenciasEquipoUseCase(
+    private val repository: IAusenciaRepository
+) {
+    suspend operator fun invoke(
+        estado: EstadoAusencia? = null
+    ): Result<List<RespuestaAusenciaDTO>> =
+        repository.obtenerAusenciasEquipo(estado?.name)
+}

--- a/app/src/main/java/com/gestorrh/android/domain/usecase/supervisor/RevisarAusenciaUseCase.kt
+++ b/app/src/main/java/com/gestorrh/android/domain/usecase/supervisor/RevisarAusenciaUseCase.kt
@@ -1,0 +1,48 @@
+package com.gestorrh.android.domain.usecase.supervisor
+
+import com.gestorrh.android.data.network.ausencia.EstadoAusencia
+import com.gestorrh.android.data.network.ausencia.PeticionRevisionAusenciaDTO
+import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
+import com.gestorrh.android.domain.repository.IAusenciaRepository
+
+/**
+ * Caso de uso que valida y ejecuta la revisión (aprobación o rechazo) de una
+ * solicitud de ausencia por parte del supervisor.
+ *
+ * Validaciones aplicadas antes de la llamada de red:
+ * - El estado destino debe ser [EstadoAusencia.APROBADA] o [EstadoAusencia.RECHAZADA].
+ *   Intentar revisar dejando el estado en [EstadoAusencia.SOLICITADA] es un error
+ *   de lógica que se rechaza en cliente sin necesidad de un viaje de red.
+ * - Las observaciones son opcionales en ambos casos: el servidor las acepta como null.
+ *
+ * Si la validación es correcta delega en [IAusenciaRepository.revisarAusencia].
+ * Los errores de red o de negocio devueltos por el servidor (400/404) se propagan
+ * tal cual como [Result.failure] con el mensaje extraído del campo `message` del JSON.
+ *
+ * @property repository Contrato de dominio para las operaciones de ausencia.
+ */
+class RevisarAusenciaUseCase(
+    private val repository: IAusenciaRepository
+) {
+
+    sealed class ErrorValidacion(mensaje: String) : Exception(mensaje) {
+        data object EstadoInvalido : ErrorValidacion("estado_invalido")
+    }
+
+    suspend operator fun invoke(
+        idAusencia: Long,
+        estado: EstadoAusencia,
+        observaciones: String? = null
+    ): Result<RespuestaAusenciaDTO> {
+        if (estado == EstadoAusencia.SOLICITADA) {
+            return Result.failure(ErrorValidacion.EstadoInvalido)
+        }
+
+        val peticion = PeticionRevisionAusenciaDTO(
+            estado = estado.name,
+            observacionesRevision = observaciones?.takeIf { it.isNotBlank() }
+        )
+
+        return repository.revisarAusencia(idAusencia, peticion)
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/AusenciaUtils.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/AusenciaUtils.kt
@@ -3,25 +3,24 @@ package com.gestorrh.android.ui.ausencia
 import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.Color
 import com.gestorrh.android.R
+import com.gestorrh.android.data.network.ausencia.EstadoAusencia
 
 object AusenciaUtils {
 
     @StringRes
-    fun obtenerStringEstado(estado: String): Int {
-        return when (estado.uppercase()) {
-            "SOLICITADA" -> R.string.ausencia_estado_solicitada
-            "APROBADA" -> R.string.ausencia_estado_aprobada
-            "RECHAZADA" -> R.string.ausencia_estado_rechazada
-            else -> R.string.ausencia_estado_desconocido
+    fun obtenerStringEstado(estado: EstadoAusencia): Int {
+        return when (estado) {
+            EstadoAusencia.SOLICITADA -> R.string.ausencia_estado_solicitada
+            EstadoAusencia.APROBADA -> R.string.ausencia_estado_aprobada
+            EstadoAusencia.RECHAZADA -> R.string.ausencia_estado_rechazada
         }
     }
 
-    fun obtenerColorEstado(estado: String): Color {
-        return when (estado.uppercase()) {
-            "SOLICITADA" -> Color(0xFFF57C00)
-            "APROBADA" -> Color(0xFF2E7D32)
-            "RECHAZADA" -> Color(0xFFD32F2F)
-            else -> Color(0xFF8B8B8B)
+    fun obtenerColorEstado(estado: EstadoAusencia): Color {
+        return when (estado) {
+            EstadoAusencia.SOLICITADA -> Color(0xFFF57C00)
+            EstadoAusencia.APROBADA -> Color(0xFF2E7D32)
+            EstadoAusencia.RECHAZADA -> Color(0xFFD32F2F)
         }
     }
 }

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/EstadoUiSolicitudAusencia.kt
@@ -38,10 +38,9 @@ data class EstadoUiSolicitudAusencia(
 
     val formularioValido: Boolean
         get() = !tipoSeleccionado.isNullOrBlank()
-            && fechaInicio != null
-            && fechaFin != null
-            && !fechaFin.isBefore(fechaInicio)
-            && !fechaInicio.isBefore(LocalDate.now())
+                && fechaInicio != null
+                && fechaFin != null
+                && !fechaFin.isBefore(fechaInicio)
 }
 
 /**

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaMisAusencias.kt
@@ -65,7 +65,9 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gestorrh.android.R
 import com.gestorrh.android.core.archivos.GestorArchivosJustificante
 import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.ausencia.EstadoAusencia
 import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
+import com.gestorrh.android.data.network.ausencia.TipoAusencia
 import java.time.format.DateTimeFormatter
 
 private val ColorEstadoRechazada = Color(0xFFD32F2F)
@@ -359,7 +361,7 @@ private fun TarjetaAusencia(
                 )
             }
 
-            if (ausencia.estado == "SOLICITADA") {
+            if (ausencia.estado == EstadoAusencia.SOLICITADA) {
                 Spacer(Modifier.height(12.dp))
                 HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                 Spacer(Modifier.height(8.dp))
@@ -404,7 +406,7 @@ private fun TarjetaAusencia(
 }
 
 @Composable
-private fun ChipEstado(estado: String) {
+private fun ChipEstado(estado: EstadoAusencia) {
     Box(
         modifier = Modifier
             .background(
@@ -423,14 +425,13 @@ private fun ChipEstado(estado: String) {
 }
 
 @Composable
-private fun etiquetaTipoAusencia(tipo: String): String {
+private fun etiquetaTipoAusencia(tipo: TipoAusencia): String {
     val resId = when (tipo) {
-        "MEDICA" -> R.string.ausencia_tipo_medica
-        "VACACIONES" -> R.string.ausencia_tipo_vacaciones
-        "MOTIVO_PERSONAL" -> R.string.ausencia_tipo_motivo_personal
-        "OTROS" -> R.string.ausencia_tipo_otros
-        else -> null
+        TipoAusencia.MEDICA -> R.string.ausencia_tipo_medica
+        TipoAusencia.VACACIONES -> R.string.ausencia_tipo_vacaciones
+        TipoAusencia.MOTIVO_PERSONAL -> R.string.ausencia_tipo_motivo_personal
+        TipoAusencia.OTROS -> R.string.ausencia_tipo_otros
     }
-    return resId?.let { stringResource(it) } ?: tipo
+    return stringResource(resId)
 }
 

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
@@ -590,7 +590,7 @@ private fun CampoFecha(
     fecha: LocalDate?,
     errorRes: Int?,
     onFechaSeleccionada: (LocalDate) -> Unit,
-    fechaMinima: LocalDate
+    fechaMinima: LocalDate?
 ) {
     var mostrandoSelector by remember { mutableStateOf(false) }
     val texto = fecha?.format(SolicitudAusenciaViewModel.FORMATO_FECHA) ?: ""
@@ -614,7 +614,7 @@ private fun CampoFecha(
 
     if (mostrandoSelector) {
         val estadoPicker = rememberDatePickerState(
-            initialSelectedDateMillis = (fecha ?: fechaMinima)
+            initialSelectedDateMillis = (fecha ?: LocalDate.now())
                 .atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
         )
         DatePickerDialog(

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/PantallaSolicitudAusencia.kt
@@ -83,6 +83,7 @@ import kotlinx.coroutines.withContext
 import com.gestorrh.android.R
 import com.gestorrh.android.core.archivos.GestorArchivosJustificante
 import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.ausencia.TipoAusencia
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -543,8 +544,12 @@ private fun DesplegableTipo(
     var expandido by remember { mutableStateOf(false) }
     Box(modifier = Modifier.fillMaxWidth()) {
         OutlinedTextField(
-            value = estadoUi.tipoSeleccionado?.let { etiquetaTipo(it) }
-                ?: if (estadoUi.cargandoTipos) stringResource(R.string.ausencia_cargando_tipos) else "",
+            value = estadoUi.tipoSeleccionado?.let { tipo ->
+                runCatching { TipoAusencia.valueOf(tipo) }
+                    .getOrNull()
+                    ?.let { etiquetaTipo(it) }
+                    ?: tipo
+            }  ?: if (estadoUi.cargandoTipos) stringResource(R.string.ausencia_cargando_tipos) else "",
             onValueChange = {},
             readOnly = true,
             label = { Text(stringResource(R.string.ausencia_label_tipo)) },
@@ -567,7 +572,7 @@ private fun DesplegableTipo(
         ) {
             estadoUi.tiposDisponibles.forEach { tipo ->
                 DropdownMenuItem(
-                    text = { Text(etiquetaTipo(tipo)) },
+                    text = { Text(runCatching { TipoAusencia.valueOf(tipo) }.getOrNull()?.let { etiquetaTipo(it) } ?: tipo) },
                     onClick = {
                         viewModel.seleccionarTipo(tipo)
                         expandido = false
@@ -666,13 +671,12 @@ private fun MiniaturaImagen(uri: Uri, modifier: Modifier = Modifier) {
 }
 
 @Composable
-private fun etiquetaTipo(tipo: String): String {
+private fun etiquetaTipo(tipo: TipoAusencia): String {
     val resId = when (tipo) {
-        "MEDICA" -> R.string.ausencia_tipo_medica
-        "VACACIONES" -> R.string.ausencia_tipo_vacaciones
-        "MOTIVO_PERSONAL" -> R.string.ausencia_tipo_motivo_personal
-        "OTROS" -> R.string.ausencia_tipo_otros
-        else -> null
+        TipoAusencia.MEDICA -> R.string.ausencia_tipo_medica
+        TipoAusencia.VACACIONES -> R.string.ausencia_tipo_vacaciones
+        TipoAusencia.MOTIVO_PERSONAL -> R.string.ausencia_tipo_motivo_personal
+        TipoAusencia.OTROS -> R.string.ausencia_tipo_otros
     }
-    return resId?.let { stringResource(it) } ?: tipo
+    return stringResource(resId)
 }

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
@@ -106,17 +106,12 @@ class SolicitudAusenciaViewModel(
 
     fun cambiarFechaInicio(fecha: LocalDate) {
         _estadoUi.update {
-            val errorInicio = if (fecha.isBefore(LocalDate.now())) {
-                R.string.ausencia_error_fecha_inicio_pasada
-            } else {
-                null
-            }
             val errorFin = if (it.fechaFin != null && it.fechaFin.isBefore(fecha)) {
                 R.string.ausencia_error_fecha_fin_anterior
             } else {
                 null
             }
-            it.copy(fechaInicio = fecha, errorFechaInicio = errorInicio, errorFechaFin = errorFin)
+            it.copy(fechaInicio = fecha, errorFechaInicio = null, errorFechaFin = errorFin)
         }
     }
 
@@ -309,13 +304,6 @@ class SolicitudAusenciaViewModel(
                 }
                 .onFailure { error ->
                     when (error) {
-                        SolicitarAusenciaUseCase.ErrorValidacion.FechaInicioPasada ->
-                            _estadoUi.update {
-                                it.copy(
-                                    enviando = false,
-                                    errorFechaInicio = R.string.ausencia_error_fecha_inicio_pasada
-                                )
-                            }
                         SolicitarAusenciaUseCase.ErrorValidacion.FechaFinAnterior ->
                             _estadoUi.update {
                                 it.copy(

--- a/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/ausencia/SolicitudAusenciaViewModel.kt
@@ -11,6 +11,7 @@ import com.gestorrh.android.core.network.ApiClient
 import com.gestorrh.android.core.security.SessionManager
 import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.network.ausencia.AusenciaApiService
+import com.gestorrh.android.data.network.ausencia.TipoAusencia
 import com.gestorrh.android.data.repository.ausencia.AusenciaRepositoryImpl
 import com.gestorrh.android.domain.repository.IAusenciaRepository
 import com.gestorrh.android.domain.usecase.ausencia.SolicitarAusenciaUseCase
@@ -381,7 +382,7 @@ class SolicitudAusenciaViewModel(
     }
 
     private fun calcularAviso(tipo: String?, hayArchivo: Boolean): Int? {
-        return if (tipo == "MEDICA" && !hayArchivo) {
+        return if (tipo == TipoAusencia.MEDICA.name && !hayArchivo) {
             R.string.ausencia_aviso_justificante_medica
         } else {
             null

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -17,6 +17,8 @@ import com.gestorrh.android.data.local.dao.FichajePendienteDao
 import com.gestorrh.android.data.local.entity.FichajePendienteEntity
 import com.gestorrh.android.data.network.asignacion.AsignacionApiService
 import com.gestorrh.android.data.network.ausencia.AusenciaApiService
+import com.gestorrh.android.data.network.ausencia.EstadoAusencia
+import com.gestorrh.android.data.network.ausencia.TipoAusencia
 import com.gestorrh.android.data.network.fichaje.FichajeApiService
 import com.gestorrh.android.data.network.fichaje.ModalidadTurno
 import com.gestorrh.android.data.network.fichaje.PeticionFichajeEntradaDTO
@@ -82,10 +84,10 @@ data class ResumenProximoTurno(
  * para que el UI traduzca tipo y estado a recursos.
  */
 data class ResumenProximaAusencia(
-    val tipo: String,
+    val tipo: TipoAusencia,
     val fechaInicio: LocalDate,
     val fechaFin: LocalDate,
-    val estado: String
+    val estado: EstadoAusencia
 )
 
 enum class EstadoFichaje {
@@ -212,7 +214,7 @@ class DashboardViewModel(
             val ausencias = resultado.getOrNull() ?: return@launch
             val hoy = LocalDate.now()
             val proxima = ausencias
-                .filter { it.estado == ESTADO_AUSENCIA_SOLICITADA || it.estado == ESTADO_AUSENCIA_APROBADA }
+                .filter { it.estado == EstadoAusencia.SOLICITADA || it.estado == EstadoAusencia.APROBADA }
                 .filter { !it.fechaFin.isBefore(hoy) }
                 .minByOrNull { it.fechaInicio }
                 ?.let { dto ->
@@ -495,11 +497,6 @@ class DashboardViewModel(
         val minutos = (segundosTotales % 3600) / 60
         val segundos = segundosTotales % 60
         return String.format(java.util.Locale.ROOT, "%02d:%02d:%02d", horas, minutos, segundos)
-    }
-
-    companion object {
-        private const val ESTADO_AUSENCIA_SOLICITADA = "SOLICITADA"
-        private const val ESTADO_AUSENCIA_APROBADA = "APROBADA"
     }
 }
 

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -56,6 +56,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.core.app.ActivityCompat
+import com.gestorrh.android.data.network.ausencia.EstadoAusencia
+import com.gestorrh.android.data.network.ausencia.TipoAusencia
 
 @Composable
 fun PantallaDashboard(
@@ -401,9 +403,9 @@ private fun TarjetaProximaAusencia(
     val etiquetaEstado = stringResource(
         id = AusenciaUtils.obtenerStringEstado(proximaAusencia.estado)
     )
-    val colorEstado = when (proximaAusencia.estado.uppercase()) {
-        "SOLICITADA" -> SemanticWarning
-        "APROBADA" -> SemanticSuccess
+    val colorEstado = when (proximaAusencia.estado) {
+        EstadoAusencia.SOLICITADA -> SemanticWarning
+        EstadoAusencia.APROBADA -> SemanticSuccess
         else -> MaterialTheme.colorScheme.onSurfaceVariant
     }
     TarjetaInformativa(
@@ -418,15 +420,14 @@ private fun TarjetaProximaAusencia(
 }
 
 @Composable
-private fun etiquetaTipoAusenciaDashboard(tipo: String): String {
+private fun etiquetaTipoAusenciaDashboard(tipo: TipoAusencia): String {
     val resId = when (tipo) {
-        "MEDICA" -> R.string.ausencia_tipo_medica
-        "VACACIONES" -> R.string.ausencia_tipo_vacaciones
-        "MOTIVO_PERSONAL" -> R.string.ausencia_tipo_motivo_personal
-        "OTROS" -> R.string.ausencia_tipo_otros
-        else -> null
+        TipoAusencia.MEDICA -> R.string.ausencia_tipo_medica
+        TipoAusencia.VACACIONES -> R.string.ausencia_tipo_vacaciones
+        TipoAusencia.MOTIVO_PERSONAL -> R.string.ausencia_tipo_motivo_personal
+        TipoAusencia.OTROS -> R.string.ausencia_tipo_otros
     }
-    return resId?.let { stringResource(it) } ?: tipo
+    return stringResource(resId)
 }
 
 @Composable

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/PantallaGestionEquipo.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/PantallaGestionEquipo.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.gestorrh.android.R
+import com.gestorrh.android.ui.equipo.ausencias.PantallaAusenciasEquipo
 import com.gestorrh.android.ui.equipo.cuadrante.PantallaCuadranteDepartamento
 import com.gestorrh.android.ui.equipo.fichajes.PantallaModificacionFichajes
 
@@ -73,6 +74,7 @@ fun PantallaGestionEquipo() {
             }
 
             when (tabSeleccionada) {
+                0 -> PantallaAusenciasEquipo()
                 1 -> PantallaCuadranteDepartamento()
                 2 -> PantallaModificacionFichajes()
                 else -> PlaceholderProximamente()

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/AusenciasEquipoViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/AusenciasEquipoViewModel.kt
@@ -63,7 +63,12 @@ class AusenciasEquipoViewModel(
             _estadoUi.update { it.copy(cargando = true, mensajeError = null) }
             obtenerAusenciasEquipoUseCase(_estadoUi.value.filtroActivo)
                 .onSuccess { lista ->
-                    _estadoUi.update { it.copy(cargando = false, ausencias = lista) }
+                    val listaOrdenada = lista
+                        .sortedWith(
+                            compareBy<RespuestaAusenciaDTO> { it.nombreCompletoEmpleado ?: "" }
+                                .thenByDescending { it.fechaInicio }
+                        )
+                    _estadoUi.update { it.copy(cargando = false, ausencias = listaOrdenada) }
                 }
                 .onFailure { error ->
                     _estadoUi.update {

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/AusenciasEquipoViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/AusenciasEquipoViewModel.kt
@@ -1,0 +1,248 @@
+package com.gestorrh.android.ui.equipo.ausencias
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.gestorrh.android.R
+import com.gestorrh.android.core.archivos.GestorArchivosJustificante
+import com.gestorrh.android.core.network.ApiClient
+import com.gestorrh.android.core.security.SessionManager
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.ausencia.AusenciaApiService
+import com.gestorrh.android.data.network.ausencia.EstadoAusencia
+import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
+import com.gestorrh.android.data.repository.ausencia.AusenciaRepositoryImpl
+import com.gestorrh.android.domain.repository.IAusenciaRepository
+import com.gestorrh.android.domain.usecase.supervisor.ObtenerAusenciasEquipoUseCase
+import com.gestorrh.android.domain.usecase.supervisor.RevisarAusenciaUseCase
+import com.gestorrh.android.ui.ausencia.JustificanteParaAbrir
+import com.google.gson.Gson
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.io.IOException
+
+/**
+ * ViewModel de la pantalla de validación de ausencias del equipo para el rol SUPERVISOR.
+ *
+ * Responsabilidades:
+ * - Carga las ausencias del departamento filtrando por [EstadoAusencia], mostrando
+ *   por defecto las solicitudes pendientes ([EstadoAusencia.SOLICITADA]) al entrar.
+ * - Gestiona el cambio de filtro recargando la lista desde el servidor.
+ * - Aplica actualización optimista tanto en aprobación como en rechazo: el item
+ *   se actualiza en la lista local de forma inmediata y se revierte si la llamada
+ *   de red falla, mostrando el error en un Snackbar.
+ * - Gestiona el estado del diálogo de rechazo mediante [EstadoUiAusenciasEquipo.ausenciaARechazar].
+ * - Descarga justificantes con el mismo patrón que [com.gestorrh.android.ui.ausencia.MisAusenciasViewModel],
+ *   delegando en [GestorArchivosJustificante] para el caché y apertura con el visor del sistema.
+ *
+ * @property obtenerAusenciasEquipoUseCase Caso de uso para listar ausencias del departamento.
+ * @property revisarAusenciaUseCase Caso de uso que valida y ejecuta la aprobación o rechazo.
+ * @property ausenciaRepository Repositorio usado directamente para la descarga de justificantes.
+ * @property contextoAplicacion Contexto de aplicación necesario para [GestorArchivosJustificante].
+ */
+class AusenciasEquipoViewModel(
+    private val obtenerAusenciasEquipoUseCase: ObtenerAusenciasEquipoUseCase,
+    private val revisarAusenciaUseCase: RevisarAusenciaUseCase,
+    private val ausenciaRepository: IAusenciaRepository,
+    private val contextoAplicacion: Context
+) : ViewModel() {
+
+    private val _estadoUi = MutableStateFlow(EstadoUiAusenciasEquipo())
+    val estadoUi: StateFlow<EstadoUiAusenciasEquipo> = _estadoUi.asStateFlow()
+
+    init {
+        cargarAusencias()
+    }
+
+    fun cargarAusencias() {
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(cargando = true, mensajeError = null) }
+            obtenerAusenciasEquipoUseCase(_estadoUi.value.filtroActivo)
+                .onSuccess { lista ->
+                    _estadoUi.update { it.copy(cargando = false, ausencias = lista) }
+                }
+                .onFailure { error ->
+                    _estadoUi.update {
+                        it.copy(
+                            cargando = false,
+                            mensajeError = mensajeDesdeError(error)
+                        )
+                    }
+                }
+        }
+    }
+
+    fun cambiarFiltro(estado: EstadoAusencia?) {
+        _estadoUi.update { it.copy(filtroActivo = estado) }
+        cargarAusencias()
+    }
+
+    fun aprobarAusencia(id: Long, observaciones: String? = null) {
+        if (_estadoUi.value.revisando != null) return
+        val listaOriginal = _estadoUi.value.ausencias
+        _estadoUi.update { estado ->
+            estado.copy(
+                revisando = id,
+                ausencias = estado.ausencias.map { ausencia ->
+                    if (ausencia.idAusencia == id) {
+                        ausencia.copy(estado = EstadoAusencia.APROBADA)
+                    } else {
+                        ausencia
+                    }
+                }
+            )
+        }
+        viewModelScope.launch {
+            revisarAusenciaUseCase(id, EstadoAusencia.APROBADA, observaciones)
+                .onSuccess { actualizada ->
+                    _estadoUi.update { estado ->
+                        estado.copy(
+                            revisando = null,
+                            ausencias = estado.ausencias.map { ausencia ->
+                                if (ausencia.idAusencia == id) actualizada else ausencia
+                            },
+                            mensajeExito = MensajeUi.Recurso(R.string.ausencias_equipo_aprobada_ok)
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _estadoUi.update {
+                        it.copy(
+                            revisando = null,
+                            ausencias = listaOriginal,
+                            mensajeError = mensajeDesdeError(error)
+                        )
+                    }
+                }
+        }
+    }
+
+    fun iniciarAprobacion(ausencia: RespuestaAusenciaDTO) {
+        _estadoUi.update { it.copy(ausenciaAAprobar = ausencia) }
+    }
+
+    fun cerrarDialogAprobacion() {
+        _estadoUi.update { it.copy(ausenciaAAprobar = null) }
+    }
+
+    fun iniciarRechazo(ausencia: RespuestaAusenciaDTO) {
+        _estadoUi.update { it.copy(ausenciaARechazar = ausencia) }
+    }
+
+    fun confirmarRechazo(observaciones: String?) {
+        val ausencia = _estadoUi.value.ausenciaARechazar ?: return
+        if (_estadoUi.value.revisando != null) return
+        val id = ausencia.idAusencia
+        val listaOriginal = _estadoUi.value.ausencias
+        _estadoUi.update { estado ->
+            estado.copy(
+                revisando = id,
+                ausenciaARechazar = null,
+                ausencias = estado.ausencias.map {
+                    if (it.idAusencia == id) it.copy(estado = EstadoAusencia.RECHAZADA) else it
+                }
+            )
+        }
+        viewModelScope.launch {
+            revisarAusenciaUseCase(id, EstadoAusencia.RECHAZADA, observaciones)
+                .onSuccess { actualizada ->
+                    _estadoUi.update { estado ->
+                        estado.copy(
+                            revisando = null,
+                            ausencias = estado.ausencias.map {
+                                if (it.idAusencia == id) actualizada else it
+                            },
+                            mensajeExito = MensajeUi.Recurso(R.string.ausencias_equipo_rechazada_ok)
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _estadoUi.update {
+                        it.copy(
+                            revisando = null,
+                            ausencias = listaOriginal,
+                            mensajeError = mensajeDesdeError(error)
+                        )
+                    }
+                }
+        }
+    }
+
+    fun cerrarDialogRechazo() {
+        _estadoUi.update { it.copy(ausenciaARechazar = null) }
+    }
+
+    fun descargarJustificante(idAusencia: Long, nombreArchivo: String) {
+        if (_estadoUi.value.descargandoJustificanteDe != null) return
+        viewModelScope.launch {
+            _estadoUi.update { it.copy(descargandoJustificanteDe = idAusencia) }
+            ausenciaRepository.descargarJustificante(nombreArchivo)
+                .onSuccess { bytes ->
+                    val uri = GestorArchivosJustificante.guardarEnCacheYObtenerUri(
+                        contextoAplicacion, bytes, nombreArchivo
+                    )
+                    _estadoUi.update {
+                        it.copy(
+                            descargandoJustificanteDe = null,
+                            abrirJustificante = JustificanteParaAbrir(uri, nombreArchivo)
+                        )
+                    }
+                }
+                .onFailure { error ->
+                    _estadoUi.update {
+                        it.copy(
+                            descargandoJustificanteDe = null,
+                            mensajeError = mensajeDesdeError(error)
+                        )
+                    }
+                }
+        }
+    }
+
+    fun aperturaJustificanteConsumida() {
+        _estadoUi.update { it.copy(abrirJustificante = null) }
+    }
+
+    fun notificarSinVisorDisponible() {
+        _estadoUi.update {
+            it.copy(mensajeError = MensajeUi.Recurso(R.string.ausencia_error_sin_visor))
+        }
+    }
+
+    fun errorMostrado() {
+        _estadoUi.update { it.copy(mensajeError = null) }
+    }
+
+    fun exitoMostrado() {
+        _estadoUi.update { it.copy(mensajeExito = null) }
+    }
+
+    private fun mensajeDesdeError(error: Throwable): MensajeUi =
+        if (error is IOException) MensajeUi.Recurso(R.string.error_conexion)
+        else MensajeUi.Dinamico(error.message ?: "")
+
+    companion object {
+        fun factory(contexto: Context): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val sessionManager = SessionManager(contexto)
+                    val retrofit = ApiClient.crearRetrofit(sessionManager)
+                    val apiService = retrofit.create(AusenciaApiService::class.java)
+                    val repository = AusenciaRepositoryImpl(apiService, Gson())
+                    val obtenerUseCase = ObtenerAusenciasEquipoUseCase(repository)
+                    val revisarUseCase = RevisarAusenciaUseCase(repository)
+                    return AusenciasEquipoViewModel(
+                        obtenerAusenciasEquipoUseCase = obtenerUseCase,
+                        revisarAusenciaUseCase = revisarUseCase,
+                        ausenciaRepository = repository,
+                        contextoAplicacion = contexto.applicationContext
+                    ) as T
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/EstadoUiAusenciasEquipo.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/EstadoUiAusenciasEquipo.kt
@@ -1,0 +1,19 @@
+package com.gestorrh.android.ui.equipo.ausencias
+
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.ausencia.EstadoAusencia
+import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
+import com.gestorrh.android.ui.ausencia.JustificanteParaAbrir
+
+data class EstadoUiAusenciasEquipo(
+    val ausencias: List<RespuestaAusenciaDTO> = emptyList(),
+    val cargando: Boolean = false,
+    val filtroActivo: EstadoAusencia? = EstadoAusencia.SOLICITADA,
+    val mensajeError: MensajeUi? = null,
+    val mensajeExito: MensajeUi? = null,
+    val revisando: Long? = null,
+    val ausenciaAAprobar: RespuestaAusenciaDTO? = null,
+    val ausenciaARechazar: RespuestaAusenciaDTO? = null,
+    val descargandoJustificanteDe: Long? = null,
+    val abrirJustificante: JustificanteParaAbrir? = null
+)

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/PantallaAusenciasEquipo.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/PantallaAusenciasEquipo.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -115,13 +116,9 @@ fun PantallaAusenciasEquipo(
         }
     }
 
-    Scaffold(
-        snackbarHost = { SnackbarHost(snackbarHostState) }
-    ) { padding ->
+    Box(modifier = Modifier.fillMaxSize()) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
+            modifier = Modifier.fillMaxSize()
         ) {
             FilaFiltros(
                 filtroActivo = estadoUi.filtroActivo,
@@ -144,11 +141,9 @@ fun PantallaAusenciasEquipo(
                             CircularProgressIndicator()
                         }
                     }
-
                     estadoUi.ausencias.isEmpty() -> EstadoVacio(
                         modifier = Modifier.fillMaxSize()
                     )
-
                     else -> ListaAusencias(
                         ausencias = estadoUi.ausencias,
                         revisando = estadoUi.revisando,
@@ -164,6 +159,11 @@ fun PantallaAusenciasEquipo(
                 }
             }
         }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        )
     }
 
     estadoUi.ausenciaARechazar?.let { ausencia ->
@@ -229,21 +229,54 @@ private fun ListaAusencias(
     onRechazar: (RespuestaAusenciaDTO) -> Unit,
     onDescargarJustificante: (RespuestaAusenciaDTO) -> Unit
 ) {
+    val grupos = remember(ausencias) {
+        ausencias.groupBy { it.nombreCompletoEmpleado ?: "" }
+    }
+
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        items(ausencias, key = { it.idAusencia }) { ausencia ->
-            TarjetaAusenciaEquipo(
-                ausencia = ausencia,
-                revisando = revisando == ausencia.idAusencia,
-                descargandoJustificante = descargandoJustificanteDe == ausencia.idAusencia,
-                onAprobar = { onAprobar(ausencia) },
-                onRechazar = { onRechazar(ausencia) },
-                onDescargarJustificante = { onDescargarJustificante(ausencia) }
-            )
+        grupos.forEach { (nombre, ausenciasEmpleado) ->
+            item(key = "empleado_$nombre") {
+                SeparadorEmpleado(nombre = nombre)
+                Spacer(modifier = Modifier.height(6.dp))
+            }
+            items(ausenciasEmpleado, key = { it.idAusencia }) { ausencia ->
+                TarjetaAusenciaEquipo(
+                    ausencia = ausencia,
+                    revisando = revisando == ausencia.idAusencia,
+                    descargandoJustificante = descargandoJustificanteDe == ausencia.idAusencia,
+                    onAprobar = { onAprobar(ausencia) },
+                    onRechazar = { onRechazar(ausencia) },
+                    onDescargarJustificante = { onDescargarJustificante(ausencia) }
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
         }
+    }
+}
+
+@Composable
+private fun SeparadorEmpleado(nombre: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp, bottom = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = nombre,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.outlineVariant
+        )
     }
 }
 

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/PantallaAusenciasEquipo.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/PantallaAusenciasEquipo.kt
@@ -1,0 +1,544 @@
+package com.gestorrh.android.ui.equipo.ausencias
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.EventBusy
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.gestorrh.android.R
+import com.gestorrh.android.core.archivos.GestorArchivosJustificante
+import com.gestorrh.android.core.ui.MensajeUi
+import com.gestorrh.android.data.network.ausencia.EstadoAusencia
+import com.gestorrh.android.data.network.ausencia.RespuestaAusenciaDTO
+import com.gestorrh.android.data.network.ausencia.TipoAusencia
+import com.gestorrh.android.ui.ausencia.AusenciaUtils
+import com.gestorrh.android.ui.theme.SemanticError
+import com.gestorrh.android.ui.theme.SemanticSuccess
+import java.time.format.DateTimeFormatter
+
+private val FormatoFecha: DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PantallaAusenciasEquipo(
+    contexto: Context = LocalContext.current,
+    viewModel: AusenciasEquipoViewModel = viewModel(
+        factory = AusenciasEquipoViewModel.factory(contexto.applicationContext)
+    )
+) {
+    val estadoUi by viewModel.estadoUi.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val recursos = LocalResources.current
+    val contextoLocal = LocalContext.current
+
+    LaunchedEffect(estadoUi.mensajeError) {
+        estadoUi.mensajeError?.let { mensaje ->
+            val texto = when (mensaje) {
+                is MensajeUi.Recurso -> recursos.getString(mensaje.idRecurso)
+                is MensajeUi.Dinamico -> mensaje.texto
+            }
+            snackbarHostState.showSnackbar(texto, duration = SnackbarDuration.Long)
+            viewModel.errorMostrado()
+        }
+    }
+
+    LaunchedEffect(estadoUi.mensajeExito) {
+        estadoUi.mensajeExito?.let { mensaje ->
+            val texto = when (mensaje) {
+                is MensajeUi.Recurso -> recursos.getString(mensaje.idRecurso)
+                is MensajeUi.Dinamico -> mensaje.texto
+            }
+            snackbarHostState.showSnackbar(texto, duration = SnackbarDuration.Short)
+            viewModel.exitoMostrado()
+        }
+    }
+
+    LaunchedEffect(estadoUi.abrirJustificante) {
+        estadoUi.abrirJustificante?.let { evento ->
+            val abierto = GestorArchivosJustificante.abrirConVisorSistema(
+                contextoLocal, evento.uri, evento.nombreArchivo
+            )
+            viewModel.aperturaJustificanteConsumida()
+            if (!abierto) viewModel.notificarSinVisorDisponible()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            FilaFiltros(
+                filtroActivo = estadoUi.filtroActivo,
+                onFiltroSeleccionado = viewModel::cambiarFiltro
+            )
+
+            HorizontalDivider()
+
+            PullToRefreshBox(
+                isRefreshing = estadoUi.cargando && estadoUi.ausencias.isNotEmpty(),
+                onRefresh = viewModel::cargarAusencias,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                when {
+                    estadoUi.cargando && estadoUi.ausencias.isEmpty() -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    }
+
+                    estadoUi.ausencias.isEmpty() -> EstadoVacio(
+                        modifier = Modifier.fillMaxSize()
+                    )
+
+                    else -> ListaAusencias(
+                        ausencias = estadoUi.ausencias,
+                        revisando = estadoUi.revisando,
+                        descargandoJustificanteDe = estadoUi.descargandoJustificanteDe,
+                        onAprobar = viewModel::iniciarAprobacion,
+                        onRechazar = viewModel::iniciarRechazo,
+                        onDescargarJustificante = { ausencia ->
+                            ausencia.justificante?.let { nombre ->
+                                viewModel.descargarJustificante(ausencia.idAusencia, nombre)
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    estadoUi.ausenciaARechazar?.let { ausencia ->
+        DialogRechazo(
+            ausencia = ausencia,
+            onConfirmar = viewModel::confirmarRechazo,
+            onDescartar = viewModel::cerrarDialogRechazo
+        )
+    }
+
+    estadoUi.ausenciaAAprobar?.let { ausencia ->
+        DialogAprobacion(
+            ausencia = ausencia,
+            onConfirmar = { observaciones ->
+                viewModel.aprobarAusencia(ausencia.idAusencia, observaciones)
+                viewModel.cerrarDialogAprobacion()
+            },
+            onDescartar = viewModel::cerrarDialogAprobacion
+        )
+    }
+}
+
+@Composable
+private fun FilaFiltros(
+    filtroActivo: EstadoAusencia?,
+    onFiltroSeleccionado: (EstadoAusencia?) -> Unit
+) {
+    data class OpcionFiltro(val estado: EstadoAusencia?, val etiquetaRes: Int)
+
+    val opciones = listOf(
+        OpcionFiltro(null, R.string.ausencias_equipo_filtro_todos),
+        OpcionFiltro(EstadoAusencia.SOLICITADA, R.string.ausencias_equipo_filtro_solicitadas),
+        OpcionFiltro(EstadoAusencia.APROBADA, R.string.ausencias_equipo_filtro_aprobadas),
+        OpcionFiltro(EstadoAusencia.RECHAZADA, R.string.ausencias_equipo_filtro_rechazadas)
+    )
+
+    LazyRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(opciones) { opcion ->
+            FilterChip(
+                selected = filtroActivo == opcion.estado,
+                onClick = { onFiltroSeleccionado(opcion.estado) },
+                label = { Text(stringResource(opcion.etiquetaRes)) },
+                colors = FilterChipDefaults.filterChipColors(
+                    selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun ListaAusencias(
+    ausencias: List<RespuestaAusenciaDTO>,
+    revisando: Long?,
+    descargandoJustificanteDe: Long?,
+    onAprobar: (RespuestaAusenciaDTO) -> Unit,
+    onRechazar: (RespuestaAusenciaDTO) -> Unit,
+    onDescargarJustificante: (RespuestaAusenciaDTO) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        items(ausencias, key = { it.idAusencia }) { ausencia ->
+            TarjetaAusenciaEquipo(
+                ausencia = ausencia,
+                revisando = revisando == ausencia.idAusencia,
+                descargandoJustificante = descargandoJustificanteDe == ausencia.idAusencia,
+                onAprobar = { onAprobar(ausencia) },
+                onRechazar = { onRechazar(ausencia) },
+                onDescargarJustificante = { onDescargarJustificante(ausencia) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun TarjetaAusenciaEquipo(
+    ausencia: RespuestaAusenciaDTO,
+    revisando: Boolean,
+    descargandoJustificante: Boolean,
+    onAprobar: (RespuestaAusenciaDTO) -> Unit,
+    onRechazar: (RespuestaAusenciaDTO) -> Unit,
+    onDescargarJustificante: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = ausencia.nombreCompletoEmpleado ?: "",
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = etiquetaTipo(ausencia.tipo),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                if (!ausencia.justificante.isNullOrBlank()) {
+                    IconButton(
+                        onClick = onDescargarJustificante,
+                        enabled = !descargandoJustificante
+                    ) {
+                        if (descargandoJustificante) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(18.dp),
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.Filled.AttachFile,
+                                contentDescription = stringResource(
+                                    R.string.ausencias_equipo_cd_justificante
+                                ),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+                }
+
+                ChipEstado(estado = ausencia.estado)
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(
+                    R.string.mis_ausencias_rango_fechas,
+                    ausencia.fechaInicio.format(FormatoFecha),
+                    ausencia.fechaFin.format(FormatoFecha)
+                ),
+                style = MaterialTheme.typography.bodyMedium
+            )
+
+            if (!ausencia.descripcion.isNullOrBlank()) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = ausencia.descripcion,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            if (!ausencia.observacionesRevision.isNullOrBlank()) {
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = stringResource(
+                        R.string.ausencias_equipo_observaciones,
+                        ausencia.observacionesRevision
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            if (ausencia.estado == EstadoAusencia.SOLICITADA) {
+                Spacer(Modifier.height(12.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Spacer(Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextButton(
+                        onClick = { onAprobar(ausencia) },
+                        enabled = !revisando,
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = SemanticSuccess
+                        )
+                    ) {
+                        if (revisando) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                strokeWidth = 2.dp,
+                                color = SemanticSuccess
+                            )
+                        } else {
+                            Text(stringResource(R.string.ausencias_equipo_btn_aprobar))
+                        }
+                    }
+                    TextButton(
+                        onClick = { onRechazar(ausencia) },
+                        enabled = !revisando,
+                        colors = ButtonDefaults.textButtonColors(
+                            contentColor = SemanticError
+                        )
+                    ) {
+                        Text(stringResource(R.string.ausencias_equipo_btn_rechazar))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChipEstado(estado: EstadoAusencia) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = AusenciaUtils.obtenerColorEstado(estado),
+                shape = RoundedCornerShape(50)
+            )
+            .padding(horizontal = 12.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = stringResource(id = AusenciaUtils.obtenerStringEstado(estado)),
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+@Composable
+private fun DialogRechazo(
+    ausencia: RespuestaAusenciaDTO,
+    onConfirmar: (String?) -> Unit,
+    onDescartar: () -> Unit
+) {
+    var observaciones by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDescartar,
+        title = {
+            Text(stringResource(R.string.ausencias_equipo_dialog_rechazo_titulo))
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = ausencia.nombreCompletoEmpleado ?: "",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                OutlinedTextField(
+                    value = observaciones,
+                    onValueChange = { observaciones = it },
+                    label = {
+                        Text(stringResource(R.string.ausencias_equipo_dialog_rechazo_hint))
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 2,
+                    maxLines = 4
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onConfirmar(observaciones.takeIf { it.isNotBlank() })
+                },
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = SemanticError
+                )
+            ) {
+                Text(stringResource(R.string.ausencias_equipo_dialog_confirmar))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDescartar) {
+                Text(stringResource(R.string.ausencia_dialog_cancelar))
+            }
+        }
+    )
+}
+
+@Composable
+private fun EstadoVacio(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.EventBusy,
+            contentDescription = null,
+            modifier = Modifier.size(72.dp),
+            tint = MaterialTheme.colorScheme.outlineVariant
+        )
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text = stringResource(R.string.ausencias_equipo_vacio_titulo),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.ausencias_equipo_vacio_descripcion),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun etiquetaTipo(tipo: TipoAusencia): String {
+    val resId = when (tipo) {
+        TipoAusencia.MEDICA -> R.string.ausencia_tipo_medica
+        TipoAusencia.VACACIONES -> R.string.ausencia_tipo_vacaciones
+        TipoAusencia.MOTIVO_PERSONAL -> R.string.ausencia_tipo_motivo_personal
+        TipoAusencia.OTROS -> R.string.ausencia_tipo_otros
+    }
+    return stringResource(resId)
+}
+
+@Composable
+private fun DialogAprobacion(
+    ausencia: RespuestaAusenciaDTO,
+    onConfirmar: (String?) -> Unit,
+    onDescartar: () -> Unit
+) {
+    var observaciones by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDescartar,
+        title = {
+            Text(stringResource(R.string.ausencias_equipo_dialog_aprobacion_titulo))
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = ausencia.nombreCompletoEmpleado ?: "",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                OutlinedTextField(
+                    value = observaciones,
+                    onValueChange = { observaciones = it },
+                    label = {
+                        Text(stringResource(R.string.ausencias_equipo_dialog_aprobacion_hint))
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 2,
+                    maxLines = 4
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onConfirmar(observaciones.takeIf { it.isNotBlank() })
+                },
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = SemanticSuccess
+                )
+            ) {
+                Text(stringResource(R.string.ausencias_equipo_dialog_confirmar_aprobacion))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDescartar) {
+                Text(stringResource(R.string.ausencia_dialog_cancelar))
+            }
+        }
+    )
+}
+

--- a/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/principal/PantallaPrincipal.kt
@@ -129,7 +129,7 @@ fun PantallaPrincipal(
                         controladorNavegacionInterno.navigate(
                             RutasDestino.SolicitarAusencia.rutaEditar(
                                 id = ausencia.idAusencia,
-                                tipo = ausencia.tipo,
+                                tipo = ausencia.tipo.name,
                                 fechaInicioIso = ausencia.fechaInicio.toString(),
                                 fechaFinIso = ausencia.fechaFin.toString(),
                                 descripcion = ausencia.descripcion,

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -269,4 +269,26 @@
     <string name="modificacion_fichaje_error_horas">Invalid schedule. For day shifts, clock-out must be after clock-in. For night shifts, clock-in must be from 16:00 and clock-out by 08:00.</string>
     <string name="modificacion_fichaje_error_conflicto">Concurrency conflict — reload and try again</string>
     <string name="modificacion_fichaje_anadir_salida">+ Add clock-out</string>
+
+    <!-- Team Absences Screen (Supervisor) -->
+    <string name="ausencias_equipo_filtro_todos">All</string>
+    <string name="ausencias_equipo_filtro_solicitadas">Pending</string>
+    <string name="ausencias_equipo_filtro_aprobadas">Approved</string>
+    <string name="ausencias_equipo_filtro_rechazadas">Rejected</string>
+    <string name="ausencias_equipo_btn_aprobar">✓ Approve</string>
+    <string name="ausencias_equipo_btn_rechazar">✗ Reject</string>
+    <string name="ausencias_equipo_cd_aprobar">Approve absence</string>
+    <string name="ausencias_equipo_cd_rechazar">Reject absence</string>
+    <string name="ausencias_equipo_cd_justificante">View attachment</string>
+    <string name="ausencias_equipo_dialog_rechazo_titulo">Reject request</string>
+    <string name="ausencias_equipo_dialog_rechazo_hint">Notes (optional)</string>
+    <string name="ausencias_equipo_dialog_confirmar">Confirm rejection</string>
+    <string name="ausencias_equipo_aprobada_ok">Absence approved</string>
+    <string name="ausencias_equipo_rechazada_ok">Absence rejected</string>
+    <string name="ausencias_equipo_vacio_titulo">No requests</string>
+    <string name="ausencias_equipo_vacio_descripcion">No absences in this state for your department</string>
+    <string name="ausencias_equipo_observaciones">Notes: %1$s</string>
+    <string name="ausencias_equipo_dialog_aprobacion_titulo">Approve request</string>
+    <string name="ausencias_equipo_dialog_aprobacion_hint">Notes (optional)</string>
+    <string name="ausencias_equipo_dialog_confirmar_aprobacion">Confirm approval</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -270,4 +270,26 @@
     <string name="modificacion_fichaje_error_horas">Horario inválido. Para turnos diurnos la salida debe ser posterior a la entrada. Para turnos nocturnos la entrada debe ser desde las 16:00 y la salida hasta las 08:00.</string>
     <string name="modificacion_fichaje_error_conflicto">Conflicto de concurrencia — recarga e inténtalo de nuevo</string>
     <string name="modificacion_fichaje_anadir_salida">+ Añadir salida</string>
+
+    <!-- Pantalla Ausencias Equipo (Supervisor) -->
+    <string name="ausencias_equipo_filtro_todos">Todas</string>
+    <string name="ausencias_equipo_filtro_solicitadas">Pendientes</string>
+    <string name="ausencias_equipo_filtro_aprobadas">Aprobadas</string>
+    <string name="ausencias_equipo_filtro_rechazadas">Rechazadas</string>
+    <string name="ausencias_equipo_btn_aprobar">✓ Aprobar</string>
+    <string name="ausencias_equipo_btn_rechazar">✗ Rechazar</string>
+    <string name="ausencias_equipo_cd_aprobar">Aprobar ausencia</string>
+    <string name="ausencias_equipo_cd_rechazar">Rechazar ausencia</string>
+    <string name="ausencias_equipo_cd_justificante">Ver justificante</string>
+    <string name="ausencias_equipo_dialog_rechazo_titulo">Rechazar solicitud</string>
+    <string name="ausencias_equipo_dialog_rechazo_hint">Observaciones (opcional)</string>
+    <string name="ausencias_equipo_dialog_confirmar">Confirmar rechazo</string>
+    <string name="ausencias_equipo_aprobada_ok">Ausencia aprobada</string>
+    <string name="ausencias_equipo_rechazada_ok">Ausencia rechazada</string>
+    <string name="ausencias_equipo_vacio_titulo">Sin solicitudes</string>
+    <string name="ausencias_equipo_vacio_descripcion">No hay ausencias en este estado para tu departamento</string>
+    <string name="ausencias_equipo_observaciones">Observaciones: %1$s</string>
+    <string name="ausencias_equipo_dialog_aprobacion_titulo">Aprobar solicitud</string>
+    <string name="ausencias_equipo_dialog_aprobacion_hint">Observaciones (opcional)</string>
+    <string name="ausencias_equipo_dialog_confirmar_aprobacion">Confirmar aprobación</string>
 </resources>


### PR DESCRIPTION
## Descripción
Implementa la subsección de Ausencias dentro de la pantalla de Gestión Equipo, permitiendo al supervisor visualizar, filtrar, aprobar y rechazar las solicitudes de ausencia de su departamento.

## Cambios implementados

### Data Layer
- Tipado de `estado` y `tipo` en `RespuestaAusenciaDTO` con enums `EstadoAusencia` y `TipoAusencia`
- Nuevo DTO `PeticionRevisionAusenciaDTO`
- Nuevos endpoints en `AusenciaApiService`: `getAusenciasEquipo` y `revisarAusencia`
- Nuevos métodos en `IAusenciaRepository` y `AusenciaRepositoryImpl`

### Domain Layer
- `ObtenerAusenciasEquipoUseCase` — lista ausencias del departamento con filtro por estado
- `RevisarAusenciaUseCase` — valida y ejecuta aprobación o rechazo de una ausencia

### Presentation Layer
- `PantallaAusenciasEquipo` con filtros por estado, agrupación por empleado y orden por fecha descendente
- `AusenciasEquipoViewModel` con actualización optimista en aprobación y rechazo
- Diálogo de observaciones opcionales tanto en aprobación como en rechazo
- Descarga y previsualización de justificantes adjuntos
- Conectado al tab de Ausencias en `PantallaGestionEquipo`

### Fixes incluidos
- Permitir solicitar ausencias en fechas pasadas y presentes
- Ajuste de todos los usos de `AusenciaUtils` al nuevo tipado de enum

## Issues relacionados
- Closes #41
- Bug pendiente en API: error FK al aprobar ausencias con fichajes asociados
- Feature pendiente en API: validar fichajes en rango al solicitar ausencia