### PR TITLE
fix: permisos de escritura en workflow release APK

### DIFF
--- a/.github/workflows/release-apk.yml
+++ b/.github/workflows/release-apk.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   build-and-upload:
     name: Build y subir APK firmado


### PR DESCRIPTION
## Problema
El workflow `release-apk.yml` fallaba al intentar subir la APK a la release con el error:

`Resource not accessible by integration`

## Causa
El `GITHUB_TOKEN` no tiene permisos de escritura sobre releases por defecto.

## Solución
Añadido bloque `permissions: contents: write` en el workflow para que pueda subir archivos a la release.