### PR TITLE
fix: adaptar deserialización a OffsetDateTime tras normalización UTC de la API

### DIFF
--- a/app/src/main/java/com/gestorrh/android/core/network/ApiClient.kt
+++ b/app/src/main/java/com/gestorrh/android/core/network/ApiClient.kt
@@ -14,6 +14,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import com.gestorrh.android.core.network.LocalTimeDeserializer
 import java.time.LocalTime
+import java.time.ZoneId
 
 /**
  * Motor central de comunicaciones HTTP de la aplicación.
@@ -48,7 +49,11 @@ object ApiClient {
             .registerTypeAdapter(
                 LocalDateTime::class.java,
                 JsonSerializer<LocalDateTime> { src, _, _ ->
-                    JsonPrimitive(src.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                    JsonPrimitive(
+                        src.atZone(ZoneId.systemDefault())
+                            .toOffsetDateTime()
+                            .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                    )
                 }
             )
             .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())

--- a/app/src/main/java/com/gestorrh/android/core/network/LocalDateTimeDeserializer.kt
+++ b/app/src/main/java/com/gestorrh/android/core/network/LocalDateTimeDeserializer.kt
@@ -5,14 +5,26 @@ import com.google.gson.JsonDeserializer
 import com.google.gson.JsonElement
 import java.lang.reflect.Type
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 /**
- * Enseña a Retrofit (Gson) cómo transformar el String ISO-8601 de Spring Boot
- * en un objeto LocalDateTime de Kotlin.
+ * Enseña a Retrofit (Gson) cómo transformar el String ISO-8601 con offset de la API
+ * en un objeto LocalDateTime en la zona horaria local del dispositivo.
+ *
+ * La API devuelve timestamps con offset explícito (ej: 2026-05-18T17:35:00Z).
+ * El deserializador convierte ese instante al equivalente en hora local del dispositivo,
+ * de forma que el resto del código puede seguir trabajando con LocalDateTime sin cambios.
  */
 class LocalDateTimeDeserializer : JsonDeserializer<LocalDateTime> {
-    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): LocalDateTime {
-        return LocalDateTime.parse(json.asString, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    override fun deserialize(
+        json: JsonElement,
+        typeOfT: Type,
+        context: JsonDeserializationContext
+    ): LocalDateTime {
+        return OffsetDateTime.parse(json.asString, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+            .atZoneSameInstant(ZoneId.systemDefault())
+            .toLocalDateTime()
     }
 }

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -270,10 +270,7 @@ class DashboardViewModel(
 
                     if (datos.trabajandoActualmente && datos.horaEntrada != null) {
                         if (!hayEstadoActivo) {
-                            // TODO: cuando se resuelva GestorRH-API#110 (normalizar fechas a UTC),
-                            //  actualizar LocalDateTimeDeserializer en ApiClient para convertir a hora local
-                            //  y revisar este cálculo si fuera necesario.
-                            val segundos = ChronoUnit.SECONDS.between(datos.horaEntrada, java.time.LocalDateTime.now())
+                            val segundos = ChronoUnit.SECONDS.between(datos.horaEntrada, LocalDateTime.now())
                             segundosAcumulados = segundos.coerceAtLeast(0L)
                             iniciarTemporizador()
                         }

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/DashboardViewModel.kt
@@ -133,12 +133,6 @@ class DashboardViewModel(
     init {
         val nombre = sessionManager.getNombre() ?: ""
         _estadoUi.update { it.copy(nombreEmpleado = nombre) }
-
-        sincronizarEstado()
-        cargarFichajesPendientes()
-        cargarProximoTurno()
-        cargarProximaAusencia()
-        cargarUltimosFichajes()
     }
 
     /**
@@ -151,13 +145,21 @@ class DashboardViewModel(
         viewModelScope.launch {
             val hoy = LocalDate.now()
             val hace7Dias = hoy.minusDays(7)
-            fichajeRepository.obtenerHistorialFichajes(hace7Dias, hoy)
-                .onSuccess { fichajes ->
-                    val ultimos = fichajes
-                        .sortedByDescending { it.horaEntrada }
-                        .take(3)
-                    _estadoUi.update { it.copy(ultimosFichajes = ultimos) }
-                }
+            val resultado = if (sessionManager.isSupervisor()) {
+                fichajeRepository.obtenerHistorialFichajesSupervisor(
+                    fechaInicio = hace7Dias,
+                    fechaFin = hoy,
+                    empleadoId = sessionManager.getId()
+                )
+            } else {
+                fichajeRepository.obtenerHistorialFichajes(hace7Dias, hoy)
+            }
+            resultado.onSuccess { fichajes ->
+                val ultimos = fichajes
+                    .sortedByDescending { it.horaEntrada }
+                    .take(3)
+                _estadoUi.update { it.copy(ultimosFichajes = ultimos) }
+            }
         }
     }
 

--- a/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/dashboard/PantallaDashboard.kt
@@ -76,10 +76,6 @@ fun PantallaDashboard(
     val errorPermisoTexto = stringResource(id = R.string.error_permiso_ubicacion)
     val recursos = LocalResources.current
 
-    LaunchedEffect(Unit) {
-        viewModel.cargarFichajesPendientes()
-    }
-
     val propietarioCicloVida = LocalLifecycleOwner.current
     DisposableEffect(propietarioCicloVida) {
         val observador = LifecycleEventObserver { _, evento ->

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
@@ -394,17 +394,48 @@ private fun ListaFichajes(
     onEditar: (RespuestaFichajeDTO) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val grupos = remember(fichajes) {
+        fichajes.groupBy { it.fecha }.toSortedMap(compareByDescending { it })
+    }
+
     LazyColumn(
         modifier = modifier,
         contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        items(fichajes, key = { it.idFichaje }) { fichaje ->
-            TarjetaFichajeSupervisor(
-                fichaje = fichaje,
-                onEditar = { onEditar(fichaje) }
-            )
+        grupos.forEach { (fecha, fichajesDia) ->
+            item(key = "fecha_$fecha") {
+                SeparadorFecha(fecha = fecha)
+            }
+            items(fichajesDia, key = { it.idFichaje }) { fichaje ->
+                TarjetaFichajeSupervisor(
+                    fichaje = fichaje,
+                    onEditar = { onEditar(fichaje) }
+                )
+            }
         }
+    }
+}
+
+@Composable
+private fun SeparadorFecha(fecha: java.time.LocalDate) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp, bottom = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = fecha.format(FormatoFecha),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = MaterialTheme.colorScheme.outlineVariant
+        )
     }
 }
 

--- a/app/src/main/java/com/gestorrh/android/ui/historial/HistorialFichajesViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/historial/HistorialFichajesViewModel.kt
@@ -10,6 +10,7 @@ import com.gestorrh.android.core.security.SessionManager
 import com.gestorrh.android.core.ui.MensajeUi
 import com.gestorrh.android.data.network.fichaje.FichajeApiService
 import com.gestorrh.android.data.repository.FichajeRepository
+import com.gestorrh.android.domain.repository.IFichajeRepository
 import com.gestorrh.android.domain.usecase.fichaje.ObtenerHistorialFichajesUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -32,7 +33,9 @@ import java.time.LocalDate
  * @property obtenerHistorialFichajesUseCase Caso de uso que devuelve la lista ya ordenada.
  */
 class HistorialFichajesViewModel(
-    private val obtenerHistorialFichajesUseCase: ObtenerHistorialFichajesUseCase
+    private val obtenerHistorialFichajesUseCase: ObtenerHistorialFichajesUseCase,
+    private val fichajeRepository: IFichajeRepository,
+    private val sessionManager: SessionManager
 ) : ViewModel() {
 
     private val _estadoUi = MutableStateFlow(EstadoUiHistorialFichajes())
@@ -51,10 +54,19 @@ class HistorialFichajesViewModel(
             _estadoUi.update { it.copy(cargando = true, mensajeError = null) }
 
             val rango = _estadoUi.value
-            obtenerHistorialFichajesUseCase(
-                fechaInicio = rango.fechaInicio,
-                fechaFin = rango.fechaFin
-            )
+            val resultado = if (sessionManager.isSupervisor()) {
+                fichajeRepository.obtenerHistorialFichajesSupervisor(
+                    fechaInicio = rango.fechaInicio,
+                    fechaFin = rango.fechaFin,
+                    empleadoId = sessionManager.getId()
+                )
+            } else {
+                obtenerHistorialFichajesUseCase(
+                    fechaInicio = rango.fechaInicio,
+                    fechaFin = rango.fechaFin
+                )
+            }
+            resultado
                 .onSuccess { fichajes ->
                     _estadoUi.update { it.copy(cargando = false, fichajes = fichajes) }
                 }
@@ -95,7 +107,7 @@ class HistorialFichajesViewModel(
                     val apiService = retrofit.create(FichajeApiService::class.java)
                     val repository = FichajeRepository(apiService)
                     val useCase = ObtenerHistorialFichajesUseCase(repository)
-                    return HistorialFichajesViewModel(useCase) as T
+                    return HistorialFichajesViewModel(useCase, repository, sessionManager) as T
                 }
             }
         }


### PR DESCRIPTION
## Cambios realizados

### fix: deserialización OffsetDateTime (#85)
- `LocalDateTimeDeserializer` ahora parsea `OffsetDateTime` con offset explícito y convierte a hora local del dispositivo
- `ApiClient` serializa `LocalDateTime` con offset explícito para `PeticionModificacionFichajeDTO`
- Eliminado workaround `ZoneOffset.UTC` del cronómetro en `DashboardViewModel`

### fix: corregir duplicados en dashboard e historial
- Eliminadas llamadas de red del `init` de `DashboardViewModel` (ya las gestiona `ON_RESUME`)
- Eliminado `LaunchedEffect(Unit)` duplicado en `PantallaDashboard`
- El supervisor usa `obtenerHistorialFichajesSupervisor` con su propio id en dashboard e historial personal para ver solo sus fichajes
- El empleado normal mantiene el flujo existente sin cambios

### feat: agrupar fichajes del equipo por fecha
- `PantallaModificacionFichajes` agrupa los fichajes por fecha con separador visual igual al de `PantallaMisTurnos`

## Testing
- `./gradlew test` pasa sin errores
- Verificado con rol EMPLEADO y rol SUPERVISOR
- Verificado en zona horaria `Europe/Madrid`

Closes #85