### PR TITLE
fix: corregir bugs de UI en pantallas de supervisor y sincronización de datos

### DIFF
--- a/app/src/main/java/com/gestorrh/android/data/local/dao/AsignacionDao.kt
+++ b/app/src/main/java/com/gestorrh/android/data/local/dao/AsignacionDao.kt
@@ -2,6 +2,7 @@ package com.gestorrh.android.data.local.dao
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Upsert
 import com.gestorrh.android.data.local.entity.AsignacionEntity
 import kotlinx.coroutines.flow.Flow
@@ -37,4 +38,10 @@ interface AsignacionDao {
      */
     @Query("DELETE FROM asignaciones")
     suspend fun deleteAll()
+
+    @Transaction
+    suspend fun reemplazarTodo(asignaciones: List<AsignacionEntity>) {
+        deleteAll()
+        upsertAll(asignaciones)
+    }
 }

--- a/app/src/main/java/com/gestorrh/android/data/repository/asignacion/AsignacionRepositoryImpl.kt
+++ b/app/src/main/java/com/gestorrh/android/data/repository/asignacion/AsignacionRepositoryImpl.kt
@@ -51,7 +51,7 @@ class AsignacionRepositoryImpl(
             if (respuesta.isSuccessful && respuesta.body() != null) {
                 val ahora = System.currentTimeMillis()
                 val entidades = respuesta.body()!!.map { it.toEntity(ahora) }
-                dao.upsertAll(entidades)
+                dao.reemplazarTodo(entidades)
                 ResultadoSincronizacion.Exito
             } else {
                 val mensaje = extraerMensajeError(respuesta.errorBody())

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/AusenciasEquipoViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/AusenciasEquipoViewModel.kt
@@ -1,8 +1,10 @@
 package com.gestorrh.android.ui.equipo.ausencias
 
 import android.content.Context
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewModelScope
 import com.gestorrh.android.R
 import com.gestorrh.android.core.archivos.GestorArchivosJustificante
@@ -23,6 +25,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
 import java.io.IOException
 
 /**
@@ -76,6 +79,17 @@ class AusenciasEquipoViewModel(
                         )
                     }
                 }
+        }
+    }
+
+    fun iniciarPolling(lifecycle: Lifecycle) {
+        viewModelScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                while (true) {
+                    delay(INTERVALO_POLLING_MS)
+                    cargarAusencias()
+                }
+            }
         }
     }
 
@@ -229,6 +243,8 @@ class AusenciasEquipoViewModel(
         else MensajeUi.Dinamico(error.message ?: "")
 
     companion object {
+        private const val INTERVALO_POLLING_MS = 60_000L
+
         fun factory(contexto: Context): ViewModelProvider.Factory =
             object : ViewModelProvider.Factory {
                 @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/AusenciasEquipoViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/AusenciasEquipoViewModel.kt
@@ -54,9 +54,7 @@ class AusenciasEquipoViewModel(
     private val _estadoUi = MutableStateFlow(EstadoUiAusenciasEquipo())
     val estadoUi: StateFlow<EstadoUiAusenciasEquipo> = _estadoUi.asStateFlow()
 
-    init {
-        cargarAusencias()
-    }
+    init {}
 
     fun cargarAusencias() {
         viewModelScope.launch {

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/PantallaAusenciasEquipo.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/PantallaAusenciasEquipo.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -56,6 +57,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gestorrh.android.R
@@ -83,6 +87,17 @@ fun PantallaAusenciasEquipo(
     val snackbarHostState = remember { SnackbarHostState() }
     val recursos = LocalResources.current
     val contextoLocal = LocalContext.current
+    val propietarioCicloVida = LocalLifecycleOwner.current
+
+    DisposableEffect(propietarioCicloVida) {
+        val observador = LifecycleEventObserver { _, evento ->
+            if (evento == Lifecycle.Event.ON_RESUME) {
+                viewModel.cargarAusencias()
+            }
+        }
+        propietarioCicloVida.lifecycle.addObserver(observador)
+        onDispose { propietarioCicloVida.lifecycle.removeObserver(observador) }
+    }
 
     LaunchedEffect(estadoUi.mensajeError) {
         estadoUi.mensajeError?.let { mensaje ->

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/PantallaAusenciasEquipo.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/ausencias/PantallaAusenciasEquipo.kt
@@ -99,6 +99,10 @@ fun PantallaAusenciasEquipo(
         onDispose { propietarioCicloVida.lifecycle.removeObserver(observador) }
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.iniciarPolling(propietarioCicloVida.lifecycle)
+    }
+
     LaunchedEffect(estadoUi.mensajeError) {
         estadoUi.mensajeError?.let { mensaje ->
             val texto = when (mensaje) {

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/PantallaCuadranteDepartamento.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/cuadrante/PantallaCuadranteDepartamento.kt
@@ -57,6 +57,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -72,6 +73,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gestorrh.android.R
@@ -103,6 +107,17 @@ fun PantallaCuadranteDepartamento(
     val snackbarHostState = remember { SnackbarHostState() }
     val recursos = LocalResources.current
     val textoReintentar = stringResource(R.string.cuadrante_reintentar)
+    val propietarioCicloVida = LocalLifecycleOwner.current
+
+    DisposableEffect(propietarioCicloVida) {
+        val observador = LifecycleEventObserver { _, evento ->
+            if (evento == Lifecycle.Event.ON_RESUME) {
+                viewModel.cargarAsignaciones()
+            }
+        }
+        propietarioCicloVida.lifecycle.addObserver(observador)
+        onDispose { propietarioCicloVida.lifecycle.removeObserver(observador) }
+    }
 
     LaunchedEffect(estadoUi.mensajeError) {
         estadoUi.mensajeError?.let { mensaje ->

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/ModificacionFichajesViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/ModificacionFichajesViewModel.kt
@@ -168,7 +168,10 @@ class ModificacionFichajesViewModel(
         _estadoUi.update { it.copy(dialogMotivo = motivo) }
     }
 
-    fun guardarModificacion() {
+    fun guardarModificacion(
+        nuevaEntrada: LocalDateTime,
+        nuevaSalida: LocalDateTime?
+    ) {
         val estado = _estadoUi.value
         val fichaje = estado.fichajeEditando ?: return
         if (estado.guardando) return
@@ -178,8 +181,8 @@ class ModificacionFichajesViewModel(
 
             modificarFichajeUseCase(
                 idFichaje = fichaje.idFichaje,
-                nuevaHoraEntrada = estado.dialogEntrada,
-                nuevaHoraSalida = estado.dialogSalida,
+                nuevaHoraEntrada = nuevaEntrada,
+                nuevaHoraSalida = nuevaSalida,
                 motivoModificacion = estado.dialogMotivo
             )
                 .onSuccess { fichajeActualizado ->

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/ModificacionFichajesViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/ModificacionFichajesViewModel.kt
@@ -88,7 +88,7 @@ class ModificacionFichajesViewModel(
         }
     }
 
-    fun cargarFichajes() {
+    private fun cargarFichajes() {
         viewModelScope.launch {
             _estadoUi.update { it.copy(cargandoFichajes = true, mensajeError = null) }
             val estado = _estadoUi.value
@@ -126,10 +126,12 @@ class ModificacionFichajesViewModel(
 
     fun actualizarFechaInicio(fecha: LocalDate) {
         _estadoUi.update { it.copy(fechaInicio = fecha) }
+        cargarFichajes()
     }
 
     fun actualizarFechaFin(fecha: LocalDate) {
         _estadoUi.update { it.copy(fechaFin = fecha) }
+        cargarFichajes()
     }
 
     fun abrirDialogEdicion(fichaje: RespuestaFichajeDTO) {

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
@@ -165,10 +165,10 @@ fun PantallaModificacionFichajes(
         DialogEdicionFichaje(
             estadoUi = estadoUi,
             onDismiss = viewModel::cerrarDialog,
-            onEntradaCambiada = viewModel::actualizarDialogEntrada,
-            onSalidaCambiada = viewModel::actualizarDialogSalida,
             onMotivoCambiado = viewModel::actualizarDialogMotivo,
-            onGuardar = viewModel::guardarModificacion
+            onGuardar = { entrada, salida ->
+                viewModel.guardarModificacion(entrada, salida)
+            }
         )
     }
 }
@@ -553,25 +553,24 @@ private fun TarjetaFichajeSupervisor(
 private fun DialogEdicionFichaje(
     estadoUi: EstadoUiModificacionFichajes,
     onDismiss: () -> Unit,
-    onEntradaCambiada: (LocalDateTime) -> Unit,
-    onSalidaCambiada: (LocalDateTime?) -> Unit,
     onMotivoCambiado: (String) -> Unit,
-    onGuardar: () -> Unit
+    onGuardar: (LocalDateTime, LocalDateTime?) -> Unit
 ) {
+
     val fichaje = estadoUi.fichajeEditando ?: return
 
-    val horaEntradaInicial = estadoUi.dialogEntrada ?: fichaje.horaEntrada
-    val horaSalidaInicial = estadoUi.dialogSalida ?: fichaje.horaSalida
+    val horaEntradaBase = estadoUi.dialogEntrada ?: fichaje.horaEntrada
+    val horaSalidaBase = estadoUi.dialogSalida ?: fichaje.horaSalida
 
     var anadirSalida by remember { mutableStateOf(false) }
 
     val timePickerEntradaState = rememberTimePickerState(
-        initialHour = horaEntradaInicial.hour,
-        initialMinute = horaEntradaInicial.minute,
+        initialHour = horaEntradaBase.hour,
+        initialMinute = horaEntradaBase.minute,
         is24Hour = true
     )
 
-    val horaSalidaParaPicker = horaSalidaInicial ?: LocalDateTime.now()
+    val horaSalidaParaPicker = horaSalidaBase ?: horaEntradaBase.plusHours(8)
     val timePickerSalidaState = rememberTimePickerState(
         initialHour = horaSalidaParaPicker.hour,
         initialMinute = horaSalidaParaPicker.minute,
@@ -616,16 +615,6 @@ private fun DialogEdicionFichaje(
                         selectorColor = MaterialTheme.colorScheme.primary
                     )
                 )
-                LaunchedEffect(
-                    timePickerEntradaState.hour,
-                    timePickerEntradaState.minute
-                ) {
-                    val nuevaEntrada = fichaje.horaEntrada
-                        .withHour(timePickerEntradaState.hour)
-                        .withMinute(timePickerEntradaState.minute)
-                        .withSecond(0)
-                    onEntradaCambiada(nuevaEntrada)
-                }
 
                 HorizontalDivider()
 
@@ -636,7 +625,7 @@ private fun DialogEdicionFichaje(
                 )
 
                 when {
-                    horaSalidaInicial != null -> {
+                    horaSalidaBase != null -> {
                         TimeInput(
                             state = timePickerSalidaState,
                             colors = TimePickerDefaults.colors(
@@ -644,16 +633,6 @@ private fun DialogEdicionFichaje(
                                 selectorColor = MaterialTheme.colorScheme.primary
                             )
                         )
-                        LaunchedEffect(
-                            timePickerSalidaState.hour,
-                            timePickerSalidaState.minute
-                        ) {
-                            val nuevaSalida = fichaje.horaSalida
-                                ?.withHour(timePickerSalidaState.hour)
-                                ?.withMinute(timePickerSalidaState.minute)
-                                ?.withSecond(0)
-                            onSalidaCambiada(nuevaSalida)
-                        }
                     }
 
                     anadirSalida -> {
@@ -664,16 +643,6 @@ private fun DialogEdicionFichaje(
                                 selectorColor = MaterialTheme.colorScheme.primary
                             )
                         )
-                        LaunchedEffect(
-                            timePickerSalidaState.hour,
-                            timePickerSalidaState.minute
-                        ) {
-                            val nuevaSalida = fichaje.horaEntrada
-                                .withHour(timePickerSalidaState.hour)
-                                .withMinute(timePickerSalidaState.minute)
-                                .withSecond(0)
-                            onSalidaCambiada(nuevaSalida)
-                        }
                     }
 
                     else -> {
@@ -688,14 +657,7 @@ private fun DialogEdicionFichaje(
                                 color = ColorAmbar,
                                 fontWeight = FontWeight.SemiBold
                             )
-                            TextButton(onClick = {
-                                anadirSalida = true
-                                val nuevaSalida = fichaje.horaEntrada
-                                    .withHour(timePickerSalidaState.hour)
-                                    .withMinute(timePickerSalidaState.minute)
-                                    .withSecond(0)
-                                onSalidaCambiada(nuevaSalida)
-                            }) {
+                            TextButton(onClick = { anadirSalida = true }) {
                                 Text(stringResource(R.string.modificacion_fichaje_anadir_salida))
                             }
                         }
@@ -725,7 +687,26 @@ private fun DialogEdicionFichaje(
         },
         confirmButton = {
             Button(
-                onClick = onGuardar,
+                onClick = {
+                    val nuevaEntrada = horaEntradaBase
+                        .withHour(timePickerEntradaState.hour)
+                        .withMinute(timePickerEntradaState.minute)
+                        .withSecond(0)
+
+                    val nuevaSalida = when {
+                        horaSalidaBase != null -> horaSalidaBase
+                            .withHour(timePickerSalidaState.hour)
+                            .withMinute(timePickerSalidaState.minute)
+                            .withSecond(0)
+                        anadirSalida -> horaEntradaBase
+                            .withHour(timePickerSalidaState.hour)
+                            .withMinute(timePickerSalidaState.minute)
+                            .withSecond(0)
+                        else -> null
+                    }
+
+                    onGuardar(nuevaEntrada, nuevaSalida)
+                },
                 enabled = estadoUi.dialogGuardarHabilitado
             ) {
                 if (estadoUi.guardando) {

--- a/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/equipo/fichajes/PantallaModificacionFichajes.kt
@@ -125,8 +125,7 @@ fun PantallaModificacionFichajes(
                 estadoUi = estadoUi,
                 onEmpleadoSeleccionado = viewModel::seleccionarEmpleado,
                 onFechaInicioActualizada = viewModel::actualizarFechaInicio,
-                onFechaFinActualizada = viewModel::actualizarFechaFin,
-                onAplicarFiltro = viewModel::cargarFichajes
+                onFechaFinActualizada = viewModel::actualizarFechaFin
             )
 
             HorizontalDivider()
@@ -179,8 +178,7 @@ private fun SeccionFiltros(
     estadoUi: EstadoUiModificacionFichajes,
     onEmpleadoSeleccionado: (RespuestaEmpleadoDTO?) -> Unit,
     onFechaInicioActualizada: (LocalDate) -> Unit,
-    onFechaFinActualizada: (LocalDate) -> Unit,
-    onAplicarFiltro: () -> Unit
+    onFechaFinActualizada: (LocalDate) -> Unit
 ) {
     var mostrarSelectorInicio by remember { mutableStateOf(false) }
     var mostrarSelectorFin by remember { mutableStateOf(false) }
@@ -214,14 +212,6 @@ private fun SeccionFiltros(
                 modifier = Modifier.weight(1f),
                 alSeleccionar = { mostrarSelectorFin = true }
             )
-        }
-
-        Button(
-            onClick = onAplicarFiltro,
-            modifier = Modifier.fillMaxWidth(),
-            enabled = !estadoUi.cargandoFichajes
-        ) {
-            Text(stringResource(R.string.historial_fichajes_aplicar_filtro))
         }
     }
 

--- a/app/src/main/java/com/gestorrh/android/ui/turnos/MisTurnosViewModel.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/turnos/MisTurnosViewModel.kt
@@ -40,7 +40,6 @@ class MisTurnosViewModel(
 
     init {
         observarCache()
-        cargarAsignaciones()
     }
 
     private fun observarCache() {

--- a/app/src/main/java/com/gestorrh/android/ui/turnos/PantallaMisTurnos.kt
+++ b/app/src/main/java/com/gestorrh/android/ui/turnos/PantallaMisTurnos.kt
@@ -27,6 +27,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gestorrh.android.R
@@ -55,6 +58,17 @@ fun PantallaMisTurnos(
     val estadoUi by viewModel.estadoUi.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val recursos = LocalResources.current
+    val propietarioCicloVida = LocalLifecycleOwner.current
+
+    DisposableEffect(propietarioCicloVida) {
+        val observador = LifecycleEventObserver { _, evento ->
+            if (evento == Lifecycle.Event.ON_RESUME) {
+                viewModel.cargarAsignaciones()
+            }
+        }
+        propietarioCicloVida.lifecycle.addObserver(observador)
+        onDispose { propietarioCicloVida.lifecycle.removeObserver(observador) }
+    }
 
     val textoReintentar = stringResource(id = R.string.turnos_reintentar)
     val textoSinConexion = stringResource(id = R.string.turnos_sin_conexion)


### PR DESCRIPTION
## Cambios

Corrige varios bugs detectados en la pantalla Mi equipo (rol SUPERVISOR)
y en la sincronización de datos entre el servidor y el cliente.

### Bugs corregidos

**Modificación de fichajes sin salida**
El diálogo de edición se bloqueaba al pulsar "+ Añadir salida", impidiendo
interactuar con cualquier campo e incluso cerrando la app en algunos casos.
Causa: LaunchedEffect reactivos al estado del TimePickerState generaban un
bucle de recomposición. Se elimina la reactividad y la construcción del
LocalDateTime se mueve al onClick del botón Guardar.

**Filtros de la pantalla de fichajes**
El filtro por empleado actualizaba la lista automáticamente pero el filtro
por fecha requería pulsar "Aplicar filtro". Se unifica el comportamiento
para que cualquier cambio de filtro lance la búsqueda de forma inmediata,
eliminando el botón "Aplicar filtro".

**Turnos y cuadrante no reflejan ausencias aprobadas**
Al aprobar una ausencia el backend elimina las asignaciones correspondientes
pero el cliente no se enteraba hasta cerrar sesión. Dos causas:
- AsignacionRepositoryImpl usaba upsertAll que nunca borra registros obsoletos
  de Room. Se reemplaza por una operación transaccional deleteAll + upsertAll.
- PantallaMisTurnos y PantallaCuadranteDepartamento no sincronizaban con el
  servidor al navegar a ellas. Se añade DisposableEffect con ON_RESUME en
  ambas pantallas.

**Ausencias del equipo no se actualizan en tiempo real**
El supervisor no veía nuevas solicitudes de ausencia hasta cerrar sesión.
Se añade DisposableEffect con ON_RESUME para recargar al navegar a la
pestaña, y polling cada 60 segundos para detectar solicitudes nuevas
mientras el supervisor permanece en la pantalla, con pausado automático
al ir a segundo plano mediante repeatOnLifecycle.

## Testing

- Verificado que el diálogo de modificación de fichajes funciona correctamente
  con y sin hora de salida
- Verificado que cualquier cambio de filtro en fichajes actualiza la lista
- Verificado que los turnos del empleado se actualizan sin cerrar sesión
  tras aprobar una ausencia
- Verificado que el cuadrante refleja las asignaciones eliminadas al navegar
  a la pestaña
- Verificado que las nuevas solicitudes de ausencia aparecen al navegar a
  la pestaña y durante el polling